### PR TITLE
Ubuntu arm-builder: Configurable trusted-public-keys

### DIFF
--- a/terraform/arm-builder.tf
+++ b/terraform/arm-builder.tf
@@ -46,6 +46,7 @@ module "arm_builder_vm" {
   virtual_machine_name        = "ghaf-builder-aarch64-${count.index}-${local.ws}"
   virtual_machine_size        = local.opts[local.conf].vm_size_builder_aarch64
   virtual_machine_osdisk_size = local.opts[local.conf].osdisk_size_builder
+  binary_cache_public_key     = local.opts[local.conf].binary_cache_public_key
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({
     users = [{

--- a/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
+++ b/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
@@ -8,8 +8,8 @@ set -x # debug
 ################################################################################
 
 # Assume root if HOME and USER are unset
-[ -z "${HOME}" ] && export HOME="/root"
-[ -z "${USER}" ] && export USER="root"
+[ -z "$HOME" ] && export HOME="/root"
+[ -z "$USER" ] && export USER="root"
 
 ################################################################################
 
@@ -52,12 +52,12 @@ configure_builder() {
 # 20 GB (20*1024*1024*1024)
 min-free = 21474836480
 # 500 GB (500*1024*1024*1024)
-# osdisk size for prod builders 
+# osdisk size for prod builders
 max-free = 536870912000
 system-features = nixos-test benchmark big-parallel kvm
 trusted-users = remote-build
-substituters = http://localhost:8080 https://cache.vedenemo.dev https://cache.nixos.org
-trusted-public-keys = ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I= cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+substituters = ${bincache_url} https://cache.vedenemo.dev https://cache.nixos.org
+trusted-public-keys = ${bincache_pubkey} cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
     sudo sh -c "printf '$extra_nix_conf\n' >> /etc/nix/nix.conf"
 }
 

--- a/terraform/modules/arm-builder-vm/variables.tf
+++ b/terraform/modules/arm-builder-vm/variables.tf
@@ -45,3 +45,12 @@ variable "data_disks" {
   description = "List of dict containing keys of the storage_data_disk block"
   default     = []
 }
+
+variable "binary_cache_public_key" {
+  type = string
+}
+
+variable "binary_cache_url" {
+  type    = string
+  default = "http://localhost:8080"
+}

--- a/terraform/modules/arm-builder-vm/virtual_machine.tf
+++ b/terraform/modules/arm-builder-vm/virtual_machine.tf
@@ -131,7 +131,7 @@ resource "azurerm_virtual_machine_extension" "deploy_ubuntu_builder" {
   type_handler_version = "2.1"
   settings             = <<EOF
     {
-        "script": "${base64encode(file("./modules/arm-builder-vm/ubuntu-builder.sh"))}"
+        "script": "${base64encode(templatefile("./modules/arm-builder-vm/ubuntu-builder.sh.tpl", { bincache_url = "${var.binary_cache_url}", bincache_pubkey = "${var.binary_cache_public_key}" }))}"
     }
     EOF
 }


### PR DESCRIPTION
Configure the trusted-public-keys in Ubuntu ARM builders based on the `binary_cache_public_key` configuration option in terraform the root module. Also, support setting the `binary_cache_url` on the Ubuntu ARM builders similarly.

For reference: this PR implements the change outlined in an earlier PR at: https://github.com/tiiuae/ghaf-infra/pull/106#issuecomment-2014565749