### PR TITLE
feat: support nixosConfigurations in perSystem

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -4,7 +4,6 @@
 {
   self,
   inputs,
-  lib,
   ...
 }: {
   flake.nixosModules = {
@@ -15,25 +14,33 @@
     generic-disk-config = import ./generic-disk-config.nix;
   };
 
-  flake.nixosConfigurations = let
-    # make self and inputs available in nixos modules
-    specialArgs = {inherit self inputs;};
-  in {
-    ghafhydra = lib.nixosSystem {
-      inherit specialArgs;
-      modules = [./ghafhydra/configuration.nix];
-    };
-    binarycache = lib.nixosSystem {
-      inherit specialArgs;
-      modules = [./binarycache/configuration.nix];
-    };
-    monitoring = lib.nixosSystem {
-      inherit specialArgs;
-      modules = [./monitoring/configuration.nix];
-    };
-    ficolobuild = lib.nixosSystem {
-      inherit specialArgs;
-      modules = [./ficolobuild/configuration.nix];
-    };
+  perSystem = {
+    pkgs,
+    lib,
+    system,
+    ...
+  }: {
+    nixosConfigurations = let
+      # make self and inputs available in nixos modules
+      specialArgs = {inherit self inputs;};
+    in
+      lib.mkIf (system == "x86_64-linux") {
+        ghafhydra = lib.nixosSystem {
+          inherit pkgs specialArgs;
+          modules = [./ghafhydra/configuration.nix];
+        };
+        binarycache = lib.nixosSystem {
+          inherit pkgs specialArgs;
+          modules = [./binarycache/configuration.nix];
+        };
+        monitoring = lib.nixosSystem {
+          inherit pkgs specialArgs;
+          modules = [./monitoring/configuration.nix];
+        };
+        ficolobuild = lib.nixosSystem {
+          inherit pkgs specialArgs;
+          modules = [./ficolobuild/configuration.nix];
+        };
+      };
   };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,6 +6,7 @@
     ./checks.nix
     ./devshell.nix
     ./nixpkgs.nix
+    ./nixos.nix
     ./treefmt.nix
   ];
 }

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  config,
+  flake-parts-lib,
+  ...
+}: let
+  inherit (config) systems allSystems;
+in {
+  options.perSystem = flake-parts-lib.mkPerSystemOption {
+    options.nixosConfigurations = with lib;
+      mkOption {
+        description = "define nixosConfigurations in a perSystem function";
+        type = types.lazyAttrsOf types.unspecified;
+        default = {};
+      };
+  };
+
+  config = {
+    flake = {
+      nixosConfigurations = with lib;
+        builtins.foldl'
+        (x: y: x // y) {}
+        (attrValues (genAttrs systems (system: allSystems.${system}.nixosConfigurations)));
+    };
+  };
+}


### PR DESCRIPTION
Adds a flake.parts module which transposes `nixosConfigurations` defined within `perSystem` functions.

Makes it easier to re-use the `perSystem` `pkgs` instance within `lib.nixosSystem`.