### PR TITLE
Update cache secret keys

### DIFF
--- a/hosts/binarycache/secrets.yaml
+++ b/hosts/binarycache/secrets.yaml
@@ -1,5 +1,5 @@
-cache-sig-key: ENC[AES256_GCM,data:tD6JbL9uHOLt5jAlJUekYeq1Q2m+ONUROx6LTJYv4/ld38HrQewJv9ulnJ2saPIASGwf37WMpikz1BUB2PFHPskQnXTTqtH6jSCpBrxf/nU2G+1bvLWN8ZrMAsAkaB6UctcwaA==,iv:wuFcIZ40O3FrP5eIQWwdkybPEonusNzVY9bd5ee5Kvc=,tag:KRsmhvW2MQfsGfiKrqXCoA==,type:str]
-cache-public: ENC[AES256_GCM,data:lrmnExWY9koYFe+16MeY9UqWtw54uqMUAO8ZedgH7iV2J4LgK7yhaRe24sD9Ue5G7W9erBjlpdY=,iv:BszhQdZD0osQW/mk8c/zoK8BKex7PqAXzE/wxfOH96Q=,tag:NwBW3ajzF+nsXF7njAD+3Q==,type:str]
+cache-sig-key: ENC[AES256_GCM,data:+gUZdbCcym2dXa4aKd1ItSdIVQduCVJWyIkHAbHXmh59Imgc/8zkzDaOpB/UQsu+BZwVsQcpEa1pLsyExDBKlR7qgIF6XIDaYoxxIhNHi62PBE23cR8YIu+6sbBiZ53n9cYlXT3QYAD3kMU=,iv:K8qlqKCUHoUuGG8HxQa8IT267/sgYhhAAOOJUAvDevM=,tag:UIJRjHBmqV7lgEd/uTVDHw==,type:str]
+cache-public: ENC[AES256_GCM,data:4EkreC/HwzV6psOQHa1HJfxIf9AvJa8XNMu57gXR5gBEE1/fCi03KUg88h7moJdGWNH2HyEZGnwsukjTdY2J,iv:XoNGSvBiRBykhzh/mGHdzxucNzZC2o/NJuMLo2gzkeE=,tag:H552Io8ElfW/jH1LbXazqg==,type:str]
 ssh_host_ed25519_key: ENC[AES256_GCM,data:xMOLc6wKUJron1kf3oW84cWNbnSMzM9DxDR28yL8rFZdix2c/Y2HjNMDh8V8b3T+hiCIlSeJgAsBEj9Bi1EfZkEEOcr9j8LbggxSwx6zDnokVgSdQPYd7cClT/Chx+K0/C9DB8zsfIn+5MhDg6uObTI3eut57nsgpCLnvTK/9WamePZ13RP5trHsExOmD7Zw/f6+L1ru1PjR7OB00HNjyO8GvD5G9oOcN2KZmLf0LHangaa0d2on0V0JsOShhVrXLijYC0JVUITOvVXPaKeSFl1YZDc0Sfq86FJ7BqRqwLt4EqtBgrL5JzUmtTru3DqGeJ2cN5JpN2XshTinSRE/I9NSLgBKlhcaoJENZkFiWbT61tozedznQof6BVf8nYlxx5uLO8XXA2FI/0+jsGLNdIdXiWGnT2UE0kPm4EdAaOcBvn27dK+LTz7i3ADuNwh63BCSGezw5UVBSUsZjt/8tkxwJyw08Lhl8PPXme2mRuARdgpsQ8l/YrhAmLC0rWzJeMT5dj1T6dvS/dQ+aQZD,iv:RXURQCZmn7Te2oLom980ktL3fSwIjMpMDH3EsarK6b4=,tag:mhdWOwjDPWoVYonq9sg9mw==,type:str]
 sops:
     kms: []
@@ -25,8 +25,8 @@ sops:
             ZVQzeHhWZVQxdERVQlZqUmZHT0ttSzAKqrd+kqRiFfqPdtK6p6zD0qxffEtDlgzQ
             jbrnN+r7cptt9bLHd7uJ+c6w2JpfVBDrZnloAgFq81G4eayhPYzsbA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-11-03T15:23:52Z"
-    mac: ENC[AES256_GCM,data:OOjFkwpezRn0EwNhqmC4hjfqZzu4y5pZOqNhIOcQbXzGE1cKKR6Z78L739mZvbxvCGmPDC6F+5EBqtYaB672WHXIWzSix0BfLgjfXNEKwRuTrp2kVgd/URGj2xpX0B4O9UcSbzJAVx9DNJRi3qOfqRfxAUmvz7w3Je80CyNApIQ=,iv:HKbN1dUOyYKWNshe1hpnPnBIZcScgqvJMiKkfc46j+8=,tag:JFqD7PaiACsOw67iHfc/FQ==,type:str]
+    lastmodified: "2023-11-20T13:24:13Z"
+    mac: ENC[AES256_GCM,data:WbeulA/JjWB56PAoyOHl4VkwpGH+DPP9XWlKmRnX5zhTVJXJyMFOcVzuxb1jJbIEjVjWIk12G7MvKm5TKW/Q+3RSL9fkSq49wLkl7QD4+whlRYn6mI9p7JKpV186/WG5sC/lrnspVWWNdGe3VUJ7KlhvHQnPQIzyLdCGsdrm5MI=,iv:SrZgmagFTJCm0mciZ0sDtLSpoQ/uu+wcI4F4mkjvVVY=,tag:qaMNjEpmNRL0tkuhdAxVqA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
You can't see the contents but I updated the key names to be `cache.vedenemo.dev:xxx` instead of `binarycache:xxx`