### PR TITLE
Ignore tmp files in main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ terraform.tfstate
 terraform.tfstate.backup
 .idea
 .direnv
+*.tmp


### PR DESCRIPTION
Switching between main branch and azure-images branch leaves dirty git state because these files are only ignored on the other branch. This should fix that temporarily.