### PR TITLE
Separate machine specific x86 builder configuration from the common one

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -32,9 +32,9 @@
       inherit specialArgs;
       modules = [./monitoring/configuration.nix];
     };
-    ficolobuild = lib.nixosSystem {
+    ficolobuild3 = lib.nixosSystem {
       inherit specialArgs;
-      modules = [./ficolobuild/configuration.nix];
+      modules = [./ficolobuild/build3.nix];
     };
     prbuilder = lib.nixosSystem {
       inherit specialArgs;

--- a/hosts/ficolobuild/build3.nix
+++ b/hosts/ficolobuild/build3.nix
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+#
+{
+  self,
+  lib,
+  ...
+}: {
+  imports = lib.flatten [
+    (with self.nixosModules; [
+      user-themisto
+      user-barna
+    ])
+    ./builder.nix
+  ];
+
+  # build3 specific configuration
+
+  networking.hostName = "build3";
+
+  # Trust Themisto Hydra user
+  nix.settings = {
+    trusted-users = ["root" "themisto" "barna"];
+  };
+}

--- a/hosts/ficolobuild/builder.nix
+++ b/hosts/ficolobuild/builder.nix
@@ -21,7 +21,6 @@
       user-hrosten
       user-jrautiola
       user-mkaapu
-      user-themisto
       user-tervis
       user-karim
       user-mika
@@ -42,9 +41,4 @@
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
-
-  # Trust Themisto Hydra user
-  nix.settings = {
-    trusted-users = ["root" "themisto"];
-  };
 }

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-FileCopyrightText: 2023-2024 Technology Innovation Institute (TII)
 # SPDX-FileCopyrightText: 2023 Nix community projects
 #
 # SPDX-License-Identifier: MIT
@@ -86,7 +86,7 @@ TARGETS = OrderedDict(
         ),
         "build3-ficolo": TargetHost(
             hostname="172.18.20.104",
-            nixosconfig="ficolobuild",
+            nixosconfig="ficolobuild3",
         ),
         "prbuilder": TargetHost(
             hostname="172.18.20.106",


### PR DESCRIPTION
Changes:
- adds build3 (x86 builder on Ficolo) specific configuration
- adds Barna as a trusted user to build3 specific configuration
- hostname of build3 machine changed from "nixos" to "build3"

Notes:
- Hostname change will not take place without running the hostname tool or without reboot