### PR TITLE
Add ubuntu aarch64 builder configuration

### DIFF
--- a/hosts/qemu-common.nix
+++ b/hosts/qemu-common.nix
@@ -1,13 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
-{
-  inputs,
-  lib,
-  config,
-  pkgs,
-  ...
-}: {
+_: {
   services.qemuGuest.enable = true;
   boot.kernelParams = ["console=ttyS0" "earlyprintk=ttyS0" "rootdelay=300" "panic=1" "boot.panic_on_fail"];
   boot.initrd.availableKernelModules = ["ahci" "xhci_pci" "virtio_pci" "sr_mod" "virtio_blk" "uhci_hcd" "ehci_pci" "virtio_scsi"];

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,9 @@ TARGETS = OrderedDict(
     {
         "build01-dev": TargetHost(hostname="51.12.57.124", nixosconfig="build01"),
         "ghafhydra-dev": TargetHost(hostname="51.12.56.79", nixosconfig="ghafhydra"),
-        "binarycache-ficolo": TargetHost(hostname="172.18.20.109", nixosconfig="binarycache"),
+        "binarycache-ficolo": TargetHost(
+            hostname="172.18.20.109", nixosconfig="binarycache"
+        ),
     }
 )
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -68,16 +68,30 @@ $ terraform fmt
 # Test the changes:
 $ terraform validate
 
-# Once the changes are ready to be deployed, create a new PR
-# attaching the output of `terraform plan` to the PR:
-$ terraform plan
-# Notice: `terraform plan` only outputs the execution plan,
-# showing what actions terraform would take. It does not
-# perform the planned actions.
-
-# Once the PR is merged, apply your configuration changes:
+# Test applying your configuration changes:
 $ terraform apply
 ```
+
+### Common Terraform Errors
+
+Below are some common Terraform errors with tips on how to resolve each.
+
+#### Error: A resource with the ID <ID> already exists
+```bash
+$ terraform apply
+...
+azurerm_virtual_machine_extension.deploy_ubuntu_builder: Creating...
+╷
+│ Error: A resource with the ID "/subscriptions/<SUBID>/resourceGroups/ghaf-infra-tf-dev/providers/Microsoft.Compute/virtualMachines/azarm/extensions/azarm-vmext" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_virtual_machine_extension" for more information.
+```
+
+Example fix:
+```bash
+$ terraform import azurerm_virtual_machine_extension.deploy_ubuntu_builder /subscriptions/<SUBID>/resourceGroups/ghaf-infra-tf-dev/providers/Microsoft.Compute/virtualMachines/azarm/extensions/azarm-vmext
+
+# Ref: https://stackoverflow.com/questions/61418168/terraform-resource-with-the-id-already-exists
+```
+
 
 ## References
 - Azure secrets: https://registry.terraform.io/providers/hashicorp/azuread/0.9.0/docs/guides/service_principal_client_secret

--- a/terraform/azure-ghaf-infra.tf
+++ b/terraform/azure-ghaf-infra.tf
@@ -168,5 +168,16 @@ resource "azurerm_linux_virtual_machine" "azarm_vm" {
     public_key = data.sops_file.ghaf_infra.data["vm_admin_rsa_pub"]
   }
 }
-
+resource "azurerm_virtual_machine_extension" "deploy_ubuntu_builder" {
+  name                 = "azarm-vmext"
+  virtual_machine_id   = azurerm_linux_virtual_machine.azarm_vm.id
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.1"
+  settings             = <<EOF
+    {
+        "script": "${base64encode(file("scripts/ubuntu-builder.sh"))}"
+    }
+    EOF
+}
 ################################################################################

--- a/terraform/scripts/ubuntu-builder.sh
+++ b/terraform/scripts/ubuntu-builder.sh
@@ -53,8 +53,14 @@ configure_builder () {
     chown -R nix:nix /home/nix/.ssh
     chmod 700 /home/nix/.ssh
     chmod 600 /home/nix/.ssh/authorized_keys
-    # Extra nix config for the builder
+    # Extra nix config for the builder,
+    # for detailed description of each of the below options see:
+    # https://nixos.org/manual/nix/stable/command-ref/conf-file
     extra_nix_conf="
+# 20 GB (20*1024*1024*1024)
+min-free = 21474836480
+# 200 GB (200*1024*1024*1024)
+max-free = 214748364800
 system-features = nixos-test benchmark big-parallel kvm
 trusted-users = nix
 substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org

--- a/terraform/scripts/ubuntu-builder.sh
+++ b/terraform/scripts/ubuntu-builder.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -x # debug
+
+################################################################################
+
+# Assume root if HOME and USER are unset
+[ -z "${HOME}" ] && export HOME="/root"
+[ -z "${USER}" ] && export USER="root"
+
+################################################################################
+
+apt_update () {
+    sudo apt-get update -y
+    sudo apt-get upgrade -y
+    sudo apt-get install -y ca-certificates curl xz-utils 
+}
+
+install_nix () {
+    type="$1"
+    if [ "$type" = "single" ]; then
+        # Single-user
+        sh <(curl -L https://nixos.org/nix/install) --yes --no-daemon
+    elif [ "$type" = "multi" ]; then
+        # Multi-user
+        sh <(curl -L https://nixos.org/nix/install) --yes --daemon
+    else
+        echo "Error: unknown installation type: '$type'"
+        exit 1
+    fi
+    # Fix https://github.com/nix-community/home-manager/issues/3734:
+    sudo mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/"$USER"
+    sudo chown -R "$USER:nixbld" "/nix/var/nix/profiles/per-user/$USER"
+    # Enable flakes
+    extra_nix_conf="experimental-features = nix-command flakes"
+    sudo sh -c "printf '$extra_nix_conf\n'>>/etc/nix/nix.conf"
+    # https://github.com/NixOS/nix/issues/1078#issuecomment-1019327751
+    for f in /nix/var/nix/profiles/default/bin/nix*; do
+        sudo ln -fs "$f" "/usr/bin/$(basename "$f")"
+    done
+}
+
+configure_builder () {
+    # Add user: nix
+    sudo useradd -m -d /home/nix nix
+    # Allow ssh login with buildfarm public key
+    mkdir -p /home/nix/.ssh
+    echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIQwSH1R9xShZg1w5dZjRagYLae0QFBPYT3i80iHW1Ej' >> /home/nix/.ssh/authorized_keys
+    chown -R nix:nix /home/nix/.ssh
+    chmod 700 /home/nix/.ssh
+    chmod 600 /home/nix/.ssh/authorized_keys
+    # Extra nix config for the builder
+    extra_nix_conf="
+system-features = nixos-test benchmark big-parallel kvm
+trusted-users = nix
+substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
+trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.vedenemo.dev:RGHheQnb6rXGK5v9gexJZ8iWTPX6OcSeS56YeXYzOcg= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    sudo sh -c "printf '$extra_nix_conf\n'>>/etc/nix/nix.conf"
+}
+
+restart_nix_daemon () {
+    # Re-start nix-daemon
+    if systemctl list-units | grep -iq "nix-daemon"; then
+        sudo systemctl restart nix-daemon
+        if ! systemctl status nix-daemon; then
+            echo "Error: nix-daemon failed to start"
+            exit 1
+        fi
+    fi
+}
+
+uninstall_nix () {
+    # https://github.com/NixOS/nix/issues/1402
+    if grep -q nixbld /etc/passwd; then 
+        grep nixbld /etc/passwd | awk -F ":" '{print $1}' | xargs -t -n 1 sudo userdel -r
+    fi
+    if grep -q nixbld /etc/group; then
+        sudo groupdel nixbld
+    fi
+    rm -rf "$HOME/"{.nix-channels,.nix-defexpr,.nix-profile,.config/nixpkgs,.config/nix,.config/home-manager,.local/state/nix,.local/state/home-manager}
+    sudo rm -rf /etc/profile.d/nix.sh
+    if [ -d "/nix" ]; then
+        sudo rm -rf /nix
+    fi
+    if [ -d "/etc/nix" ]; then
+        sudo rm -fr /etc/nix 
+    fi
+    sudo find /etc -iname "*backup-before-nix*" -delete 
+    sudo find -L /usr/bin -iname "nix*" -delete
+    [ -f "$HOME/.profile" ] && sed -i "/\/nix/d" "$HOME/.profile"
+    [ -f "$HOME/.bash_profile" ] && sed -i "/\/nix/d" "$HOME/.bash_profile"
+    [ -f "$HOME/.bashrc" ] && sed -i "/\/nix/d" "$HOME/.bashrc"
+    if systemctl list-units | grep -iq "nix-daemon"; then
+        sudo systemctl stop nix-daemon nix-daemon.socket
+        sudo systemctl disable nix-daemon nix-daemon.socket
+        sudo find /etc/systemd -iname "*nix-daemon*" -delete
+        sudo find /usr/lib/systemd -iname "*nix-daemon*" -delete
+        sudo systemctl daemon-reload
+        sudo systemctl reset-failed
+    fi
+    unset NIX_PATH
+}
+
+outro () {
+    set +x
+    echo ""
+    nixpkgs_ver=$(nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version' 2>/dev/null)
+    if [ -n "$nixpkgs_ver" ]; then
+        echo "Installed nixpkgs version: $nixpkgs_ver"
+    else
+        echo "Failed reading installed nixpkgs version"
+        exit 1
+    fi
+    echo ""
+    echo "Open a new terminal for the changes to take impact"
+    echo ""
+}
+
+exit_unless_command_exists () {
+    if ! command -v "$1" 2> /dev/null; then
+        echo "Error: command '$1' is not installed" >&2
+        exit 1
+    fi
+}
+
+################################################################################
+
+main () {
+    exit_unless_command_exists "apt-get"
+    exit_unless_command_exists "systemctl"
+    apt_update
+    uninstall_nix
+    install_nix "multi"
+    configure_builder
+    restart_nix_daemon
+    exit_unless_command_exists "nix-shell"
+    outro
+}
+
+################################################################################
+
+main "$@"
+
+################################################################################


### PR DESCRIPTION
- Add a shell script that configures aarch64 ubuntu host so that it can be used part of the buildfarm. Run the script on applying the terraform configuration.
- Start collecting some common terraform errors and solutions to the terraform README.md.
- Apply formatting fixes to qemu-common.nix and tasks.py.