### PR TITLE
Jenkins controller: Increase jenkins home disk size

### DIFF
--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -128,7 +128,7 @@ resource "azurerm_managed_disk" "jenkins_controller_jenkins_state" {
   location             = azurerm_resource_group.infra.location
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
-  disk_size_gb         = 10
+  disk_size_gb         = 1000
 }
 
 # Grant the VM read-only access to the Azure Key Vault Secret containing the


### PR DESCRIPTION
This is workaround to allow more build records to be stored on Jenkins home directory.

My suggestion to continuation work:

Separate store for Jenkins workspace
- for proper CI control / build isolation, Jenkins master node should have 0 executors and all working directories should reside in agent machines.

Separate jobs configuration, build records and artifacts from Jenkins home
- one solution: symbolic links to another store
- build artifacts may needs some more persistent store separate from other build records