### PR TITLE
Configuration for binarycache vm

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -8,6 +8,8 @@ keys:
   - &ghafhydra age1qnufx7gvz5kmm48nvdma4chxd4p0lca88f5fsyce8lrae6gp2a8sul692y
   - &hrosten age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
   - &karim age122lvqyrdqz30fkfututykl0yle9u63u2em6e4aut7e5draws83ns3npt3a
+  - &jrautiola age15jq5gjjd7ypsdlqfjtqy4red57v8ggqq9na6u3xffznu678nydpsuuwjg0
+  - &binarycache age1s47a3y44j695gemcl0kqgjlxxvaa50de9s69jy2l6vc8xtmk5pcskhpknl
 creation_rules:
   - path_regex: terraform/secrets.yaml$
     key_groups:
@@ -27,3 +29,8 @@ creation_rules:
       - *flokli
       - *hrosten
       - *build01
+  - path_regex: hosts/binarycache/secrets.yaml$
+    key_groups:
+    - age:
+      - *jrautiola
+      - *binarycache

--- a/hosts/binarycache/default.nix
+++ b/hosts/binarycache/default.nix
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  inputs,
+  lib,
+  config,
+  ...
+}: {
+  sops.defaultSopsFile = ./secrets.yaml;
+  sops.secrets.cache-sig-key.owner = "root";
+
+  imports = lib.flatten [
+    (with inputs; [
+      nix-serve-ng.nixosModules.default
+      sops-nix.nixosModules.sops
+      disko.nixosModules.disko
+    ])
+    (with self.nixosModules; [
+      common
+      qemu-common
+      service-openssh
+      service-binary-cache
+      service-nginx
+      user-jrautiola
+      user-cazfi
+      user-hydra
+    ])
+    ./disk-config.nix
+  ];
+
+  nix.settings = {
+    # we don't want the cache to be a substitutor for itself
+    substituters = lib.mkForce ["https://cache.nixos.org/"];
+    trusted-users = ["hydra"];
+  };
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  services.openssh.enable = true;
+
+  boot.loader.grub = {
+    enable = true;
+    # qemu vms are using SeaBIOS which is not UEFI
+    efiSupport = false;
+  };
+
+  networking = {
+    hostName = "binarycache";
+    nameservers = ["1.1.1.1" "8.8.8.8"];
+  };
+
+  # acme gets https certificates when we have dns
+  # security.acme = {
+  #   acceptTerms = true;
+  #   defaults.email = "trash@unikie.com";
+  # };
+
+  services.nginx = {
+    virtualHosts = {
+      # "cache.vedenemo.dev" = {
+      "_" = {
+        # enableACME = true;
+        # forceSSL = true;
+        default = true;
+        locations."/" = {
+          proxyPass = "http://${config.services.nix-serve.bindAddress}:${toString config.services.nix-serve.port}";
+        };
+      };
+    };
+  };
+}

