### PR TITLE
Fix caddy startup

### DIFF
--- a/hosts/azure/binary-cache/configuration.nix
+++ b/hosts/azure/binary-cache/configuration.nix
@@ -88,7 +88,7 @@
     ""
     "${pkgs.caddy}/bin/caddy run --environ --config ${config.services.caddy.configFile}/Caddyfile"
   ];
-  systemd.services.caddy.serviceConfig.EnvironmentFile = "/run/caddy.env";
+  systemd.services.caddy.serviceConfig.EnvironmentFile = "/var/lib/caddy/caddy.env";
 
   # Wait for cloud-init mounting before we start caddy.
   systemd.services.caddy.after = ["cloud-init.service"];

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -348,7 +348,7 @@ in {
     ""
     "${pkgs.caddy}/bin/caddy run --environ --config ${config.services.caddy.configFile}/Caddyfile"
   ];
-  systemd.services.caddy.serviceConfig.EnvironmentFile = "/run/caddy.env";
+  systemd.services.caddy.serviceConfig.EnvironmentFile = "/var/lib/caddy/caddy.env";
 
   # Wait for cloud-init mounting before we start caddy.
   systemd.services.caddy.after = ["cloud-init.service"];

--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -40,7 +40,7 @@ module "binary_cache_vm" {
       },
       {
         content = "SITE_ADDRESS=ghaf-binary-cache-${local.env}.northeurope.cloudapp.azure.com",
-        "path"  = "/run/caddy.env"
+        "path"  = "/var/lib/caddy/caddy.env"
       },
     ],
   })])

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -65,7 +65,7 @@ module "jenkins_controller_vm" {
       },
       {
         content = "SITE_ADDRESS=ghaf-jenkins-controller-${local.env}.northeurope.cloudapp.azure.com",
-        "path"  = "/run/caddy.env"
+        "path"  = "/var/lib/caddy/caddy.env"
       }
     ]
   })])


### PR DESCRIPTION
Move caddy environment file from `/run/caddy.env` to `/var/lib/caddy/caddy.env` to make it persist reboots. Before this change, caddy service would fail to start after the first boot due to missing caddy environment file.