### PR TITLE
hosts/*: remove lib.flatten usage

### DIFF
--- a/hosts/binarycache/configuration.nix
+++ b/hosts/binarycache/configuration.nix
@@ -11,12 +11,13 @@
   sops.defaultSopsFile = ./secrets.yaml;
   sops.secrets.cache-sig-key.owner = "root";
 
-  imports = lib.flatten [
-    (with inputs; [
-      sops-nix.nixosModules.sops
-      disko.nixosModules.disko
-    ])
-    (with self.nixosModules; [
+  imports =
+    [
+      ./disk-config.nix
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
       common
       qemu-common
       ficolo-common
@@ -31,9 +32,7 @@
       user-hrosten
       user-mkaapu
       user-avnik
-    ])
-    ./disk-config.nix
-  ];
+    ]);
 
   nix.settings = {
     # we don't want the cache to be a substitutor for itself

--- a/hosts/ficolobuild/build3.nix
+++ b/hosts/ficolobuild/build3.nix
@@ -1,19 +1,16 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{
-  self,
-  lib,
-  ...
-}: {
-  imports = lib.flatten [
-    (with self.nixosModules; [
+{self, ...}: {
+  imports =
+    [
+      ./builder.nix
+      ./developers.nix
+    ]
+    ++ (with self.nixosModules; [
       user-themisto
       user-ktu
       user-avnik
-    ])
-    ./builder.nix
-    ./developers.nix
-  ];
+    ]);
 
   # build3 specific configuration
 

--- a/hosts/ficolobuild/build4.nix
+++ b/hosts/ficolobuild/build4.nix
@@ -1,16 +1,13 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{
-  self,
-  lib,
-  ...
-}: {
-  imports = lib.flatten [
-    (with self.nixosModules; [
+{self, ...}: {
+  imports =
+    [
+      ./builder.nix
+    ]
+    ++ (with self.nixosModules; [
       user-themisto
-    ])
-    ./builder.nix
-  ];
+    ]);
 
   # build4 specific configuration
 

--- a/hosts/ficolobuild/builder.nix
+++ b/hosts/ficolobuild/builder.nix
@@ -9,10 +9,13 @@
   modulesPath,
   ...
 }: {
-  imports = lib.flatten [
-    (modulesPath + "/installer/scan/not-detected.nix")
-    inputs.disko.nixosModules.disko
-    (with self.nixosModules; [
+  imports =
+    [
+      ./disk-config.nix
+      (modulesPath + "/installer/scan/not-detected.nix")
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
       common
       ficolo-common
       service-openssh
@@ -24,9 +27,7 @@
       user-tervis
       user-karim
       user-mika
-    ])
-    ./disk-config.nix
-  ];
+    ]);
 
   # Hardwre Configuration:
 

--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -16,12 +16,13 @@ in {
   sops.defaultSopsFile = ./secrets.yaml;
   sops.secrets.sshified_private_key.owner = "sshified";
 
-  imports = lib.flatten [
-    (with inputs; [
-      sops-nix.nixosModules.sops
-      disko.nixosModules.disko
-    ])
-    (with self.nixosModules; [
+  imports =
+    [
+      ./disk-config.nix
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
       common
       qemu-common
       ficolo-common
@@ -30,9 +31,7 @@ in {
       service-node-exporter
       user-jrautiola
       user-tervis
-    ])
-    ./disk-config.nix
-  ];
+    ]);
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 

--- a/hosts/prbuilder/configuration.nix
+++ b/hosts/prbuilder/configuration.nix
@@ -8,12 +8,13 @@
   pkgs,
   ...
 }: {
-  imports = lib.flatten [
-    (with inputs; [
-      nix-serve-ng.nixosModules.default
-      disko.nixosModules.disko
-    ])
-    (with self.nixosModules; [
+  imports =
+    [
+      ./disk-config.nix
+      inputs.nix-serve-ng.nixosModules.default
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
       common
       qemu-common
       ficolo-common
@@ -26,9 +27,7 @@
       user-tervis
       user-barna
       user-mika
-    ])
-    ./disk-config.nix
-  ];
+    ]);
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   # List packages installed in system profile
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
We can simply concatenate lists with the `++` operator, no need to call lib.flatten on a list of lists to archieve the same thing.

Also, remove the surrounding with statement in case it's only used once or twice, and sort file imports before others.