### PR TITLE
flake.lock: bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699291058,
-        "narHash": "sha256-5ggduoaAMPHUy4riL+OrlAZE14Kh7JWX4oLEs22ZqfU=",
+        "lastModified": 1700989516,
+        "narHash": "sha256-oKbmPa2wpTHh9XB3+zIx97uMZGNnp97GPliKKG2/plo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "41de143fda10e33be0f47eab2bfe08a50f234267",
+        "rev": "d2e4de209881b38392933fabf303cde3454b0b4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The current version seems bad, there's a fixed-output derivation mismatch somewhere in the python tooling:

```
       > error: hash mismatch importing path '/nix/store/c3cjxhn73xa5s8fm79w95d0879bijp04-python3-3.10.13';
       >          specified: sha256:0psh4a7hf891sfc6z38qb3a3jxb1jzljym2kfw3p4i4x409989mr
       >          got:       sha256:1i6kl621m9gm2i2f6p3qm36wqvwh654rfhz0z6hc3fa93a0cngmp
       > copying path '/nix/store/b4fk2q4zn8z1bf9zf19lhf8iygs2z3b7-command-not-found' to 'local'...
```