### PR TITLE
Beef-up priv jenkins-controller

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -95,7 +95,7 @@ locals {
       vm_size_builder_x86     = "Standard_D2_v3"
       vm_size_builder_aarch64 = "Standard_D2ps_v5"
       osdisk_size_builder     = "150"
-      vm_size_controller      = "Standard_E2_v5"
+      vm_size_controller      = "Standard_E4_v5"
       osdisk_size_controller  = "150"
       num_builders_x86        = 1
       num_builders_aarch64    = 1


### PR DESCRIPTION
Beef-up jenkins-controller VM on the priv instance(s) to the same VM size as what is already used in dev. This is needed since 16GiB RAM on jenkins-controller is simply no longer enough to evaluate the Ghaf flake targets (the evaluation needs to happen on the jenkins-controller).