### PR TITLE
Resolve test-infra.tf

### DIFF
--- a/terraform/playground/test-infra.tf
+++ b/terraform/playground/test-infra.tf
@@ -110,7 +110,7 @@ module "test_vm" {
   # https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/#pricing
   virtual_machine_size         = terraform.workspace == "default" ? "Standard_D2_v2" : "Standard_D1_v2"
   virtual_machine_source_image = module.test_image.image_id
-
+  virtual_machine_osdisk_size  = "50"
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({
     users = [
       {


### PR DESCRIPTION
When attempting to execute the Terraform configuration in test-infra.tf, an error occurs due to a missing required argument. Specifically, the virtual_machine_osdisk_size argument is not defined within the module "test_vm", 