### PR TITLE
Fix pre-push formatting checks

### DIFF
--- a/hosts/prbuilder/configuration.nix
+++ b/hosts/prbuilder/configuration.nix
@@ -24,13 +24,13 @@
     ./disk-config.nix
   ];
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
-   # List packages installed in system profile
+  # List packages installed in system profile
   environment.systemPackages = with pkgs; [
     git
     emacs
   ];
   # docker daemon running
-  virtualisation.docker.enable=true;
+  virtualisation.docker.enable = true;
 
   networking = {
     hostName = "prbuilder";

--- a/tasks.py
+++ b/tasks.py
@@ -32,23 +32,22 @@
 """ Misc dev and deployment helper tasks """
 
 import json
+import logging
 import os
+import socket
 import subprocess
 import sys
-import logging
-import socket
 import time
+from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Union
-from collections import OrderedDict
-from dataclasses import dataclass
 
-from tabulate import tabulate
 from colorlog import ColoredFormatter, default_log_colors
 from deploykit import DeployHost, HostKeyCheck
 from invoke import task
-
+from tabulate import tabulate
 
 ################################################################################
 
@@ -74,19 +73,24 @@ class TargetHost:
 TARGETS = OrderedDict(
     {
         "ghafhydra-dev": TargetHost(
-            hostname="ghafhydra.northeurope.cloudapp.azure.com", nixosconfig="ghafhydra"
+            hostname="ghafhydra.northeurope.cloudapp.azure.com",
+            nixosconfig="ghafhydra",
         ),
         "binarycache-ficolo": TargetHost(
-            hostname="172.18.20.109", nixosconfig="binarycache"
+            hostname="172.18.20.109",
+            nixosconfig="binarycache",
         ),
         "monitoring-ficolo": TargetHost(
-            hostname="172.18.20.108", nixosconfig="monitoring"
+            hostname="172.18.20.108",
+            nixosconfig="monitoring",
         ),
         "build3-ficolo": TargetHost(
-            hostname="172.18.20.104", nixosconfig="ficolobuild"
+            hostname="172.18.20.104",
+            nixosconfig="ficolobuild",
         ),
         "prbuilder": TargetHost(
-            hostname="172.18.20.106", nixosconfig="prbuilder"
+            hostname="172.18.20.106",
+            nixosconfig="prbuilder",
         ),
     }
 )

--- a/tasks.py
+++ b/tasks.py
@@ -495,9 +495,10 @@ def pre_push(c: Any) -> None:
     if not ret:
         LOG.warning("Run `terraform fmt -recursive` locally to fix formatting")
         sys.exit(1)
-    cmd = "nix fmt"
+    cmd = "nix fmt -- --fail-on-change"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
+        LOG.warning("Run `nix fmt` locally to fix formatting")
         sys.exit(1)
     cmd = "nix flake check -v"
     ret = exec_cmd(cmd, raise_on_error=False)


### PR DESCRIPTION
Current main branch does not pass `nix flake check` as the formatting is wrong in prbuilder configuration. This passed our automatic checks because the pre-push task silently reformats the files before running `nix flake check`. Thus the pre-push checks pass even though files have been changed.

`nix fmt` has no `--check` option so this was changed to ~~`alejandra --check .`~~ `nix fmt -- --fail-on-change`.

For `tasks.py`, added some commas so `black` will format the aliases consistently in the same way. Without this the wrapping would depend on the line length. Imports have also been sorted with `isort`.