### PR TITLE
Make osdisk size configurable

### DIFF
--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-#
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 module "binary_cache_image" {
@@ -22,6 +21,7 @@ module "binary_cache_vm" {
   location                     = azurerm_resource_group.infra.location
   virtual_machine_name         = "ghaf-binary-cache-${local.env}"
   virtual_machine_size         = local.opts[local.conf].vm_size_binarycache
+  virtual_machine_osdisk_size  = "50"
   virtual_machine_source_image = module.binary_cache_image.image_id
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({

--- a/terraform/builder.tf
+++ b/terraform/builder.tf
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-#
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 module "builder_image" {
@@ -28,6 +27,7 @@ module "builder_vm" {
   location                     = azurerm_resource_group.infra.location
   virtual_machine_name         = "ghaf-builder-${count.index}-${local.env}"
   virtual_machine_size         = local.opts[local.conf].vm_size_builder
+  virtual_machine_osdisk_size  = "150"
   virtual_machine_source_image = module.builder_image.image_id
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-#
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the Jenkins controller image
@@ -24,6 +23,7 @@ module "jenkins_controller_vm" {
   location                     = azurerm_resource_group.infra.location
   virtual_machine_name         = "ghaf-jenkins-controller-${local.env}"
   virtual_machine_size         = local.opts[local.conf].vm_size_controller
+  virtual_machine_osdisk_size  = "150"
   virtual_machine_source_image = module.jenkins_controller_image.image_id
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({

--- a/terraform/modules/azurerm-linux-vm/variables.tf
+++ b/terraform/modules/azurerm-linux-vm/variables.tf
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-#
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 variable "resource_group_name" {
@@ -15,6 +14,10 @@ variable "virtual_machine_name" {
 }
 
 variable "virtual_machine_size" {
+  type = string
+}
+
+variable "virtual_machine_osdisk_size" {
   type = string
 }
 

--- a/terraform/modules/azurerm-linux-vm/virtual_machine.tf
+++ b/terraform/modules/azurerm-linux-vm/virtual_machine.tf
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
-#
+# SPDX-FileCopyrightText: 2022-2024 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
 resource "azurerm_virtual_machine" "main" {
@@ -56,7 +55,7 @@ resource "azurerm_virtual_machine" "main" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
-    disk_size_gb      = "100"
+    disk_size_gb      = var.virtual_machine_osdisk_size
   }
 
   dynamic "storage_data_disk" {


### PR DESCRIPTION
Default osdisk sizes:
- jenkins-controller: 150 GB
- builder: 150 GB
- binary-cache: 50 GB