### PR TITLE
x86 builder: Add access to binary cache and Gala app sources

### DIFF
--- a/hosts/ficolobuild/configuration.nix
+++ b/hosts/ficolobuild/configuration.nix
@@ -36,4 +36,10 @@
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+
+  # Connect hosts in the same network.
+  networking.extraHosts = "
+    172.18.20.102 vedenemo.dev # for fetching Gala app sources
+    172.18.20.109 cache.vedenemo.dev # Binary cache
+  ";
 }


### PR DESCRIPTION
Add access to extra hosts:
Add access to vedenemo.dev to fetch Gala app sources.
Add access to cache.vedenemo.dev (Binary cache).
