### PR TITLE
Azure builders: Drop vedenemo cache

### DIFF
--- a/hosts/azure/builder/configuration.nix
+++ b/hosts/azure/builder/configuration.nix
@@ -20,16 +20,10 @@
     remote = ":azureblob:binary-cache-v1";
   };
 
-  # Configure Nix to use this as a substitutor, and the public key used for signing.
-  # TODO: remove cache.vedenemo.dev substituter
-  nix.settings.trusted-public-keys = [
-    "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
-  ];
   nix.settings.substituters = [
     # Configure Nix to use the bucket (through rclone-http) as a substitutor.
     # The public key is passed in externally.
     "http://localhost:8080"
-    "https://cache.vedenemo.dev"
   ];
 
   system.stateVersion = "23.05";

--- a/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
+++ b/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
@@ -56,8 +56,8 @@ min-free = 21474836480
 max-free = 536870912000
 system-features = nixos-test benchmark big-parallel kvm
 trusted-users = remote-build
-substituters = ${bincache_url} https://cache.vedenemo.dev https://cache.nixos.org
-trusted-public-keys = ${bincache_pubkey} cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+substituters = ${bincache_url} https://cache.nixos.org
+trusted-public-keys = ${bincache_pubkey} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
     sudo sh -c "printf '$extra_nix_conf\n' >> /etc/nix/nix.conf"
 }
 


### PR DESCRIPTION
Stop using cache.vedenemo.dev cache in ghaf-infra azure builders. Apparently, despite configuring 'builders-use-substitutes', the Azure builders do not properly use the cache.vedenemo.dev substitute (see more details in Jira item [SP-3983](https://ssrc.atlassian.net/browse/SP-3983)). Moreover, we have to stop relying on cache.vedenemo.dev, as the azure ghaf-infra itself is soon supposed to replace (or feed into) the vedenemo cache.