### PR TITLE
Refactor rclone-http into a module

### DIFF
--- a/hosts/azure/builder/configuration.nix
+++ b/hosts/azure/builder/configuration.nix
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
-  pkgs,
   lib,
   ...
 }: {
@@ -10,32 +9,15 @@
     ../../azure-common.nix
     self.nixosModules.service-openssh
     self.nixosModules.service-remote-build
+    self.nixosModules.service-rclone-http
   ];
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 
-  # Run a read-only HTTP webserver proxying to the "binary-cache-v1" storage
-  # container via http://localhost:8080.
-  # This relies on IAM to grant access to the storage container.
-  systemd.services.rclone-http = {
-    after = ["network.target"];
-    requires = ["network.target"];
-    wantedBy = ["multi-user.target"];
-    serviceConfig = {
-      Type = "notify";
-      Restart = "always";
-      RestartSec = 2;
-      DynamicUser = true;
-      RuntimeDirectory = "rclone-http";
-      ExecStart =
-        "${pkgs.rclone}/bin/rclone "
-        + "serve http "
-        + "--azureblob-env-auth "
-        + "--read-only "
-        + "--addr localhost:8080 "
-        + ":azureblob:binary-cache-v1";
-      EnvironmentFile = "/var/lib/rclone-http/env";
-    };
+  services.rclone-http = {
+    enable = true;
+    readOnly = true;
+    remote = ":azureblob:binary-cache-v1";
   };
 
   # Configure Nix to use this as a substitutor, and the public key used for signing.

--- a/services/default.nix
+++ b/services/default.nix
@@ -8,5 +8,6 @@
     service-node-exporter = import ./node-exporter;
     service-openssh = import ./openssh;
     service-remote-build = import ./remote-build;
+    service-rclone-http = import ./rclone-http;
   };
 }

--- a/services/rclone-http/default.nix
+++ b/services/rclone-http/default.nix
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+with lib; let
+  cfg = config.services.rclone-http;
+in {
+  options.services.rclone-http = {
+    enable = mkEnableOption "rclone-http service";
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "localhost:8080";
+      description = "IPaddress:Port, :Port or unix:///path/to/socket to bind server to";
+    };
+
+    readOnly = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Only allow read-only access";
+    };
+
+    protocol = mkOption {
+      type = types.enum ["http" "webdav"];
+      default = "http";
+      description = "The protocol to serve the remote over";
+    };
+
+    remote = mkOption {
+      type = types.str;
+      description = "The remote to serve";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Run a read-only HTTP webserver proxying to an rclone remote at the configured address
+    # This relies on IAM to grant access to the storage container.
+    systemd.services.rclone-http = {
+      after = ["network.target"];
+      requires = ["network.target"];
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "notify";
+        Restart = "always";
+        RestartSec = 2;
+        DynamicUser = true;
+        RuntimeDirectory = "rclone-http";
+        EnvironmentFile = "/var/lib/rclone-http/env";
+
+        ExecStart =
+          "${pkgs.rclone}/bin/rclone "
+          + "serve ${cfg.protocol} "
+          + "--azureblob-env-auth "
+          + "${optionalString cfg.readOnly "--read-only "}"
+          + "--addr ${cfg.listenAddress} "
+          + "${cfg.remote}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Replaced copypasted rclone-http services with a reusable module, with configurable options. The caddyfile workaround is also removed as the fix has been merged into nixpkgs and backported to our version.