### PR TITLE
Use dep5 license

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Copyright: 2023 Technology Innovation Institute (TII)
+License: Apache-2.0
+Files: *.lock *.png *.svg *.csv *.yaml

--- a/flake.lock.license
+++ b/flake.lock.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0

--- a/hosts/binarycache/secrets.yaml.license
+++ b/hosts/binarycache/secrets.yaml.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0

--- a/hosts/build01/secrets.yaml.license
+++ b/hosts/build01/secrets.yaml.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -25,10 +25,12 @@ in {
       experimental-features = "nix-command flakes";
       # Subsituters
       trusted-public-keys = [
+        "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="
         "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
         "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
       ];
       substituters = [
+        "https://ghaf-dev.cachix.org?priority=20"
         "https://cache.vedenemo.dev"
         "https://cache.ssrcdevops.tii.ae"
       ];

--- a/hosts/ghafhydra/secrets.yaml.license
+++ b/hosts/ghafhydra/secrets.yaml.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0

--- a/hosts/monitoring/secrets.yaml.license
+++ b/hosts/monitoring/secrets.yaml.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0

--- a/terraform/secrets.yaml.license
+++ b/terraform/secrets.yaml.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-
-SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
- Use dep5 to replace `.license` files: https://reuse.software/faq/#bulk-license
- Add ghaf-dev.cachix.org substitutre, since it's now also used in Ghaf: https://github.com/tiiuae/ghaf/blob/aef5ad3a916b51c33f23163b657045bd2f9f4df8/flake.nix#L22