### PR TITLE
x86 builder: Include ficolohosts module

### DIFF
--- a/hosts/ficolo-hosts.nix
+++ b/hosts/ficolo-hosts.nix
@@ -4,7 +4,6 @@
 {
   networking.extraHosts = ''
     172.18.20.102 vedenemo.dev
-    172.18.20.105 ganymede.vedenemo.dev
     172.18.20.109 cache.vedenemo.dev
   '';
 }

--- a/hosts/ficolobuild/configuration.nix
+++ b/hosts/ficolobuild/configuration.nix
@@ -15,6 +15,7 @@
     (with self.nixosModules; [
       common
       service-openssh
+      ficolo-hosts
       user-cazfi
       user-hrosten
       user-jrautiola
@@ -38,12 +39,6 @@
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
-
-  # Connect hosts in the same network.
-  networking.extraHosts = "
-    172.18.20.102 vedenemo.dev # for fetching Gala app sources
-    172.18.20.109 cache.vedenemo.dev # Binary cache
-  ";
 
   # Trust Themisto Hydra user
   nix.settings = {


### PR DESCRIPTION
General ficolohosts module defining extra hosts were tested and introduced after x86 builder configuration.
- Removing extra hosts configuration from hosts/ficolobuild/configuration.nix
- Including ficolohosts module
- This also fixes a bug caused by using double quotation marks instead of single ones to list extra hosts in configuration, which added extra spaces before the IP addresses in /etc/hosts which are not allowed.

Extra commit: Ganymede is taken down so removing that from extra hosts.