### PR TITLE
Nixos configuration build4 for the pandia.vedenemo.dev

### DIFF
--- a/hosts/ficolobuild/build4/configuration.nix
+++ b/hosts/ficolobuild/build4/configuration.nix
@@ -7,6 +7,7 @@
     ]
     ++ (with self.nixosModules; [
       user-themisto
+      service-nginx
     ]);
 
   # build4 specific configuration
@@ -28,5 +29,23 @@
   # Trust Themisto Hydra user
   nix.settings = {
     trusted-users = ["root" "themisto"];
+  };
+
+  security.acme = {
+    acceptTerms = true;
+    defaults.email = "trash@unikie.com";
+  };
+
+  services.nginx = {
+    virtualHosts = {
+      "pandia.vedenemo.dev" = {
+        enableACME = true;
+        forceSSL = true;
+        default = true;
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:3015";
+        };
+      };
+    };
   };
 }


### PR DESCRIPTION
-ACME: config protocol is used for automated domain-validated SSL certificates. The configuration is updated to accept the terms of Let's Encrypt, automated, and open Certificate Authority that uses the ACME protocol. The default email`trash@unikie.com`.
-Nginx config: includes enabling ACME for SSL certificate management, forcing SSL for secure connections, and setting this as the default server block!
-root location (`/`) for this server is configured to proxy pass to `http:127.0.0.1:3015`