### PR TITLE
Stop using RSA

### DIFF
--- a/hosts/ficolobuild/developers.nix
+++ b/hosts/ficolobuild/developers.nix
@@ -9,7 +9,7 @@
     {
       name = "barna";
       keys = [
-        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQChDMYWXg51H1/3Y3fGb8Bn6Dj1jauzKKsPdtRjFHTWSCde4GmF1/uPUJ9qogLNBS2B0nDS+IxnNNIKWarZhkb1aHvWHBy1n1s4gULwCZcF36yaFfKKCIfro+YI1/1uOZuv/AtVLzAgFlgUb21xLF9m11yuobB6OqSd9Fxt8i2AdfwVuj1fxyRlI+l5v82g0d3KiN0Pw+FqtzIZ6sEcpw8Mqn469PIDARUmYxo7mRMug8QPmQPgv57YhbppLN6cHUbYlud/2UeESUFsXrCAMDLtghvkNlAlmriaqhlVoH3jTLJ8ljIbHeFrBidZZk1/e7Ucw8iLkesQ11YrAY0QqqyH6vRr/o0XHiCbnxJl7rH9AC8tguqgFR/K2T8qygJZfs1szaOQg/+O7tdqwU8+j2NDSuh+PjYGnMOIT11ErtAYB2DAd8xVYOOWCsLeHVoiC1jgkVjehkV4wmwmq3d7X5iyuK7n4zJTEIqDzbrfshUnpL9ERe7zlFaocqUVedn1DDU= barna.bakos@unikie.com"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHrmxamlb4JNX+lrN88rfEEskCM0A5MhGSKaA4CZDM8y barna.bakos@unikie.com"
       ];
     }
     {

--- a/services/openssh/default.nix
+++ b/services/openssh/default.nix
@@ -4,10 +4,19 @@
 {
   services.openssh = {
     enable = true;
-    settings.PermitRootLogin = "no";
-    settings.KbdInteractiveAuthentication = false;
-    settings.PasswordAuthentication = false;
-    settings.ClientAliveInterval = 60;
+
+    settings = {
+      PermitRootLogin = "no";
+      KbdInteractiveAuthentication = false;
+      PasswordAuthentication = false;
+      ClientAliveInterval = 60;
+    };
+
+    # Only allow ed25519 keys
+    extraConfig = ''
+      PubkeyAcceptedKeyTypes ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com
+    '';
+
     hostKeys = [
       {
         path = "/etc/ssh/ssh_host_ed25519_key";
@@ -15,7 +24,10 @@
       }
     ];
   };
+
+  # Open port for ssh connections
   networking.firewall.allowedTCPPorts = [22];
+
   # Ban brute force SSH
   services.fail2ban.enable = true;
 }

--- a/users/barna.nix
+++ b/users/barna.nix
@@ -6,7 +6,7 @@
     barna = {
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
-        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQChDMYWXg51H1/3Y3fGb8Bn6Dj1jauzKKsPdtRjFHTWSCde4GmF1/uPUJ9qogLNBS2B0nDS+IxnNNIKWarZhkb1aHvWHBy1n1s4gULwCZcF36yaFfKKCIfro+YI1/1uOZuv/AtVLzAgFlgUb21xLF9m11yuobB6OqSd9Fxt8i2AdfwVuj1fxyRlI+l5v82g0d3KiN0Pw+FqtzIZ6sEcpw8Mqn469PIDARUmYxo7mRMug8QPmQPgv57YhbppLN6cHUbYlud/2UeESUFsXrCAMDLtghvkNlAlmriaqhlVoH3jTLJ8ljIbHeFrBidZZk1/e7Ucw8iLkesQ11YrAY0QqqyH6vRr/o0XHiCbnxJl7rH9AC8tguqgFR/K2T8qygJZfs1szaOQg/+O7tdqwU8+j2NDSuh+PjYGnMOIT11ErtAYB2DAd8xVYOOWCsLeHVoiC1jgkVjehkV4wmwmq3d7X5iyuK7n4zJTEIqDzbrfshUnpL9ERe7zlFaocqUVedn1DDU= barna.bakos@unikie.com"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHrmxamlb4JNX+lrN88rfEEskCM0A5MhGSKaA4CZDM8y barna.bakos@unikie.com"
       ];
       extraGroups = ["wheel" "docker"];
     };

--- a/users/karim.nix
+++ b/users/karim.nix
@@ -6,7 +6,7 @@
     karim = {
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
-        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDe5L8iOqhNPsYz5eh9Bz/URYguG60JjMGmKG0wwLIb6Gf2M8Txzk24ESGbMR/F5RYsV1yWYOocL47ngDWQIbO6MGJ7ftUr7slWoUA/FSVwh/jsG681mRqIuJXjKM/YQhBkI9k6+eVxRfLDTs5XZfbwdm7T4aP8ZI2609VY0guXfa/F7DSE1BxN7IJMn0CWLQJanBpoYUxqyQXCUXgljMokdPjTrqAxlBluMsVTP+ZKDnjnpHcVE/hCKk5BxaU6K97OdeIOOEWXAd6uEHssomjtU7+7dhiZzjhzRPKDiSJDF9qtIw50kTHz6ZTdH8SAZmu0hsS6q8OmmDTAnt24dFJV karim@nixos"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOWo1W2XgAYxqntPxdI0k7K/3EgWB6lAaPkEwUwUT2Ey karim@nixos"
       ];
       extraGroups = ["wheel" "networkmanager"];
     };


### PR DESCRIPTION
RSA keys are not secure and we should not allow them in this repo.

> [OpenSSH 9.5](https://www.openssh.com/releasenotes.html) (2023-10-04) includes [ssh-keygen(1)](https://man.openbsd.org/ssh-keygen.1) which now generates Ed25519 keys by default.