### PR TITLE
Don't run automatic gc on cache

### DIFF
--- a/hosts/binarycache/default.nix
+++ b/hosts/binarycache/default.nix
@@ -37,6 +37,9 @@
     trusted-users = ["hydra"];
   };
 
+  # do not run garbage collection, we have enough disk space
+  nix.gc.automatic = lib.mkForce false;
+
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 
   networking = {


### PR DESCRIPTION
The automatic gc was deleting for example provenance files from the cache, causing issues in jenkins pipelines.