### PR TITLE
Enable aarch64 emulation on azure x86 builders

### DIFF
--- a/hosts/azure/builder/configuration.nix
+++ b/hosts/azure/builder/configuration.nix
@@ -23,6 +23,8 @@
     remote = ":azureblob:binary-cache-v1";
   };
 
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
   nix.settings.substituters = [
     # Configure Nix to use the bucket (through rclone-http) as a substitutor.
     # The public key is passed in externally.


### PR DESCRIPTION
With this change, imx8mp target can be built on azure.