--- a/hosts/binarycache/disk-config.nix
+++ b/hosts/binarycache/disk-config.nix
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# BIOS compatible gpt partition
+{
+  disko.devices = {
+    disk = {
+      vda = {
+        device = "/dev/vda";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            boot = {
+              size = "1M";
+              type = "EF02";
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+      vdb = {
+        device = "/dev/vdb";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            nix = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/nix";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/binarycache/secrets.yaml
+++ b/hosts/binarycache/secrets.yaml
@@ -1,0 +1,32 @@
+cache-sig-key: ENC[AES256_GCM,data:tD6JbL9uHOLt5jAlJUekYeq1Q2m+ONUROx6LTJYv4/ld38HrQewJv9ulnJ2saPIASGwf37WMpikz1BUB2PFHPskQnXTTqtH6jSCpBrxf/nU2G+1bvLWN8ZrMAsAkaB6UctcwaA==,iv:wuFcIZ40O3FrP5eIQWwdkybPEonusNzVY9bd5ee5Kvc=,tag:KRsmhvW2MQfsGfiKrqXCoA==,type:str]
+cache-public: ENC[AES256_GCM,data:lrmnExWY9koYFe+16MeY9UqWtw54uqMUAO8ZedgH7iV2J4LgK7yhaRe24sD9Ue5G7W9erBjlpdY=,iv:BszhQdZD0osQW/mk8c/zoK8BKex7PqAXzE/wxfOH96Q=,tag:NwBW3ajzF+nsXF7njAD+3Q==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:xMOLc6wKUJron1kf3oW84cWNbnSMzM9DxDR28yL8rFZdix2c/Y2HjNMDh8V8b3T+hiCIlSeJgAsBEj9Bi1EfZkEEOcr9j8LbggxSwx6zDnokVgSdQPYd7cClT/Chx+K0/C9DB8zsfIn+5MhDg6uObTI3eut57nsgpCLnvTK/9WamePZ13RP5trHsExOmD7Zw/f6+L1ru1PjR7OB00HNjyO8GvD5G9oOcN2KZmLf0LHangaa0d2on0V0JsOShhVrXLijYC0JVUITOvVXPaKeSFl1YZDc0Sfq86FJ7BqRqwLt4EqtBgrL5JzUmtTru3DqGeJ2cN5JpN2XshTinSRE/I9NSLgBKlhcaoJENZkFiWbT61tozedznQof6BVf8nYlxx5uLO8XXA2FI/0+jsGLNdIdXiWGnT2UE0kPm4EdAaOcBvn27dK+LTz7i3ADuNwh63BCSGezw5UVBSUsZjt/8tkxwJyw08Lhl8PPXme2mRuARdgpsQ8l/YrhAmLC0rWzJeMT5dj1T6dvS/dQ+aQZD,iv:RXURQCZmn7Te2oLom980ktL3fSwIjMpMDH3EsarK6b4=,tag:mhdWOwjDPWoVYonq9sg9mw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age15jq5gjjd7ypsdlqfjtqy4red57v8ggqq9na6u3xffznu678nydpsuuwjg0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQUzA2ZllMUFR3SWdiQUVs
+            R3Z6ejFGNzBEWTlQd3NXYUo3ZmhsOXpUSERzCmozRy9WOWhQZldSREZnazdORXhD
+            dHRoR2RUMlNLSjJpVkZubElGZkVHR3MKLS0tIHZFM0xRQ2l5azNJNXNSbkUvcUs0
+            UDVZVXVRcUw5bGYra3B4Ykh1ZmhHYTQKAb7KKp/u3kIkE3NwSBCj5gCnGKbJXP0V
+            z2YVm2qLZaVaIWAdUklj2QM84AzCg4xU73tL6FuVkClh3DrZKRTSJA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1s47a3y44j695gemcl0kqgjlxxvaa50de9s69jy2l6vc8xtmk5pcskhpknl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTSDhycEV1dDkwYnhmTEVr
+            YnA5dzNkL3pWWkF1RngrSEU1YUY2NitCYmlJCmUvM0hnQzlrakYzMlpNcjBTaGxk
+            aFh0cHJZeVNoUTF5ZEYrdHhMNHMvdUEKLS0tIEZjZW05SSswU2tXUnlJdWU5aTF6
+            ZVQzeHhWZVQxdERVQlZqUmZHT0ttSzAKqrd+kqRiFfqPdtK6p6zD0qxffEtDlgzQ
+            jbrnN+r7cptt9bLHd7uJ+c6w2JpfVBDrZnloAgFq81G4eayhPYzsbA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2023-11-03T15:23:52Z"
+    mac: ENC[AES256_GCM,data:OOjFkwpezRn0EwNhqmC4hjfqZzu4y5pZOqNhIOcQbXzGE1cKKR6Z78L739mZvbxvCGmPDC6F+5EBqtYaB672WHXIWzSix0BfLgjfXNEKwRuTrp2kVgd/URGj2xpX0B4O9UcSbzJAVx9DNJRi3qOfqRfxAUmvz7w3Je80CyNApIQ=,iv:HKbN1dUOyYKWNshe1hpnPnBIZcScgqvJMiKkfc46j+8=,tag:JFqD7PaiACsOw67iHfc/FQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3

--- a/hosts/binarycache/secrets.yaml.license
+++ b/hosts/binarycache/secrets.yaml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+
+SPDX-License-Identifier: Apache-2.0

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -10,11 +10,13 @@
   flake.nixosModules = {
     # shared modules
     azure-common = import ./azure-common.nix;
+    qemu-common = import ./qemu-common.nix;
     common = import ./common.nix;
     generic-disk-config = import ./generic-disk-config.nix;
     # host modules
     host-build01 = import ./build01;
     host-ghafhydra = import ./ghafhydra;
+    host-binarycache = import ./binarycache;
   };
 
   flake.nixosConfigurations = let
@@ -28,6 +30,10 @@
     ghafhydra = lib.nixosSystem {
       inherit specialArgs;
       modules = [self.nixosModules.host-ghafhydra];
+    };
+    binarycache = lib.nixosSystem {
+      inherit specialArgs;
+      modules = [self.nixosModules.host-binarycache];
     };
   };
 }

--- a/hosts/qemu-common.nix
+++ b/hosts/qemu-common.nix
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  inputs,
+  lib,
+  config,
+  pkgs,
+  ...
+}: {
+  services.qemuGuest.enable = true;
+  boot.kernelParams = ["console=ttyS0" "earlyprintk=ttyS0" "rootdelay=300" "panic=1" "boot.panic_on_fail"];
+  boot.initrd.availableKernelModules = ["ahci" "xhci_pci" "virtio_pci" "sr_mod" "virtio_blk" "uhci_hcd" "ehci_pci" "virtio_scsi"];
+  boot.initrd.kernelModules = ["kvm-intel" "dm-snapshot"];
+}

--- a/tasks.py
+++ b/tasks.py
@@ -75,6 +75,7 @@ TARGETS = OrderedDict(
     {
         "build01-dev": TargetHost(hostname="51.12.57.124", nixosconfig="build01"),
         "ghafhydra-dev": TargetHost(hostname="51.12.56.79", nixosconfig="ghafhydra"),
+        "binarycache-ficolo": TargetHost(hostname="172.18.20.109", nixosconfig="binarycache"),
     }
 )
 

--- a/users/cazfi.nix
+++ b/users/cazfi.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    cazfi = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHzAww8Md+anrVfg93jNYey35Lu/YPEdbEh9QRu+riyf cazfi@cazfi-wlt"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}

--- a/users/default.nix
+++ b/users/default.nix
@@ -7,5 +7,8 @@
     user-builder = import ./builder.nix;
     user-hrosten = import ./hrosten.nix;
     user-tester = import ./tester.nix;
+    user-jrautiola = import ./jrautiola.nix;
+    user-hydra = import ./hydra.nix;
+    user-cazfi = import ./cazfi.nix;
   };
 }

--- a/users/hydra.nix
+++ b/users/hydra.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    hydra = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILbycq53k6oz1VvTC8I7wYt1c5t2YGYd41MJUeakte5t hydra@build4"
+      ];
+      extraGroups = [];
+    };
+  };
+}

--- a/users/jrautiola.nix
+++ b/users/jrautiola.nix
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    jrautiola = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6EoeiMBiiwfGJfQYyuBKg8rDpswX0qh194DUQqUotL joonas@buutti"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPjn9ZyVUkSuhcfpAtjrEQn2g1MhQdKc3vLLRqCz0tWk joonas@unikie"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}


### PR DESCRIPTION
Add configuration for nixos binary cache (new cache.vedenemo.dev) that runs in a qemu vm on ficolo. it exposes nix-serve-ng through http (https soon when we get the dns records changed).

includes disko config to format the second disk and mount it under `/nix` to hold the nix store