### PR TITLE
Replace builder to az-builder

### DIFF
--- a/terraform/playground/test-infra.tf
+++ b/terraform/playground/test-infra.tf
@@ -75,7 +75,7 @@ resource "azurerm_storage_container" "vm_images" {
 module "test_image" {
   source = "../modules/azurerm-nix-vm-image"
 
-  nix_attrpath   = "outputs.nixosConfigurations.builder.config.system.build.azureImage"
+  nix_attrpath   = "outputs.nixosConfigurations.az-builder.config.system.build.azureImage"
   nix_entrypoint = "${path.module}/../.."
 
   name                = "playground_vm_img"


### PR DESCRIPTION
After recent changes, the nixosConfiguration name 'builder' has been replaced with 'az-builder'.