### PR TITLE
az-common: Stop automatic daily gc

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -21,14 +21,11 @@ in {
       # When free disk space in /nix/store drops below min-free during build,
       # perform a garbage-collection until max-free bytes are available or there
       # is no more garbage.
-      min-free = asGB 10;
-      max-free = asGB 50;
+      min-free = asGB 20;
+      max-free = asGB 200;
       # check the free disk space every 5 seconds
       min-free-check-interval = 5;
     };
-    # Garbage collection
-    gc.automatic = true;
-    gc.options = pkgs.lib.mkDefault "--delete-older-than 7d";
   };
   systemd.services.nix-gc.serviceConfig = {
     Restart = "on-failure";


### PR DESCRIPTION
Stop automatic garbage collector on Azure hosts. Before this change, gc automatically ran daily at [03:15](https://search.nixos.org/options?channel=unstable&show=nix.gc.dates&from=0&size=50&sort=relevance&type=packages&query=nix.gc).
We don't want to run it automatically, but only when `/nix/store` storage drops below certain threshold. For that, we already have `nix.settings.min-free` and `nix.settings.max-free`, the values of which are also adjusted in this PR.

Before this change, the nigthly gc would effectively clean the `/nix/store` unnecessarily removing earlier local build results. Thus, the configuration before this change triggered unnecessary downloads from the Azure blob storage when the nix store was re-populated on the first build after the daily cleanup. The [`--delete-older-than 7d`](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage#opt-delete-older-than) only applied to profiles, not to nix store objects in general.

We probably should do similar change on the 'ficolo' hosts too [here](https://github.com/tiiuae/ghaf-infra/blob/f7aad849d272eeb51e69638ccdbc7d4bbcbdfb20/hosts/common.nix#L56-L58), but since it's currently used in production, I'd prefer making this change in the Azure environment first and see how it works there.
