### PR TITLE
playground: initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ terraform.tfstate
 terraform.tfstate.backup
 .idea
 .direnv
+*.tmp

--- a/terraform/jenkins/binary_cache.tf
+++ b/terraform/jenkins/binary_cache.tf
@@ -23,8 +23,10 @@ module "binary_cache_vm" {
   resource_group_name = azurerm_resource_group.default.name
   location            = azurerm_resource_group.default.location
 
-  virtual_machine_name         = "ghaf-binary-cache"
-  virtual_machine_size         = "Standard_D1_v2"
+  virtual_machine_name = "ghaf-binary-cache-${local.name_postfix}"
+  # Use 'Standard_D2_v2' if the workspace is 'default' (2 vCPUs, 7 GiB RAM)
+  # Use 'Standard_D1_v2' if the workspace is anything but 'default' (1 vCPU, 3.5 GiB RAM)
+  virtual_machine_size         = terraform.workspace == "default" ? "Standard_D2_v2" : "Standard_D1_v2"
   virtual_machine_source_image = module.binary_cache_image.image_id
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({

--- a/terraform/jenkins/binary_cache_signing.tf
+++ b/terraform/jenkins/binary_cache_signing.tf
@@ -6,14 +6,17 @@
 # terraform import secret_resource.binary_cache_signing_key "$(< ./secret-key)"
 resource "secret_resource" "binary_cache_signing_key" {
   lifecycle {
-    prevent_destroy = true
+    # To support automatically generating and destroying temp signing keys
+    # with playground/terraform-az-dev.sh, `prevent_destroy` needs to be set
+    # to `false`:
+    prevent_destroy = false
   }
 }
 
 # Create an Azure key vault.
 resource "azurerm_key_vault" "binary_cache_signing_key" {
   # this must be globally unique
-  name                = "ghaf-binarycache-signing"
+  name                = "sig-${local.name_postfix}"
   location            = azurerm_resource_group.default.location
   resource_group_name = azurerm_resource_group.default.name
   sku_name            = "standard"

--- a/terraform/jenkins/binary_cache_storage.tf
+++ b/terraform/jenkins/binary_cache_storage.tf
@@ -4,7 +4,7 @@
 
 # Create the storage account and storage container
 resource "azurerm_storage_account" "binary_cache" {
-  name                            = "ghafbinarycache"
+  name                            = "bche${local.name_postfix}"
   resource_group_name             = azurerm_resource_group.default.name # TODO: separate resource group?
   location                        = azurerm_resource_group.default.location
   account_tier                    = "Standard"

--- a/terraform/jenkins/builder.tf
+++ b/terraform/jenkins/builder.tf
@@ -29,8 +29,10 @@ module "builder_vm" {
   resource_group_name = azurerm_resource_group.default.name
   location            = azurerm_resource_group.default.location
 
-  virtual_machine_name         = "ghaf-builder-${count.index}"
-  virtual_machine_size         = "Standard_D4_v3"
+  virtual_machine_name = "ghaf-builder-${count.index}-${local.name_postfix}"
+  # Use 'Standard_D4_v3' if the workspace is 'default' (4 vCPUs, 16 GiB RAM)
+  # Use 'Standard_D2_v3' if the workspace is anything but 'default' (2 vCPU, 8 GiB RAM)
+  virtual_machine_size         = terraform.workspace == "default" ? "Standard_D4_v3" : "Standard_D2_v3"
   virtual_machine_source_image = module.builder_image.image_id
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({

--- a/terraform/jenkins/image_storage.tf
+++ b/terraform/jenkins/image_storage.tf
@@ -5,7 +5,7 @@
 # Storage account and storage container used to store VM images
 
 resource "azurerm_storage_account" "vm_images" {
-  name                            = "ghafinfravmimages"
+  name                            = "vimg${local.name_postfix}"
   resource_group_name             = azurerm_resource_group.default.name
   location                        = azurerm_resource_group.default.location
   account_tier                    = "Standard"

--- a/terraform/jenkins/jenkins_controller.tf
+++ b/terraform/jenkins/jenkins_controller.tf
@@ -25,7 +25,7 @@ module "jenkins_controller_vm" {
   resource_group_name = azurerm_resource_group.default.name
   location            = azurerm_resource_group.default.location
 
-  virtual_machine_name         = "ghaf-jenkins-controller"
+  virtual_machine_name         = "ghaf-jenkins-controller-${local.name_postfix}"
   virtual_machine_size         = "Standard_D2_v2"
   virtual_machine_source_image = module.jenkins_controller_image.image_id
 

--- a/terraform/jenkins/main.tf
+++ b/terraform/jenkins/main.tf
@@ -17,14 +17,18 @@ terraform {
   }
 }
 
-# read ssh-keys.yaml into local.ssh_keys
 locals {
+  # read ssh-keys.yaml into local.ssh_keys
   ssh_keys = yamldecode(file("../../ssh-keys.yaml"))
+  # postfix used in the resource group name
+  rg_postfix = terraform.workspace == "default" ? "prod" : terraform.workspace
+  # postfix used in various resource names
+  name_postfix = terraform.workspace == "default" ? "ghafprod" : terraform.workspace
 }
 
 # The resource group everything in this terraform module lives in
 resource "azurerm_resource_group" "default" {
-  name     = "ghaf-infra-jenkins"
+  name     = "ghaf-infra-jenkins-${local.rg_postfix}"
   location = "northeurope"
 }
 

--- a/terraform/jenkins/remote_build_ssh.tf
+++ b/terraform/jenkins/remote_build_ssh.tf
@@ -9,8 +9,11 @@ resource "tls_private_key" "ed25519_remote_build" {
 }
 
 # Dump the ed25519 public key to disk
+# TODO: why do we need to dump the builder public key to disk and store it
+# in git?
 resource "local_file" "ed25519_remote_build_pubkey" {
-  filename        = "${path.module}/id_ed25519_remote_build.pub"
+  # For non-default workspaces, add extension .tmp to the filename
+  filename        = terraform.workspace == "default" ? "${path.module}/id_ed25519_remote_build.pub" : "${path.module}/id_ed25519_remote_build.pub.tmp"
   file_permission = "0644"
   content         = tls_private_key.ed25519_remote_build.public_key_openssh
 }
@@ -18,7 +21,7 @@ resource "local_file" "ed25519_remote_build_pubkey" {
 # Create an Azure key vault.
 resource "azurerm_key_vault" "ssh_remote_build" {
   # this must be globally unique
-  name                = "ghaf-ssh-remote-build"
+  name                = "ssh-${local.name_postfix}"
   location            = azurerm_resource_group.default.location
   resource_group_name = azurerm_resource_group.default.name
   sku_name            = "standard"

--- a/terraform/playground/README.md
+++ b/terraform/playground/README.md
@@ -1,0 +1,93 @@
+<!--
+SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Terraform Playground
+
+This project uses terraform to automate the creation of infrastructure resources.
+To support infrastructure development in isolated development environments, we use [terraform workspaces](https://developer.hashicorp.com/terraform/cli/workspaces).
+
+The tooling under this `playground` directory is provided to facilitate the usage of terraform workspaces in setting-up a distinct copy of the target infrastructure to test a set of changes before modifying shared (dev/prod) infrastructure.
+
+This page documents the usage of `terraform-playground.sh` to help facilitate the usage of private development environments for testing infra changes.
+
+**Note**: the environments created with `terraform-playground.sh` are supposed to be temporary and short-lived. Each active (non-destroyed) playground instance will cost some real money, so be sure to destroy the playground instances as soon as they are no longer needed. It's easy to spin-up a new playground environment using `terraform-playground.sh`, so there's no need to keep them alive '*just in case*'.
+
+## Usage
+
+If you still don't have nix package manager on your local host, install it following the package manager installation instructions from https://nixos.org/download.html.
+
+Then, clone this repository:
+```bash
+$ git clone https://github.com/tiiuae/ghaf-infra.git
+$ cd ghaf-infra/
+```
+
+All commands in this document are executed from nix-shell inside the `terraform/jenkins` directory.
+
+Bootstrap nix-shell with the required dependencies:
+```bash
+# Start a nix-shell with required dependencies:
+$ nix-shell
+
+# Authenticate with az login:
+$ az login
+
+# We use the configuration under terraform/jenkins as an example:
+$ cd terraform/jenkins
+```
+
+## Activating Playground Environment
+```bash
+# Activate private development environment
+$ ../playground/terraform-playground.sh activate
+# ...
+[+] Done, use terraform [validate|plan|apply] to work with your dev infra
+```
+The `activate` command sets-up a terraform workspace for your private development environment:
+```bash
+# List the current terraform worskapce
+$ ../playground/terraform-playground.sh list
+Terraform workspaces:
+  default
+* henrirosten       # <-- indicates active workspace
+```
+
+## Testing Infrastructure Changes
+With the private development workspace now setup, we can test infrastructure changes in a private development environment:
+```bash
+# In directory terraform/jenkins
+$ pwd
+[..]/ghaf-infra/terraform/jenkins
+
+# Check terraform configuration files format:
+$ terraform fmt -recursive
+
+# Check the the terraform configuration is valid:
+$ terraform validate
+
+# Show configuration changes:
+$ terraform plan
+
+# Deploy the infrastructure:
+$ terraform apply -auto-approve
+```
+
+Once `terraform apply` completes, the private development infrastructure is deployed.
+You can now play around in your isolated copy of the infrastructure, testing and updating the changes, making sure the changes work as expected before proposing the changes to a shared (prod/dev) environment.
+
+## Destroying Playground Environment
+Once the configuration changes have been tested, the private development environment can be destroyed:
+```bash
+# Destroy the private terraform worskapce
+$ ../playground/terraform-playground.sh destroy
+```
+The above command removes all the resources that were created for the private development environment.
+
+
+## References
+- Terraform workspaces: https://developer.hashicorp.com/terraform/cli/workspaces
+- How to manage multiple environments with Terraform using workspaces: https://blog.gruntwork.io/how-to-manage-multiple-environments-with-terraform-using-workspaces-98680d89a03e
+

--- a/terraform/playground/terraform-playground.sh
+++ b/terraform/playground/terraform-playground.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e # exit immediately if a command fails
+set -u # treat unset variables as an error and exit
+set -o pipefail # exit if any pipeline command fails
+
+################################################################################
+
+MYNAME=$(basename "$0")
+usage () {
+    echo "Usage: $MYNAME [activate|destroy|list]"
+    echo ""
+    echo "This script is a thin wrapper around terraform workspaces to enable private"
+    echo "development environment setup for testing Azure infra changes."
+    echo ""
+    echo "COMMANDS"
+    echo "   activate    Activate private infra development environment"
+    echo "   destroy     Destroy private infra development environment"
+    echo "   list        List current terraform workspaces"
+    echo ""
+    echo ""
+    echo " EXAMPLE:"
+    echo "    ./$MYNAME activate"
+    echo ""
+    echo "    Activate and - unless already created - create a new terraform workspace"
+    echo "    to allow testing the infra setup in a private development environment."
+    echo ""
+    echo ""
+    echo " EXAMPLE:"
+    echo "    ./$MYNAME destroy"
+    echo " "
+    echo "    Deactivate and destroy the private development infra that was previously"
+    echo "    created with the 'activate' command. This command deletes all the infra"
+    echo "    resources and removes the terraform workspace."
+    echo ""
+}
+
+################################################################################
+
+exit_unless_command_exists () {
+    if ! command -v "$1" &> /dev/null; then
+        echo "Error: command '$1' is not installed" >&2
+        exit 1
+    fi
+}
+
+generate_azure_private_workspace_name () {
+    # Generate workspace name based on azure signed-in-user:
+    # - .userPrincipalName returns the signed-in azure username
+    # - cut removes everything up until the first '@'
+    # - sed keeps only letter and number characters
+    # - final cut keeps at most 20 characters
+    # Thus, given a signed-in user 'foo.bar@baz.com', the workspace name
+    # becomes 'foobar'.
+    # Below command errors out with the azure error message if the azure user
+    # is not signed-in.
+    WORKSPACE=$(az ad signed-in-user show | jq -cr .userPrincipalName | cut -d'@' -f1 | sed 's/[^a-zA-Z0-9]//g' | cut -c 1-20)
+    # Check WORKSPACE is non-empty and not 'default'
+    if [ -z "$WORKSPACE" ] || [ "$WORKSPACE" = "default" ]; then
+        echo "Error: invalid workspace name: '$WORKSPACE'"
+        exit 1
+    fi
+}
+
+import_sigkey () {
+    # This function is a hack to automatically generate the binary cache
+    # signing key for the (ghaf-infra) private dev environment.
+
+    # No need to import anything if the below key isn't defined in the infra
+    if ! grep -q secret_resource.binary_cache_signing_key -- *.tf; then
+        return
+    fi
+
+    # Skip import if signing key is imported already
+    if terraform state list | grep -q secret_resource.binary_cache_signing_key ; then
+        return
+    fi
+
+    # Generate and import the key
+    nix-store --generate-binary-cache-key "$WORKSPACE" sigkey-secret.tmp sigkey-public.tmp
+    terraform import secret_resource.binary_cache_signing_key "$(< ./sigkey-secret.tmp)"
+}
+
+delete_keyvault () {
+    # This function is a hack to automatically delete keyvaults
+    # from the (ghaf-infra) private dev environment.
+    set +e
+    if grep -qP "sig-.*name_postfix" -- *.tf; then
+        az keyvault delete --name "sig-$WORKSPACE" 2>/dev/null
+        az keyvault purge  --name "sig-$WORKSPACE" 2>/dev/null
+    fi
+    if grep -qP "ssh-.*name_postfix" -- *.tf; then
+        az keyvault delete --name "ssh-$WORKSPACE" 2>/dev/null
+        az keyvault purge  --name "ssh-$WORKSPACE" 2>/dev/null
+    fi
+    set -e
+}
+
+activate () {
+    echo "[+] Activating workspace: '$WORKSPACE'"
+    if terraform workspace list | grep -q "$WORKSPACE"; then
+        terraform workspace select "$WORKSPACE"
+    else
+        terraform workspace new "$WORKSPACE"
+        terraform workspace select "$WORKSPACE"
+    fi
+    import_sigkey
+    echo "[+] Done, use terraform [validate|plan|apply] to work with your dev infra"
+}
+
+destroy () {
+    if ! terraform workspace list | grep -q "$WORKSPACE"; then
+        echo "[+] Devenv workspace '$WORKSPACE' does not exist, nothing to destroy"
+        exit 0
+    fi
+    echo "[+] Destroying workspace: '$WORKSPACE'"
+    terraform workspace select "$WORKSPACE"
+    delete_keyvault
+    terraform apply -destroy -auto-approve
+    terraform workspace select default
+}
+
+list () {
+    echo "Terraform workspaces:"
+    terraform workspace list
+}
+
+################################################################################
+
+main () {
+    if [ $# -ne 1 ]; then
+       usage
+       exit 0
+    fi
+    if [ "$1" != "activate" ] && [ "$1" != "destroy" ] && [ "$1" != "list" ]; then
+        echo "Error: invalid command: '$1'"
+        usage
+        exit 1
+    fi
+
+    exit_unless_command_exists az
+    exit_unless_command_exists terraform
+    exit_unless_command_exists nix-store
+    exit_unless_command_exists jq
+    exit_unless_command_exists sed
+    exit_unless_command_exists cut
+    
+    # Assigns $WORKSPACE variable
+    generate_azure_private_workspace_name
+
+    # It is safe to run terraform init multiple times
+    terraform init &> /dev/null
+
+    # Run the given command
+    if [ "$1" == "activate" ]; then
+        activate
+    fi
+    if [ "$1" == "destroy" ]; then
+        destroy
+    fi
+    if [ "$1" == "list" ]; then
+        list 
+    fi
+}
+
+main "$@"
+
+################################################################################

--- a/terraform/playground/test-infra.tf
+++ b/terraform/playground/test-infra.tf
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+  # Backend for storing tfstate (see ./azure-storage)
+  backend "azurerm" {
+    resource_group_name  = "ghaf-infra-storage"
+    storage_account_name = "ghafinfrastatestorage"
+    container_name       = "ghaf-infra-tfstate-container"
+    key                  = "ghaf-infra-playground.tfstate"
+  }
+}
+provider "azurerm" {
+  features {}
+}
+# Resource group
+resource "azurerm_resource_group" "playground_rg" {
+  name     = "ghaf-infra-playground-${terraform.workspace}"
+  location = "northeurope"
+}
+# Virtual Network
+resource "azurerm_virtual_network" "ghaf_infra_tf_vnet" {
+  name                = "ghaf-infra-tf-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.playground_rg.location
+  resource_group_name = azurerm_resource_group.playground_rg.name
+}
+# Subnet
+resource "azurerm_subnet" "playground_subnet" {
+  name                 = "ghaf-infra-tf-subnet"
+  resource_group_name  = azurerm_resource_group.playground_rg.name
+  virtual_network_name = azurerm_virtual_network.ghaf_infra_tf_vnet.name
+  address_prefixes     = ["10.0.5.0/24"]
+}
+# read ssh-keys.yaml into local.ssh_keys
+locals {
+  ssh_keys = yamldecode(file("../../ssh-keys.yaml"))
+}
+
+################################################################################
+
+# Image storage
+
+# Create a random string
+resource "random_string" "imgstr" {
+  length  = "12"
+  special = "false"
+  upper   = false
+}
+
+resource "azurerm_storage_account" "vm_images" {
+  name                            = "nixosimages${random_string.imgstr.result}"
+  resource_group_name             = azurerm_resource_group.playground_rg.name
+  location                        = azurerm_resource_group.playground_rg.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
+}
+
+resource "azurerm_storage_container" "vm_images" {
+  name                  = "ghaf-test-vm-images"
+  storage_account_name  = azurerm_storage_account.vm_images.name
+  container_access_type = "private"
+}
+
+################################################################################
+
+# VM
+
+module "test_image" {
+  source = "../../tf-modules/azurerm-nix-vm-image"
+
+  nix_attrpath   = "outputs.nixosConfigurations.builder.config.system.build.azureImage"
+  nix_entrypoint = "${path.module}/../.."
+
+  name                = "playground_vm_img"
+  resource_group_name = azurerm_resource_group.playground_rg.name
+  location            = azurerm_resource_group.playground_rg.location
+
+  storage_account_name   = azurerm_storage_account.vm_images.name
+  storage_container_name = azurerm_storage_container.vm_images.name
+}
+
+locals {
+  num_vms = 1
+}
+
+module "test_vm" {
+  source = "../../tf-modules/azurerm-linux-vm"
+
+  count = local.num_vms
+
+  resource_group_name = azurerm_resource_group.playground_rg.name
+  location            = azurerm_resource_group.playground_rg.location
+
+  virtual_machine_name = "ghaf-playground-${count.index}-${terraform.workspace}"
+  # Demonstrate a way to use different configurations in different workspaces.
+  # Here, we define the following image sizes:
+  # - Use 'Standard_D2_v2' if the workspace is 'default' (2 vCPUs, 7 GiB RAM)
+  # - Use 'Standard_D1_v2' if the workspace is anything but 'default' (1 vCPU, 3.5 GiB RAM)
+  # The idea is based on the following article:
+  # https://blog.gruntwork.io/how-to-manage-multiple-environments-with-terraform-using-workspaces-98680d89a03e#2bc6
+  #
+  # Full list of Azure image sizes are available in:
+  # https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/#pricing
+  virtual_machine_size         = terraform.workspace == "default" ? "Standard_D2_v2" : "Standard_D1_v2"
+  virtual_machine_source_image = module.test_image.image_id
+
+  virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({
+    users = [
+      {
+        name                = "hrosten"
+        sudo                = "ALL=(ALL) NOPASSWD:ALL"
+        ssh_authorized_keys = local.ssh_keys["hrosten"]
+      },
+    ]
+  })])
+
+  allocate_public_ip = true
+  subnet_id          = azurerm_subnet.playground_subnet.id
+}
+
+# Allow inbound SSH
+resource "azurerm_network_security_group" "test_vm" {
+  count               = local.num_vms
+  name                = "test-vm-${count.index}"
+  resource_group_name = azurerm_resource_group.playground_rg.name
+  location            = azurerm_resource_group.playground_rg.location
+  security_rule {
+    name                       = "AllowSSH"
+    priority                   = 400
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_ranges    = [22]
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+resource "azurerm_network_interface_security_group_association" "test_vm" {
+  count                     = local.num_vms
+  network_interface_id      = module.test_vm[count.index].virtual_machine_network_interface_id
+  network_security_group_id = azurerm_network_security_group.test_vm[count.index].id
+}
+
+################################################################################
+


### PR DESCRIPTION
Support using terraform workspaces to setup private development environments on Azure:
- Adds `playground/terraform-playground.sh` to facilitate the usage of private development environments in testing infrastructure changes
- Adds terraform workspace support for ghaf-infra-jenkins to make it possible to use the playground tooling to support setting-up temporary development environments of the ghaf-infra-jenkins infrastructure.