### PR TITLE
Fix Jenkinsfile script path

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -142,7 +142,6 @@ in {
                   };
                 }
               ];
-              script-path = "ghaf-build-pipeline.groovy";
               lightweight-checkout = true;
             };
           };


### PR DESCRIPTION
Using Jenkinsfile as script path as it is conventional and allows easy switching to a multibranch project if ever needed.