### PR TITLE
terraform: allow many persistent instances

### DIFF
--- a/hosts/builder/configuration.nix
+++ b/hosts/builder/configuration.nix
@@ -42,7 +42,7 @@
   # Configure Nix to use this as a substitutor, and the public key used for signing.
   # TODO: remove cache.vedenemo.dev substituter
   nix.settings.trusted-public-keys = [
-    "ghaf-infra-dev:zPj3qUkGtUcnMehhQY89bayLOZBpMClIfFb5KkasLQE="
+    "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="
     "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
   ];
   nix.settings.substituters = [

--- a/hosts/jenkins-controller/configuration.nix
+++ b/hosts/jenkins-controller/configuration.nix
@@ -186,7 +186,7 @@ in {
 
   # Configure Nix to use this as a substitutor, and the public key used for signing.
   nix.settings.trusted-public-keys = [
-    "ghaf-infra-dev:zPj3qUkGtUcnMehhQY89bayLOZBpMClIfFb5KkasLQE="
+    "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="
   ];
   nix.settings.substituters = [
     "http://localhost:8080"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -167,7 +167,7 @@ resource "azurerm_storage_container" "vm_images" {
 
 data "azurerm_storage_account" "binary_cache" {
   name                = "ghafbincache${local.persistent_data}${local.shortloc}"
-  resource_group_name = "ghaf-infra-persistent"
+  resource_group_name = "ghaf-infra-persistent-${local.shortloc}"
 }
 data "azurerm_storage_container" "binary_cache_1" {
   name                 = "binary-cache-v1"
@@ -176,7 +176,7 @@ data "azurerm_storage_container" "binary_cache_1" {
 
 data "azurerm_key_vault" "ssh_remote_build" {
   name                = "ssh-builder-${local.persistent_data}-${local.shortloc}"
-  resource_group_name = "ghaf-infra-persistent"
+  resource_group_name = "ghaf-infra-persistent-${local.shortloc}"
   provider            = azurerm
 }
 
@@ -194,7 +194,7 @@ data "azurerm_key_vault_secret" "ssh_remote_build_pub" {
 
 data "azurerm_key_vault" "binary_cache_signing_key" {
   name                = "bche-sigkey-${local.persistent_data}-${local.shortloc}"
-  resource_group_name = "ghaf-infra-persistent"
+  resource_group_name = "ghaf-infra-persistent-${local.shortloc}"
   provider            = azurerm
 }
 

--- a/terraform/playground/README.md
+++ b/terraform/playground/README.md
@@ -7,9 +7,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 # Terraform Playground
 
 This project uses terraform to automate the creation of infrastructure resources.
-To support infrastructure development in isolated development environments, we use [terraform workspaces](https://developer.hashicorp.com/terraform/cli/workspaces).
+To support infrastructure development in isolated development environments, this project uses [terraform workspaces](https://developer.hashicorp.com/terraform/cli/workspaces).
 
-The tooling under this `playground` directory is provided to facilitate the usage of terraform workspaces in setting-up a distinct copy of the target infrastructure to test a set of changes before modifying shared (dev/prod) infrastructure.
+The tooling under the `playground` directory is provided to facilitate the usage of terraform workspaces in setting-up a distinct copy of the target infrastructure to test a set of changes before modifying shared (dev/prod) infrastructure.
 
 This page documents the usage of `terraform-playground.sh` to help facilitate the usage of private development environments for testing infra changes.
 

--- a/terraform/playground/terraform-playground.sh
+++ b/terraform/playground/terraform-playground.sh
@@ -53,13 +53,13 @@ generate_azure_private_workspace_name () {
     # - .userPrincipalName returns the signed-in azure username
     # - cut removes everything up until the first '@'
     # - sed keeps only letter and number characters
-    # - final cut keeps at most 20 characters
+    # - final cut keeps at most 16 characters
     # - tr converts the string to lower case
     # Thus, given a signed-in user 'foo.bar@baz.com', the workspace name
     # becomes 'foobar'.
     # Below command errors out with the azure error message if the azure user
     # is not signed-in.
-    WORKSPACE=$(az ad signed-in-user show | jq -cr .userPrincipalName | cut -d'@' -f1 | sed 's/[^a-zA-Z0-9]//g' | cut -c 1-20 | tr '[:upper:]' '[:lower:]')
+    WORKSPACE=$(az ad signed-in-user show | jq -cr .userPrincipalName | cut -d'@' -f1 | sed 's/[^a-zA-Z0-9]//g' | cut -c 1-16 | tr '[:upper:]' '[:lower:]')
     # Check WORKSPACE is non-empty and not 'default'
     if [ -z "$WORKSPACE" ] || [ "$WORKSPACE" = "default" ]; then
         echo "Error: invalid workspace name: '$WORKSPACE'"

--- a/terraform/terraform-init.sh
+++ b/terraform/terraform-init.sh
@@ -10,7 +10,7 @@ set -o pipefail # exit if any pipeline command fails
 
 ################################################################################
 
-# This script is a helper to initialize the ghaf-infra:
+# This script is a helper to initialize the ghaf terraform infra:
 # - init terraform state storage
 # - init persistent secrets such as binary cache signing key (per environment)
 # - init persistent binary cache storage (per environment)
@@ -62,6 +62,8 @@ init_persistent () {
     # See: ./persistent
     pushd "$MYDIR/persistent" >/dev/null
     terraform init > /dev/null
+    # Default persistent instance: 'eun' (northeurope)
+    terraform workspace select eun 2>/dev/null || terraform workspace new eun
     import_bincache_sigkey "prod"
     import_bincache_sigkey "dev"
     echo "[+] Applying possible changes"
@@ -71,7 +73,6 @@ init_persistent () {
 
 init_terraform () {
     echo "[+] Running terraform init"
-    # It's safe to run terraform init multiple times
     terraform -chdir="$MYDIR" init >/dev/null
 }
 


### PR DESCRIPTION
Allow many instances of 'persistent' data based on workspaces. This makes it possible to have separate 'persistent' data, for instance, by Azure location. Assumes default location is 'northeurope'.