### PR TITLE
test-deployment.sh: Add a test for aarch64 builds

### DIFF
--- a/terraform/test-deployment.sh
+++ b/terraform/test-deployment.sh
@@ -90,7 +90,7 @@ argparse () {
 }
 
 exit_unless_command_exists () {
-    if ! command -v "$1" &>"$OUT"; then
+    if ! command -v "$1" &>/dev/null; then
         print_err "command '$1' is not installed (Hint: are you inside a nix-shell?)"
         exit 1
     fi
@@ -263,9 +263,6 @@ main () {
     argparse "$@"
     if [ "$DEBUG" = "true" ]; then
         set -x
-        OUT=/dev/stderr
-    else
-        OUT=/dev/null
     fi
     exit_unless_command_exists nix
     exit_unless_command_exists ssh

--- a/terraform/test-deployment.sh
+++ b/terraform/test-deployment.sh
@@ -192,7 +192,7 @@ test_build_end_to_end () {
         exit 1
     fi
     # Find the binary cache public key based on the keyname from main.tf
-    pubkey=$(grep -oP "$keyname:[^\"]+" "$MYDIR/main.tf" | head -n1 )
+    pubkey=$(sed -n -E "s|.*\"($keyname:[^\"]+)\".*|\1|p" "$MYDIR/main.tf" | head -n1 )
     if [ -z "$pubkey" ]; then
         print_err "failed reading nix binary cache public key for '$keyname'"
         exit 1


### PR DESCRIPTION
- Adds support for testing end-to-end build with different architectures. Adds a testcase to check the end-to-end build works on aarch64.
- Make the script output more informative.
- Remove the OUT variable, which was mostly a leftover from an earlier (local) version of the script.