### PR TITLE
Fix rclone service not starting on azure arm

### DIFF
--- a/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
+++ b/terraform/modules/arm-builder-vm/ubuntu-builder.sh.tpl
@@ -71,6 +71,9 @@ configure_rclone() {
 After=network.target
 Requires=network.target
 
+[Install]
+WantedBy=multi-user.target
+
 [Service]
 DynamicUser=true
 EnvironmentFile=/var/lib/rclone-http/env


### PR DESCRIPTION
Adds `WantedBy` section to the systemd service created by the ubuntu script. It now starts properly when the vm is restarted.