### PR TITLE
jenkins: preparations to upload and serve artifacts

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -327,6 +327,8 @@ in {
         "${rclone}/bin/rclone"
         "serve"
         "webdav"
+        "--dir-cache-time"
+        "5s"
         "--azureblob-env-auth"
         "--disable-dir-list"
         ":azureblob:jenkins-artifacts-v1"
@@ -359,6 +361,8 @@ in {
         "serve"
         "http"
         "--read-only"
+        "--dir-cache-time"
+        "5s"
         "--azureblob-env-auth"
         ":azureblob:jenkins-artifacts-v1"
       ];

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -88,15 +88,19 @@ in {
     listenAddress = "localhost";
     port = 8081;
     withCLI = true;
-    packages = with pkgs; [
-      bashInteractive # 'sh' step in jenkins pipeline requires this
-      coreutils
-      nix
-      git
-      zstd
-      jq
-      csvkit
-    ];
+    packages = with pkgs;
+      [
+        bashInteractive # 'sh' step in jenkins pipeline requires this
+        coreutils
+        nix
+        git
+        zstd
+        jq
+        csvkit
+      ]
+      ++ [
+        rclone # used to copy artifacts
+      ];
     extraJavaOptions = [
       # Useful when the 'sh' step fails:
       "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"

--- a/pkgs/rclone/default.nix
+++ b/pkgs/rclone/default.nix
@@ -36,6 +36,9 @@ buildGoModule rec {
   patches = [
     # https://github.com/rclone/rclone/pull/7801
     ./http-socket-activation.patch
+
+    # https://github.com/rclone/rclone/pull/7865
+    ./webdav-introduce-unix_socket_path.patch
   ];
 
   vendorHash = "sha256-zGBwgIuabLDqWbutvPHDbPRo5Dd9kNfmgToZXy7KVgI=";

--- a/pkgs/rclone/webdav-introduce-unix_socket_path.patch
+++ b/pkgs/rclone/webdav-introduce-unix_socket_path.patch
@@ -1,0 +1,139 @@
+From 5e34ec7912a629e1d6561a6cc60c1663be4f4423 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Fri, 24 May 2024 11:45:10 +0200
+Subject: [PATCH] webdav: introduce unix_socket_path
+
+This adds a new optional parameter to the backend, allowing to specify a
+path to a unix domain socket to connect to, instead the specified URL.
+
+If the parameter is set, we use `fshttp.NewClientCustom` to modify the
+HTTP transport, to use a dialer connecting to the unix domain socket
+path specified for that backend.
+
+The URL itself is still used for the rest of the HTTP client, allowing
+host and subpath to stay intact.
+
+This allows using rclone with the webdav backend to connect to a WebDAV
+server provided at a Unix Domain socket:
+
+```
+RCLONE_WEBDAV_UNIX_SOCKET_PATH=/path/to/my.sock \
+RCLONE_WEBDAV_URL=http://localhost \
+rclone sync mydir :webdav:/somewhere
+```
+---
+ backend/webdav/webdav.go | 19 ++++++++++++++++++-
+ docs/content/webdav.md   | 11 +++++++++++
+ fs/config.go             |  1 +
+ fs/fshttp/http.go        |  8 +++++++-
+ 4 files changed, 37 insertions(+), 2 deletions(-)
+
+diff --git a/backend/webdav/webdav.go b/backend/webdav/webdav.go
+index f1c16f35a..c72875db8 100644
+--- a/backend/webdav/webdav.go
++++ b/backend/webdav/webdav.go
+@@ -15,6 +15,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 	"io"
++	"net"
+ 	"net/http"
+ 	"net/url"
+ 	"os/exec"
+@@ -154,6 +155,11 @@ Set to 0 to disable chunked uploading.
+ 			Help:     "Exclude ownCloud shares",
+ 			Advanced: true,
+ 			Default:  false,
++		}, {
++			Name:     "unix_socket_path",
++			Help:     "Path to a unix domain socket to dial to, instead of opening a TCP connection directly",
++			Advanced: true,
++			Default:  "",
+ 		}},
+ 	})
+ }
+@@ -171,6 +177,7 @@ type Options struct {
+ 	PacerMinSleep      fs.Duration          `config:"pacer_min_sleep"`
+ 	ChunkSize          fs.SizeSuffix        `config:"nextcloud_chunk_size"`
+ 	ExcludeShares      bool                 `config:"owncloud_exclude_shares"`
++	UnixSocketPath     string               `config:"unix_socket_path"`
+ }
+ 
+ // Fs represents a remote webdav
+@@ -452,7 +459,17 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
+ 		precision:   fs.ModTimeNotSupported,
+ 	}
+ 
+-	client := fshttp.NewClient(ctx)
++	var client *http.Client
++	if opt.UnixSocketPath == "" {
++		client = fshttp.NewClient(ctx)
++	} else {
++		fs.Debugf(f, "custom unix_socket_path configured (%v), updating dialer…", opt.UnixSocketPath)
++		client = fshttp.NewClientCustom(ctx, func(t *http.Transport) {
++			t.DialContext = func(reqCtx context.Context, network, addr string) (net.Conn, error) {
++				return fshttp.NewDialer(ctx).DialContext(reqCtx, "unix", opt.UnixSocketPath)
++			}
++		})
++	}
+ 	if opt.Vendor == "sharepoint-ntlm" {
+ 		// Disable transparent HTTP/2 support as per https://golang.org/pkg/net/http/ ,
+ 		// otherwise any connection to IIS 10.0 fails with 'stream error: stream ID 39; HTTP_1_1_REQUIRED'
+diff --git a/docs/content/webdav.md b/docs/content/webdav.md
+index 7da008014..855b0e2a0 100644
+--- a/docs/content/webdav.md
++++ b/docs/content/webdav.md
+@@ -283,6 +283,17 @@ Properties:
+ - Type:        bool
+ - Default:     false
+ 
++#### --webdav-unix-socket-path
++
++Path to a unix domain socket to dial to, instead of opening a TCP connection directly
++
++Properties:
++
++- Config:      unix_socket_path
++- Env Var:     RCLONE_WEBDAV_UNIX_SOCKET_PATH
++- Type:        string
++- Required:    false
++
+ #### --webdav-description
+ 
+ Description of the remote
+diff --git a/fs/config.go b/fs/config.go
+index 435fbf8e7..5122aae18 100644
+--- a/fs/config.go
++++ b/fs/config.go
+@@ -154,6 +154,7 @@ type ConfigInfo struct {
+ 	Inplace                    bool // Download directly to destination file instead of atomic download to temp/rename
+ 	PartialSuffix              string
+ 	MetadataMapper             SpaceSepList
++	UnixSocketPath             string // Optional unix socket to connect to
+ }
+ 
+ // NewConfig creates a new config with everything set to the default
+diff --git a/fs/fshttp/http.go b/fs/fshttp/http.go
+index 498714dfd..ff756d511 100644
+--- a/fs/fshttp/http.go
++++ b/fs/fshttp/http.go
+@@ -127,9 +127,15 @@ func NewTransport(ctx context.Context) http.RoundTripper {
+ 
+ // NewClient returns an http.Client with the correct timeouts
+ func NewClient(ctx context.Context) *http.Client {
++	return NewClientCustom(ctx, nil)
++}
++
++// NewClientCustom returns an http.Client with the correct timeouts.
++// It allows customizing the transport, using NewTransportCustom.
++func NewClientCustom(ctx context.Context, customize func(*http.Transport)) *http.Client {
+ 	ci := fs.GetConfig(ctx)
+ 	client := &http.Client{
+-		Transport: NewTransport(ctx),
++		Transport: NewTransportCustom(ctx, customize),
+ 	}
+ 	if ci.Cookie {
+ 		client.Jar = cookieJar
+-- 
+2.44.0
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -211,6 +211,22 @@ data "azurerm_storage_account" "tfstate" {
   resource_group_name = local.envs["storage_account_rg_name"]
 }
 
+# Storage account and storage container used to store Jenkins artifacts
+resource "azurerm_storage_account" "jenkins_artifacts" {
+  name                            = "art${local.ws}${local.shortloc}"
+  resource_group_name             = azurerm_resource_group.infra.name
+  location                        = azurerm_resource_group.infra.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
+}
+
+resource "azurerm_storage_container" "jenkins_artifacts_1" {
+  name                  = "jenkins-artifacts-v1"
+  storage_account_name  = azurerm_storage_account.jenkins_artifacts.name
+  container_access_type = "private"
+}
+
 # Data sources to access 'persistent' data, see ./persistent
 
 data "azurerm_storage_account" "binary_cache" {


### PR DESCRIPTION
Depends on #160, will be rebased once merged (so ignore the first 2 commits).

This adds the necessary services running on the jenkins-controller machine to upload and serve artifacts from Azure storage.

 - A per-environment storage container for artifacts is added via terraform
 - Two rclone services exposing the bucket contents, rw and ro, plus config to expose the ro part via caddy.
 - Our rclone gains another patch/feature, support to connect to webdav backends via unix domain sockets, and that rclone is made available in jenkins' `$PATH`.

