### PR TITLE
Add real names for users

### DIFF
--- a/hosts/ficolobuild/build3.nix
+++ b/hosts/ficolobuild/build3.nix
@@ -21,6 +21,7 @@
   # Yubikey signer
   users.users = {
     yubimaster = {
+      description = "Yubikey Signer";
       isNormalUser = true;
       extraGroups = ["docker"];
       openssh.authorizedKeys.keys = [

--- a/hosts/ficolobuild/build4.nix
+++ b/hosts/ficolobuild/build4.nix
@@ -19,6 +19,7 @@
   # Yubikey signer
   users.users = {
     yubimaster = {
+      description = "Yubikey Signer";
       isNormalUser = true;
       extraGroups = ["docker"];
       openssh.authorizedKeys.keys = [

--- a/hosts/ficolobuild/developers.nix
+++ b/hosts/ficolobuild/developers.nix
@@ -6,12 +6,14 @@
   # add new developers here
   developers = [
     {
+      desc = "Barna Bakos";
       name = "barna";
       keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHrmxamlb4JNX+lrN88rfEEskCM0A5MhGSKaA4CZDM8y barna.bakos@unikie.com"
       ];
     }
     {
+      desc = "Brian McGillion";
       name = "bmg";
       keys = [
         "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEJ9ewKwo5FLj6zE30KnTn8+nw7aKdei9SeTwaAeRdJDAAAABHNzaDo="
@@ -20,18 +22,21 @@
       ];
     }
     {
+      desc = "Samuli Leivo";
       name = "leivos";
       keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHRGczoQ78cjHdjEgKTyZeLKu/flWlvf+HepdUezZCDr root@nixos"
       ];
     }
     {
+      desc = "Milla Valio";
       name = "milval";
       keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGll9sWYdGc2xi9oQ25TEcI1D3T4n8MMXoMT+lJdE/KC root@nixos"
       ];
     }
     {
+      desc = "Humaid Alqasimi";
       name = "humaid";
       keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDUlaLlxVlm1KZtoG3R/nHl/KJzmKaIyckDVE2rDJYH+"
@@ -45,12 +50,14 @@ in {
     users = builtins.listToAttrs (
       map (
         {
+          desc,
           name,
           keys,
         }:
           lib.nameValuePair name {
             inherit name;
 
+            description = desc;
             openssh.authorizedKeys.keys = keys;
 
             isNormalUser = true;

--- a/users/barna.nix
+++ b/users/barna.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     barna = {
+      description = "Barna Bakos";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHrmxamlb4JNX+lrN88rfEEskCM0A5MhGSKaA4CZDM8y barna.bakos@unikie.com"

--- a/users/builder.nix
+++ b/users/builder.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     nix = {
+      description = "Nix Builder";
       isNormalUser = true;
       group = "nix";
       home = "/var/lib/nix";

--- a/users/cazfi.nix
+++ b/users/cazfi.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     cazfi = {
+      description = "Marko Lindqvist";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHzAww8Md+anrVfg93jNYey35Lu/YPEdbEh9QRu+riyf cazfi@cazfi-wlt"

--- a/users/hrosten.nix
+++ b/users/hrosten.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     hrosten = {
+      description = "Henri Rosten";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHFuB+uEjhoSdakwiKLD3TbNpbjnlXerEfZQbtRgvdSz"

--- a/users/hydra.nix
+++ b/users/hydra.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     hydra = {
+      description = "Hydra User";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILbycq53k6oz1VvTC8I7wYt1c5t2YGYd41MJUeakte5t hydra@build4"

--- a/users/jrautiola.nix
+++ b/users/jrautiola.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     jrautiola = {
+      description = "Joonas Rautiola";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6EoeiMBiiwfGJfQYyuBKg8rDpswX0qh194DUQqUotL joonas@buutti"

--- a/users/karim.nix
+++ b/users/karim.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     karim = {
+      description = "Karim Mdmirajul";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOWo1W2XgAYxqntPxdI0k7K/3EgWB6lAaPkEwUwUT2Ey karim@nixos"

--- a/users/ktu.nix
+++ b/users/ktu.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     ktu = {
+      description = "Kai Tusa";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBeMFr++WulL/hQKejDnE1ePRQscLp7LvLAy/DyLW4AU ktu@nixos"

--- a/users/mika.nix
+++ b/users/mika.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     mika = {
+      description = "Mika Nokka";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKoroafXsrWkoLewJ7EYcHodqlYILV2T8xtRo6RL99vz mika@nixos"

--- a/users/mkaapu.nix
+++ b/users/mkaapu.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     mkaapu = {
+      description = "Marko Kaapu";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE6WDXGfrD+WfY2+eP+/c4NrEOeCGpEOE2TcTlwxWXho marko.kaapu@unikie.com"

--- a/users/tervis.nix
+++ b/users/tervis.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     tervis = {
+      description = "Tero Tervala";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDJau0tg0qHhqFVarjNOJLi+ekSZNNqxal4iRD/pwM5W tervis@tervis-thinkpad"

--- a/users/tester.nix
+++ b/users/tester.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     tester = {
+      description = "Tester User";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIFbxhIZjGU6JuMBMMyeaYNXSltPCjYzGZ2WSOpegPuQ"

--- a/users/themisto.nix
+++ b/users/themisto.nix
@@ -3,6 +3,7 @@
 {
   users.users = {
     themisto = {
+      description = "Themisto Hydra";
       isNormalUser = true;
       openssh.authorizedKeys.keys = [
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMK29aVdB0Xucg9pFMqkY6fwUKV41enaWw4wP7fUjOvK cazfi@gerrit"


### PR DESCRIPTION
Adding the description field for user accounts, for normal people users in Linux this is usually the full name of the user.
For system accounts this can be a more elaborate description.