### PR TITLE
Beef-up ghafhydra-dev virtual machine

### DIFF
--- a/scripts/add-remote-user.sh
+++ b/scripts/add-remote-user.sh
@@ -74,7 +74,7 @@ exit_unless_file_exists () {
 test_remote_sudo () {
     # shellcheck disable=SC2086 # intented word splitting of $OPT_s
     if ! ssh -o ConnectTimeout=5 $OPT_s "sudo -n true"; then
-        echo "Error: sudo on remote host failed"
+        echo "Error: ssh connection or sudo on remote host failed"
         exit 1
     fi
 }

--- a/services/hydra/default.nix
+++ b/services/hydra/default.nix
@@ -20,7 +20,7 @@
   localMachine = pkgs.writeTextFile {
     name = "build-localMachine";
     text = ''
-      localhost x86_64-linux - 8 2 kvm,benchmark,big-parallel,nixos-test - -
+      localhost x86_64-linux - 14 4 kvm,benchmark,big-parallel,nixos-test - -
     '';
   };
   azarmMachine = pkgs.writeTextFile {
@@ -50,7 +50,7 @@ in {
     # Add builder machines' public ids to ssh known_hosts
     azarm = {
       hostNames = ["10.0.2.10"];
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILWojItdbPn0dNbGKfCSJv+duYsb+xzJ6hPWOu+TZ4rm";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPIuqtmsPNK6bR+OUfLjtjC3zcwMgG+ZLlWlLihDzUOF";
     };
     awsarm = {
       hostNames = ["awsarm.vedenemo.dev"];

--- a/tasks.py
+++ b/tasks.py
@@ -334,7 +334,7 @@ def install(c: Any, alias) -> None:
                 "also has access to remote host after nixos-anywhere installation "
                 "by adding your local user as a user to nixos configuration '%s'. "
                 "Hint: you might want to try the helper script at "
-                "'terraform/scripts/add-remote-user.sh' to add your current local "
+                "'scripts/add-remote-user.sh' to add your current local "
                 "user to the remote host.",
                 remote_user,
                 _get_target(alias).hostname,

--- a/terraform/azure-ghaf-infra.tf
+++ b/terraform/azure-ghaf-infra.tf
@@ -134,12 +134,12 @@ resource "azurerm_linux_virtual_machine" "ghafhydra_vm" {
   network_interface_ids = [
     azurerm_network_interface.ghafhydra_ni.id
   ]
-  size = "Standard_B8ms"
+  size = "Standard_B16ms"
   os_disk {
     name                 = "ghafhydra-disk"
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
-    disk_size_gb         = 512
+    disk_size_gb         = 1024
   }
   source_image_reference {
     publisher = "canonical"


### PR DESCRIPTION
- Increase ghafhydra-dev vm from 'Standard_B8ms' to 'Standard_B16ms'. See azure B-size specifications at: https://learn.microsoft.com/azure/virtual-machines/sizes-b-series-burstable
- Increase ghafhydra-dev disk size to 1TB
- Move the 'add-remote-user.sh' script to repository root under `scripts/` directory, since it just doesn't belong under `terraform/`
- Update azarm public key after re-installing the server. Azarm server private key should really be installed with terraform, but this part is left for another PR later.