### PR TITLE
Add robot framework packages to test agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,6 +85,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-serve-ng": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -155,6 +173,27 @@
         "type": "github"
       }
     },
+    "robot-framework": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713945007,
+        "narHash": "sha256-lUcEz/IG2TvuAJXMay9UGUdp/d3kj+HohaX5x+Smtbo=",
+        "owner": "tiiuae",
+        "repo": "ci-test-automation",
+        "rev": "61a65ef3c8c05dbc8d9fb69bb6bd755049d50f7b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "ci-test-automation",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "disko": "disko",
@@ -163,6 +202,7 @@
         "flake-root": "flake-root",
         "nix-serve-ng": "nix-serve-ng",
         "nixpkgs": "nixpkgs_2",
+        "robot-framework": "robot-framework",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix"
       }
@@ -191,6 +231,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       url = "github:nix-community/flake-compat";
       flake = false;
     };
+    robot-framework = {
+      url = "github:tiiuae/ci-test-automation";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {

--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -32,15 +32,23 @@ in {
     ]);
 
   # Bootloader.
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
 
-  networking.hostName = "testagent";
-  networking.useNetworkd = true;
+  networking = {
+    hostName = "testagent";
+    useNetworkd = true;
+  };
 
   # Enable Acroname USB Smart switch support.
   services.udev.packages = [brainstem];
-  environment.systemPackages = [brainstem];
+
+  environment.systemPackages = [
+    inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+    brainstem
+  ];
 
   # Disable suspend and hibernate - systemd settings
   services.logind.extraConfig = ''
@@ -56,10 +64,12 @@ in {
 
   # Disable the GNOME3/GDM auto-suspend feature that cannot be disabled in GUI!
   # If no user is logged in, the machine will power down after 20 minutes.
-  systemd.targets.sleep.enable = false;
-  systemd.targets.suspend.enable = false;
-  systemd.targets.hibernate.enable = false;
-  systemd.targets.hybrid-sleep.enable = false;
+  systemd.targets = {
+    sleep.enable = false;
+    suspend.enable = false;
+    hibernate.enable = false;
+    hybrid-sleep.enable = false;
+  };
 
   # The Jenkins slave service is very barebones
   # it only installs java and sets up jenkins user


### PR DESCRIPTION
[ci-test-automation](https://github.com/tiiuae/ci-test-automation) is added as a flake input as it exposes `ghaf-robot` package for use. The package is then installed onto test agent. This allows robot framework tests to be run. Also merged some repeated options.