### PR TITLE
Fix jenkins service startup

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -26,8 +26,13 @@
   # enable cloud-init, so instance metadata is set accordingly and we can use
   # cloud-config for ssh key management.
   services.cloud-init.enable = true;
-  systemd.services.cloud-config.after = ["mnt-resource.mount"];
-  systemd.services.cloud-config.requires = ["mnt-resource.mount"];
+  # FUTUREWORK: below is a hack to make cloud-init usable with azure
+  # agent (waagent). The usage of azure agent together with cloud-init
+  # needs to be properly done later, perhaps by using the
+  # azure-scatch-store-common.nix or something similar.
+  systemd.services.cloud-config.serviceConfig = {
+    Restart = "on-failure";
+  };
 
   # Use systemd-networkd for network configuration.
   services.cloud-init.network.enable = true;

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -74,8 +74,12 @@ in {
     port = 8081;
     withCLI = true;
   };
-  systemd.services.jenkins.after = ["cloud-config.service"];
-  systemd.services.jenkins.requires = ["cloud-config.service"];
+  systemd.services.jenkins.after = ["multi-user.target"];
+  systemd.services.jenkins.requires = ["multi-user.target"];
+  systemd.services.jenkins.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = 1;
+  };
 
   # set StateDirectory=jenkins, so state volume has the right permissions
   # and we wait on the mountpoint to appear.


### PR DESCRIPTION
Fix Jenkins service startup:
- Delay jenkins service startup by making it run after `multi-user.target`.
- Add a comment pointing to future work for improving the cloud-init usage together with azure agent.
- Make both `cloud-config.service` and `jenkins.service` restart on failure.
