### PR TITLE
nix-build.sh: correct copyright header

### DIFF
--- a/terraform/modules/azurerm-nix-vm-image/nix-build.sh
+++ b/terraform/modules/azurerm-nix-vm-image/nix-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-FileCopyrightText: 2023 The TVL Authors
+#
 # SPDX-License-Identifier: MIT
 
 #


### PR DESCRIPTION
This file was initially vendored from the TVL repo.

abe836b4f223ea3f3b89ce106c0d258074680589 accidentially updated the copyright header with the default TII header, but the actual copyright header needs to be preserved.