### PR TITLE
Perform better on low memory

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -292,6 +292,25 @@ in {
     };
   };
 
+  # Enable early out-of-memory killing.
+  # Make nix builds more likely to be killed over more important services.
+  services.earlyoom = {
+    enable = true;
+    # earlyoom sends SIGTERM once below 5% and SIGKILL when below half
+    # of freeMemThreshold
+    freeMemThreshold = 5;
+    extraArgs = [
+      "--prefer '^(nix-daemon)$'"
+      "--avoid '^(java|jenkins-.*|sshd|systemd|systemd-.*)$'"
+    ];
+  };
+
+  # Tell the Nix evaluator to garbage collect more aggressively
+  environment.variables.GC_INITIAL_HEAP_SIZE = "1M";
+  # Always overcommit: pretend there is always enough memory
+  # until it actually runs out
+  boot.kernel.sysctl."vm.overcommit_memory" = "1";
+
   # Configure Nix to use this as a substitutor, and the public key used for signing.
   nix.settings.trusted-public-keys = [
     "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,13 +68,13 @@ locals {
   # E.g. 'Standard_D1_v2' means: 1 vCPU, 3.5 GiB RAM
   opts = {
     priv = {
-      vm_size_binarycache = "Standard_D1_v2"
+      vm_size_binarycache = "Standard_D2_v3"
       vm_size_builder     = "Standard_D2_v3"
-      vm_size_controller  = "Standard_D2_v3"
+      vm_size_controller  = "Standard_D4_v3"
       num_builders        = 1
     }
     dev = {
-      vm_size_binarycache = "Standard_D1_v2"
+      vm_size_binarycache = "Standard_D2_v3"
       vm_size_builder     = "Standard_D4_v3"
       vm_size_controller  = "Standard_D4_v3"
       num_builders        = 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,24 +65,24 @@ locals {
   # Environment-specific configuration options.
   # See Azure vm sizes and specs at:
   # https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux
-  # E.g. 'Standard_D1_v2' means: 1 vCPU, 3.5 GiB RAM
+  # E.g. 'Standard_D2_v3' means: 2 vCPU, 8 GiB RAM
   opts = {
     priv = {
       vm_size_binarycache = "Standard_D2_v3"
       vm_size_builder     = "Standard_D2_v3"
-      vm_size_controller  = "Standard_D4_v3"
+      vm_size_controller  = "Standard_E2_v5"
       num_builders        = 1
     }
     dev = {
       vm_size_binarycache = "Standard_D2_v3"
       vm_size_builder     = "Standard_D4_v3"
-      vm_size_controller  = "Standard_D4_v3"
+      vm_size_controller  = "Standard_E4_v5"
       num_builders        = 1
     }
     prod = {
       vm_size_binarycache = "Standard_D2_v3"
       vm_size_builder     = "Standard_D8_v3"
-      vm_size_controller  = "Standard_D8_v3"
+      vm_size_controller  = "Standard_E4_v5"
       num_builders        = 2
     }
   }


### PR DESCRIPTION
- Perform better when low on memory; 'priv' and 'dev' environments should be able to run the [Jenkins pipeline](https://github.com/tiiuae/ghaf-jenkins-pipeline/blob/main/ghaf-build-pipeline.groovy) by default without OOM. Also, if running out-of-memory, try to prioritize keeping the Jenkins service alive.
- Adjust image sizes so 'priv' environments should also be able to run the Jenkins pipeline by default. Currently, it seems the Ghaf target evaluation is not possible with 8GiB RAM, therefore, increasing the 'priv' Jenkins controller VM to 'Standard_E2_v5' (which has 16GiB RAM).
- Increase the binary cache VM size from 'Standard_D1_v2' to 'Standard_D2_v3' since the cost impact is relatively small (versus the cost of time spent when people need to debug possible resource issues).
- Start using memory optimized 'Standard_E' VM sizes for all jenkins-controller configurations, since nix evaluation for Ghaf is memory intensive.