### PR TITLE
jenkins-controller: Initial Jenkins configuration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -204,6 +204,9 @@ data "azurerm_key_vault_secret" "binary_cache_signing_key" {
   provider     = azurerm
 }
 
+# Data sources to access 'workspace-specific persistent' data
+# see: ./persistent/workspace-specific
+
 data "azurerm_managed_disk" "binary_cache_caddy_state" {
   name                = "binary-cache-vm-caddy-state-${local.ws}"
   resource_group_name = "ghaf-infra-persistent-${local.shortloc}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,7 @@ variable "location" {
 }
 
 # Use azure_region module to get the short name of the Azure region,
-# see: https://registry.terraform.io/modules/claranet/regions/azurerm/latest 
+# see: https://registry.terraform.io/modules/claranet/regions/azurerm/latest
 module "azure_region" {
   source       = "claranet/regions/azurerm"
   azure_region = var.location
@@ -209,5 +209,9 @@ data "azurerm_managed_disk" "binary_cache_caddy_state" {
   resource_group_name = "ghaf-infra-persistent-${local.shortloc}"
 }
 
+data "azurerm_managed_disk" "jenkins_controller_caddy_state" {
+  name                = "jenkins-controller-vm-caddy-state-${local.ws}"
+  resource_group_name = "ghaf-infra-persistent-${local.shortloc}"
+}
 
 ################################################################################

--- a/terraform/persistent/workspace-specific/main.tf
+++ b/terraform/persistent/workspace-specific/main.tf
@@ -73,4 +73,13 @@ resource "azurerm_managed_disk" "binary_cache_caddy_state" {
   disk_size_gb         = 1
 }
 
+resource "azurerm_managed_disk" "jenkins_controller_caddy_state" {
+  name                 = "jenkins-controller-vm-caddy-state-${local.ws}"
+  resource_group_name  = data.azurerm_resource_group.persistent.name
+  location             = data.azurerm_resource_group.persistent.location
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 1
+}
+
 ################################################################################


### PR DESCRIPTION
- Configure Jenkins: install pipeline and github plugins, allow anonymous read access, disable setup wizard, install packages required by Jenkins pipeline.
- Configure build pipeline job based on the pipeline script now maintained in a separate repo at: https://github.com/tiiuae/ghaf-jenkins-pipeline.
- Deploy caddy reverse proxy, redirecting public HTTPS requests to jenkins service on the jenkins-controller VM. No need to open port 80 as caddy can deploy let's encrypt certificates using tls-alpn-01 (over HTTPS).
- Adds a 'persistent' state disk on jenkins-controller VM to store let's encrypt data for caddy.