### PR TITLE
Add aarch64 emulation for builders using binfmt

### DIFF
--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -12,6 +12,7 @@
   imports =
     [
       ../ficolo.nix
+      ../cross-compilation.nix
       ../developers.nix
       ../yubikey.nix
       inputs.sops-nix.nixosModules.sops
@@ -43,8 +44,6 @@
 
   nix = {
     settings = {
-      # add ability to build 32 bit
-      extra-platforms = ["i686-linux"];
       trusted-users = ["@wheel" "build3"];
     };
 

--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -43,11 +43,9 @@
 
   nix = {
     settings = {
-      # avoid copying stuff over ssh
-      builders-use-substitutes = true;
       # add ability to build 32 bit
       extra-platforms = ["i686-linux"];
-      trusted-users = ["root" "themisto" "@wheel" "build3"];
+      trusted-users = ["@wheel" "build3"];
     };
 
     distributedBuilds = true;

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -18,7 +18,6 @@
   nix.settings = {
     # add ability to build 32 bit
     extra-platforms = ["i686-linux"];
-    trusted-users = ["root" "themisto"];
   };
 
   users.users.yubimaster.openssh.authorizedKeys.keys = [

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -4,6 +4,7 @@
   imports =
     [
       ../ficolo.nix
+      ../cross-compilation.nix
       ../yubikey.nix
     ]
     ++ (with self.nixosModules; [
@@ -14,11 +15,6 @@
   # build4 specific configuration
 
   networking.hostName = "build4";
-
-  nix.settings = {
-    # add ability to build 32 bit
-    extra-platforms = ["i686-linux"];
-  };
 
   users.users.yubimaster.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA2BcpFzSXOuK9AzN+J1HBVnuVV8D3wgdEwPuILNy2aM signer"

--- a/hosts/builders/cross-compilation.nix
+++ b/hosts/builders/cross-compilation.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  # list of systems to emulate using binfmt
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
+  # extra nix build platforms to enable
+  nix.settings.extra-platforms = ["i686-linux"];
+}

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -56,5 +56,5 @@
     };
   };
 
-  nix.settings.trusted-users = ["root" "themisto" "@wheel"];
+  nix.settings.trusted-users = ["themisto" "@wheel"];
 }

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -20,6 +20,9 @@ in {
     nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}") config.nix.registry;
 
     settings = {
+      # root is trusted by default, but only when other users aren't specified.
+      # this line is here to merge the arrays when additional users are added
+      trusted-users = ["root"];
       # Enable flakes and new 'nix' command
       experimental-features = "nix-command flakes";
       # Subsituters

--- a/users/themisto.nix
+++ b/users/themisto.nix
@@ -10,4 +10,6 @@
       ];
     };
   };
+
+  nix.settings.trusted-users = ["themisto"];
 }


### PR DESCRIPTION
- This makes it possible to build `#packages.aarch64-linux.nxp-imx8mp-evk-debug` on x86
- Also simplified trusted users configuration.