### PR TITLE
Add Ficolo builder configuration

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -31,5 +31,9 @@
       inherit specialArgs;
       modules = [./monitoring/configuration.nix];
     };
+    ficolobuild = lib.nixosSystem {
+      inherit specialArgs;
+      modules = [./ficolobuild/configuration.nix];
+    };
   };
 }

--- a/hosts/ficolobuild/configuration.nix
+++ b/hosts/ficolobuild/configuration.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  config,
+  inputs,
+  lib,
+  modulesPath,
+  ...
+}: {
+  imports = lib.flatten [
+    (modulesPath + "/installer/scan/not-detected.nix")
+    inputs.disko.nixosModules.disko
+    (with self.nixosModules; [
+      common
+      service-openssh
+      user-cazfi
+      user-hrosten
+      user-jrautiola
+      user-mkaapu
+    ])
+    ./disk-config.nix
+  ];
+
+  # Hardwre Configuration:
+
+  boot.initrd.availableKernelModules = ["ahci" "xhci_pci" "megaraid_sas" "nvme" "usbhid" "sd_mod"];
+  boot.kernelModules = ["kvm-intel"];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  # Installation:
+
+  # Use the systemd-boot EFI boot loader.
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+}

--- a/hosts/ficolobuild/disk-config.nix
+++ b/hosts/ficolobuild/disk-config.nix
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+# BIOS compatible gpt partition
+{
+  disko.devices = {
+    disk = {
+      sdb = {
+        device = "/dev/sdb";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            boot = {
+              size = "1M";
+              type = "EF02";
+            };
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            root = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/sata";
+              };
+            };
+          };
+        };
+      };
+      sda = {
+        device = "/dev/sda";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            nix = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/nix";
+              };
+            };
+          };
+        };
+      };
+      root = {
+        device = "/dev/nvme0n1";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            nix = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/";
+              };
+            };
+          };
+        };
+      };
+      home = {
+        device = "/dev/nvme1n1";
+        type = "disk";
+        content = {
+          type = "gpt";
+          partitions = {
+            nix = {
+              size = "100%";
+              content = {
+                type = "filesystem";
+                format = "ext4";
+                mountpoint = "/home";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/ficolobuild/disk-config.nix
+++ b/hosts/ficolobuild/disk-config.nix
@@ -5,8 +5,8 @@
 {
   disko.devices = {
     disk = {
-      sdb = {
-        device = "/dev/sdb";
+      sda = {
+        device = "/dev/sda";
         type = "disk";
         content = {
           type = "gpt";
@@ -35,8 +35,8 @@
           };
         };
       };
-      sda = {
-        device = "/dev/sda";
+      sdb = {
+        device = "/dev/sdb";
         type = "disk";
         content = {
           type = "gpt";

--- a/tasks.py
+++ b/tasks.py
@@ -82,6 +82,9 @@ TARGETS = OrderedDict(
         "monitoring-ficolo": TargetHost(
             hostname="172.18.20.108", nixosconfig="monitoring"
         ),
+        "build3-ficolo": TargetHost(
+            hostname="172.18.20.104", nixosconfig="ficolobuild"
+        ),
     }
 )
 

--- a/users/default.nix
+++ b/users/default.nix
@@ -10,5 +10,6 @@
     user-jrautiola = import ./jrautiola.nix;
     user-hydra = import ./hydra.nix;
     user-cazfi = import ./cazfi.nix;
+    user-mkaapu = import ./mkaapu.nix;
   };
 }

--- a/users/mkaapu.nix
+++ b/users/mkaapu.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    mkaapu = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE6WDXGfrD+WfY2+eP+/c4NrEOeCGpEOE2TcTlwxWXho marko.kaapu@unikie.com"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}


### PR DESCRIPTION
Add common configuration to install NixOS for all Ficolo build servers replacing current Ubuntu servers

HW configuration is based on configuration generated by the nixos-generate-config tool on one of the target machines.
Preconfigured IP address is provided to Ficolo builders by an external DHCP server based on the MAC address of the server.
Disk configuration (disk-config.nix) formats 4 separate disks. Initial disk setup should be identical on all Ficolo build servers.

Configuration alias to install NixOS to the current build3 Ubuntu machine with the IP address 172.18.20.104 added.
The 'mkaapu' user account configuration added.

All existing users will be added to installed Ficolo build machines.