### PR TITLE
jenkins: migrate to configuration-as-code, enable html markup

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -219,7 +219,7 @@ in {
       # Install plugins
       jenkins-cli ${jenkins-auth} install-plugin \
         "workflow-aggregator" "github" "timestamper" "pipeline-stage-view" "blueocean" \
-        "pipeline-graph-view" "github-pullrequest" "configuration-as-code"
+        "pipeline-graph-view" "github-pullrequest" "antisamy-markup-formatter" "configuration-as-code"
 
       # Disable initial install
       jenkins-cli ${jenkins-auth} groovy = < ${jenkins-groovy}

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -14,6 +14,9 @@ jenkins:
   disableRememberMe: false
   labelAtoms:
   - name: "built-in"
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: false
   mode: NORMAL
   myViewsTabBar: "standard"
   nodeMonitors:

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -1,0 +1,123 @@
+# TODO: sort out jenkins authentication e.g.:
+# https://plugins.jenkins.io/github-oauth/
+# Below config requires admin to trigger builds or manage jenkins
+# allowing read access for anonymous users:
+
+jenkins:
+  agentProtocols:
+  - "JNLP4-connect"
+  - "Ping"
+  authorizationStrategy: "loggedInUsersCanDoAnything"
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+  disableRememberMe: false
+  labelAtoms:
+  - name: "built-in"
+  mode: NORMAL
+  myViewsTabBar: "standard"
+  nodeMonitors:
+  - diskSpaceMonitor:
+      freeSpaceThreshold: "1GB"
+  - tmpSpace:
+      freeSpaceThreshold: "1GB"
+  numExecutors: 2
+  primaryView:
+    all:
+      name: "all"
+  projectNamingStrategy: "standard"
+  quietPeriod: 5
+  remotingSecurity:
+    enabled: true
+  scmCheckoutRetryCount: 0
+  securityRealm:
+    local:
+      allowsSignup: false
+      enableCaptcha: false
+      users:
+      - id: "admin"
+        name: "admin"
+        properties:
+        - "apiToken"
+        - "myView"
+        - "timezone"
+        - "experimentalFlags"
+        - "mailer"
+        - "favorite"
+        - preferredProvider:
+            providerId: "default"
+  slaveAgentPort: -1
+  updateCenter:
+    sites:
+    - id: "default"
+      url: "https://updates.jenkins.io/update-center.json"
+  views:
+  - all:
+      name: "all"
+  viewsTabBar: "standard"
+globalCredentialsConfiguration:
+  configuration:
+    providerFilter: "none"
+    typeFilter: "none"
+appearance:
+  pipelineGraphView:
+    showGraphOnBuildPage: false
+    showGraphOnJobPage: false
+  prism:
+    theme: PRISM
+security:
+  apiToken:
+    creationOfLegacyTokenEnabled: false
+    tokenGenerationOnCreationEnabled: false
+    usageStatisticsEnabled: true
+  gitHooks:
+    allowedOnAgents: false
+    allowedOnController: false
+  gitHostKeyVerificationConfiguration:
+    sshHostKeyVerificationStrategy: "knownHostsFileVerificationStrategy"
+unclassified:
+  bitbucketEndpointConfiguration:
+    endpoints:
+    - bitbucketCloudEndpoint:
+        enableCache: false
+        manageHooks: false
+        repositoriesCacheDuration: 0
+        teamCacheDuration: 0
+  buildDiscarders:
+    configuredBuildDiscarders:
+    - "jobBuildDiscarder"
+  fingerprints:
+    fingerprintCleanupDisabled: false
+    storage: "file"
+  gitHubConfiguration:
+    apiRateLimitChecker: ThrottleForNormalize
+  junitTestResultStorage:
+    storage: "file"
+  location:
+    adminAddress: "address not configured yet <nobody@nowhere>"
+  mailer:
+    charset: "UTF-8"
+    useSsl: false
+    useTls: false
+  pollSCM:
+    pollingThreadCount: 10
+  scmGit:
+    addGitTagAction: false
+    allowSecondFetch: false
+    createAccountBasedOnEmail: false
+    disableGitToolChooser: false
+    hideCredentials: false
+    showEntireCommitSummaryInChanges: false
+    useExistingAccountWithSameEmail: false
+  timestamper:
+    allPipelines: false
+    elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"
+    systemTimeFormat: "'<b>'HH:mm:ss'</b> '"
+tool:
+  git:
+    installations:
+    - home: "git"
+      name: "Default"
+  mavenGlobalConfig:
+    globalSettingsProvider: "standard"
+    settingsProvider: "standard"


### PR DESCRIPTION
    The configuration-as-code plugin is the recommended way to configure
    Jenkins, not the Groovy script. Most plugin settings seem to be
    available through that.
    
    The yaml was produced by checking in the dump created by the plugin.

---

    azure/jenkins-controller: enable safe-html
    
    This allows configuring HTML descriptions for build descriptions, which
    we'll use to link to artifacts in the future.