### PR TITLE
Simplify tasks.py usage

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ pkgs.mkShell {
     python3.pkgs.invoke
     python3.pkgs.pycodestyle
     python3.pkgs.pylint
+    python3.pkgs.tabulate
     reuse
     sops
     ssh-to-age


### PR DESCRIPTION
- Introduce 'alias' names for combinations of hostname (IP) and target nixosConfigurations.
- Add task `alias-list` to list all alias names currently configured.
- Change the task.py so that all tasks take the 'alias' name as an argument, instead of separate hostname and configuration name. This makes it less likely to accidentally apply a configuration to a wrong host.
- This also makes it possible to apply tasks to all alias names. As an example, `deploy` without arguments could deploy all specified alias configurations at once. Such changes to tasks will be implemented later in a separate PR.