### PR TITLE
az-{jenkins-controller,binary-cache}: re-enable HTTP port

### DIFF
--- a/hosts/azure/binary-cache/configuration.nix
+++ b/hosts/azure/binary-cache/configuration.nix
@@ -81,8 +81,10 @@
   systemd.services.caddy.after = ["cloud-init.service"];
   systemd.services.caddy.requires = ["cloud-init.service"];
 
-  # Expose the HTTPS port. No need for HTTP, as caddy can use TLS-ALPN-01.
-  networking.firewall.allowedTCPPorts = [443];
+  # Expose the HTTP[S] port. We still need HTTP for the HTTP-01 challenge.
+  # While TLS-ALPN-01 could be used, disabling HTTP-01 seems only possible from
+  # the JSON config, which won't work alongside Caddyfile.
+  networking.firewall.allowedTCPPorts = [80 443];
 
   system.stateVersion = "23.05";
 }

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -335,8 +335,10 @@ in {
   systemd.services.caddy.after = ["cloud-init.service"];
   systemd.services.caddy.requires = ["cloud-init.service"];
 
-  # Expose the HTTPS port. No need for HTTP, as caddy can use TLS-ALPN-01.
-  networking.firewall.allowedTCPPorts = [443];
+  # Expose the HTTP[S] port. We still need HTTP for the HTTP-01 challenge.
+  # While TLS-ALPN-01 could be used, disabling HTTP-01 seems only possible from
+  # the JSON config, which won't work alongside Caddyfile.
+  networking.firewall.allowedTCPPorts = [80 443];
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 

--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -88,7 +88,7 @@ resource "azurerm_network_security_group" "binary_cache_vm" {
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_ranges    = [22, 443]
+    destination_port_ranges    = [22, 80, 443]
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -120,7 +120,7 @@ resource "azurerm_network_security_group" "jenkins_controller_vm" {
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_ranges    = [22, 443]
+    destination_port_ranges    = [22, 80, 443]
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }


### PR DESCRIPTION
This needs to be reachable for the HTTP-01 challenge to work.

WIthout it, a fresh deployment is unable to get a new certificate (as it tries HTTP-01, times out and backs off).

Configuring caddy to use TLS-ALPN-01 only is too annoying to do - we cannot use the Caddyfile config, but would need to fall back to the internal JSON config format.

We don't expose any vhost via http only, this only serves HTTP challenges.