### PR TITLE
 Add initial CI tests

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test ghaf-infra
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
+      - name: Run ghaf-infra CI tests
+        run: nix develop --command inv pre-push
+      - name: Run terraform fmt
+        run: |
+          TF_LOG="DEBUG" bash -c 'nix develop .#terraform --command terraform -chdir=terraform fmt'
+          TF_LOG="DEBUG" bash -c 'nix develop .#terraform --command terraform -chdir=terraform/azure-storage fmt'
+      # TODO: Enable the below check when 'terraform validate' passes:
+      # - name: Run terraform validate
+      #   run: |
+      #     TF_LOG="DEBUG" bash -c 'nix develop .#terraform --command terraform -chdir=terraform validate'
+      #     TF_LOG="DEBUG" bash -c 'nix develop .#terraform --command terraform -chdir=terraform/azure-storage validate'

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ pkgs.mkShell {
     python3.pkgs.deploykit
     python3.pkgs.invoke
     python3.pkgs.pycodestyle
+    python3.pkgs.pylint
     sops
     ssh-to-age
     reuse

--- a/tasks.py
+++ b/tasks.py
@@ -209,7 +209,7 @@ def decrypt_host_key(target: str, tmpdir: str) -> None:
     t.chmod(0o755)
     host_key = t / "etc/ssh/ssh_host_ed25519_key"
     host_key.parent.mkdir(parents=True, exist_ok=True)
-    with open(host_key, "w", opener=opener) as fh:
+    with open(host_key, "w", opener=opener, encoding="utf-8") as fh:
         try:
             subprocess.run(
                 [
@@ -224,12 +224,12 @@ def decrypt_host_key(target: str, tmpdir: str) -> None:
             )
         except subprocess.CalledProcessError:
             LOG.warning("Failed reading secret 'ssh_host_ed25519_key' for '%s'", target)
-            ask = input(f"Still continue? [y/N] ")
+            ask = input("Still continue? [y/N] ")
             if ask != "y":
                 sys.exit(1)
         else:
             pub_key = t / "etc/ssh/ssh_host_ed25519_key.pub"
-            with open(pub_key, "w") as fh:
+            with open(pub_key, "w", encoding="utf-8") as fh:
                 subprocess.run(
                     ["ssh-keygen", "-y", "-f", f"{host_key}"],
                     stdout=fh,
@@ -262,7 +262,7 @@ def install(c: Any, target: str, hostname: str) -> None:
         LOG.warning(
             "sudo on '%s' needs password: installation will likely fail", hostname
         )
-        ask = input(f"Still continue? [y/N] ")
+        ask = input("Still continue? [y/N] ")
         if ask != "y":
             sys.exit(1)
     # Check static ip
@@ -278,7 +278,7 @@ def install(c: Any, target: str, hostname: str) -> None:
             "If you do, consider making the address temporarily static "
             "before continuing."
         )
-        ask = input(f"Still continue? [y/N] ")
+        ask = input("Still continue? [y/N] ")
         if ask != "y":
             sys.exit(1)
 
@@ -380,7 +380,7 @@ def pre_push(c: Any) -> None:
     Example usage:
     inv pre-push
     """
-    cmd = f"find . -type f -name *.py ! -path *result* ! -path *eggs*"
+    cmd = "find . -type f -name *.py ! -path *result* ! -path *eggs*"
     ret = exec_cmd(cmd)
     pyfiles = ret.stdout.replace("\n", " ")
     LOG.info("Running black")
@@ -399,17 +399,17 @@ def pre_push(c: Any) -> None:
     if not ret:
         sys.exit(1)
     LOG.info("Running reuse lint")
-    cmd = f"reuse lint"
+    cmd = "reuse lint"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         sys.exit(1)
     LOG.info("Running nix fmt")
-    cmd = f"nix fmt"
+    cmd = "nix fmt"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         sys.exit(1)
     LOG.info("Running nix flake check")
-    cmd = f"nix flake check"
+    cmd = "nix flake check"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         sys.exit(1)

--- a/tasks.py
+++ b/tasks.py
@@ -408,6 +408,11 @@ def pre_push(c: Any) -> None:
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         sys.exit(1)
+    LOG.info("Running nix flake check")
+    cmd = f"nix flake check"
+    ret = exec_cmd(cmd, raise_on_error=False)
+    if not ret:
+        sys.exit(1)
     LOG.info("Building all nixosConfigurations")
     build_local(c)
     LOG.info("All pre-push checks passed")


### PR DESCRIPTION
This PR makes the following changes:

- Add github action workflow that runs CI tests against all PRs and merges to main
- Initial CI tests require that `inv pre-push` as well as `terraform fmt` pass
- As soon as `terraform validate` passes, the commented out checks should be also enabled