### PR TITLE
Add themisto user to build4

### DIFF
--- a/hosts/ficolobuild/build4.nix
+++ b/hosts/ficolobuild/build4.nix
@@ -1,8 +1,15 @@
 # SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 #
-{...}: {
-  imports = [
+{
+  self,
+  lib,
+  ...
+}: {
+  imports = lib.flatten [
+    (with self.nixosModules; [
+      user-themisto
+    ])
     # Import Ficolo x86 builder specific configuration
     ./builder.nix
   ];
@@ -10,4 +17,9 @@
   # build4 specific configuration
 
   networking.hostName = "build4";
+
+  # Trust Themisto Hydra user
+  nix.settings = {
+    trusted-users = ["root" "themisto"];
+  };
 }


### PR DESCRIPTION
The build4 (x86 Ficolo build server) will be used as remote builder with Themisto Hydra.