### PR TITLE
Change build3 to use hetzarm as arm builder

### DIFF
--- a/hosts/builders/build3/secrets.yaml
+++ b/hosts/builders/build3/secrets.yaml
@@ -1,5 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:tAmG6mDLKmP4Qw0DmHGdcxofG6r9okbV7eyPDIRnhQX9PbFTaYVCcZY7YHtkVYcEqNMSy+DiudxbAqivYAUU36rmlD4n70hx85oho01HssL/F+bycGUx9DRxgO4GFpVU5C3IeURcICwZ7ZHDBqgPjSOE4t/JHrJBZ8KG5LuTzKL6JimbhsKNxsPSgc7Mm4Mb2rOT+6q99Iq0+XDItfOUAcadlgHhOBNv5h8rS6MxBg/7Qg1/OgnkiTzAWzSyCbLajnOUB+L2ywFNFVJF7hN+qc+1Lju6HKMAFGX2XWN9hCVH3n1uL4f+YYrAj8Ug3CB/lalDoiPydebCEOJB7UfeCBMmv2nqDA/txr3qE/ifjP9kl1mHOqTl2wsIT0CMNw86e7k1XYBSolC7JXpwWR0znFTsaVgJTxpU/1v2b3B/BeAtUA1gXXgmAD4oArZMTS0VwUWJNnAX/mJmZU5NXlbaZb9dfm6DClg8u9414ejqrdt1xzqcvuI8gXP4fNopJzQz7PIlB5AFtpEOHf5AYwwQ,iv:xa19WYVdlAJ+MJlu3MIhKjPpQv6jhmzriD4f5qLzL3g=,tag:aJiQH4OaMqgm3LtJXQ9hSw==,type:str]
-awsarm_ssh_key: ENC[AES256_GCM,data:D8AsnKwXJoM4PKZo9VSVFOi0dQX4BRmIaSIE1BZtNXp729fF6oZCRmZ2HynXKBksKzasof5Vows/x3kBu/eTRllj53acnvap6VpRfqXuHoHYZAPV2FT+lc49S6l2yXfg95Or8mtPmUDScg0m4rx8pOntKucV2mN/9+Tkr4w/bmkz5b//XHKyRcV7fP7CmFP27ODFmotVxJFs0+yWaapY0hHCCA8tQHYYPVZthvXmAfwPN0K4kn4lu5rastwPEPA6/Do0I8UIcE6J9nRoHOVVqxFvTmVuxC1gkAc8zFNkEYLaMD0L2BrTiBhkByCdCyVlaK7oo2YF8mRGIxmmRJHkNJwy/TVYLdv37Pf+NhCt/bj53nnN71H8MY4UvsofWjMNaFVKL4FFKQKf2LdRYUuARTXurMOxszpKPMI3hBXXBU8k/gIegC1uqwHNS5ZCJR2MlVkQBxCs9Tpnz51ENdJ1AWOxygzVaymZj3C+ORBf6W34V3U/+BvZARikhZ39A0IIwRuCIA0XJNFFR+tIaLb6,iv:BfFw4ejHjWsDsRIXM2BFBstpQ3w18AeEkFevHUpPqvI=,tag:yNhJE1fp4o7cv+fwVBovaw==,type:str]
+ssh_private_key: ENC[AES256_GCM,data:VmgNmKkNqXEIHrMVlxHLy+wXBtEp2OeMTmpX01WVhm772nSaszQ40aqUHduWUMYqtnLBbDIM5nMN0LpK8OM0j/brz0DAo94VFd+KbIpS+T1FNfyTa1o8fOPzOxFsx9hUsgdzXesuAFp9NlZQgjV8X2L7qYjyK1lQu3e2D6v2F0MtUlxGlLxAmYa+h7+udFFiMeYjB++DqkoYwl1RXdj0+0OJqdBPWPE2KPdO62enW3T/3PODhbS+puWfyjEloNgwjffzgUnA+WBZcBMhRBXa//cb/HhU7lDr1DlT+rnVKvLvNWIaKBqfTSiw6Ebd/EymBs1jq2fA8+BEhxc5Dg+5VzSoUD3cNARpoFH2rfXnfa4NMFEyHmGnDsOt8XWgCANMqH6onYae/6tOzK847omfcHCrKEJhzRDF2rCEz/GoZOXZjEjMHgxwXL4KIl3iDptrSGdmDxN+HTnSF5o5xEcxrx/t3V6QFmcBnTqXFOJxnOZ+daTqxKjdjYhcaXmHy8DkZuuwmHMDoRNzLH4K41ia,iv:tJZZ3UrY9VgRcvhQraoIit7VRznLtbeyUVG8E/V/KuU=,tag:M9Kyw5FQoYm2BI2OWzSonA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -24,8 +24,8 @@ sops:
             UzhrejBsL0lvaDJGaWlNTXZPQThUOTAKDBeoNAjD1tm/Bw6K/8lBVEZ304rfSxCu
             HVKatuZNj4FhwXQPplDaoB8e3uDsEZ0xgwR1pS3tE8ZtBAUoRCeaBw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-04-11T14:26:54Z"
-    mac: ENC[AES256_GCM,data:KD1RvTs2ouX9Q/MqF3I5XlqZjFWeKuWk+Wt40cIziDscLA5D3G5jWgE9XNrXmlamGMF6lLdnGJ15un3K6o5o+2zNOgojqyZwzviePxLOo0kzz8SoycSLrDTUJpBRClrPrN+MUzzOLEIqOZGl1F4HKM/AlqfQgNCFEuMcJvVzNsA=,iv:DOF8tHlz2UPxjGnFLMltsRfTTAL4Hs7c6TSQuSnpyFc=,tag:F8uFDwXcMjWFhDetpQmWZA==,type:str]
+    lastmodified: "2024-05-24T05:48:00Z"
+    mac: ENC[AES256_GCM,data:ZISriCWwstvq6nSp+cXvfhLlTc4wrfHnx0I06Ezkwyd2Hr3WNbMDQl8hA/Iq5UOlkULNg/w8j2zJEn7WKzSyzpC5cSiLCwwr0YJJUtLvyodK/cq/JfRoYEzZlMVZaMwH4UCdj5a4v5+sThdxCFUJaMF8i0c/IpzD0tCPfYEUSEc=,iv:ElxzzfvVS/4Gco7AQDlReywdmJdE+IoFh/aMSldZAQI=,tag:IZGkov+bFDbE+yA57lfKSA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -29,15 +29,6 @@
       user-themisto
     ]);
 
-  # Set authorized keys for sshified user
-  users.users.sshified = {
-    isNormalUser = true;
-    group = "sshified";
-    openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEKd30t0EFmMyULGlecaUX6puIAF4IjynZUo+X9k8h69 monitoring"
-    ];
-  };
-  users.groups.sshified = {};
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
   hardware.enableRedistributableFirmware = true;
 
@@ -56,5 +47,23 @@
     };
   };
 
-  nix.settings.trusted-users = ["themisto" "@wheel"];
+  users.users = {
+    # sshified user for monitoring server to log in as
+    sshified = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEKd30t0EFmMyULGlecaUX6puIAF4IjynZUo+X9k8h69 monitoring"
+      ];
+    };
+
+    # build3 can use this as remote builder
+    build3 = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf56a3ISY64w0Y0BmoLu+RyTIWQrXG6ugla6if9RteT build3"
+      ];
+    };
+  };
+
+  nix.settings.trusted-users = ["@wheel" "build3"];
 }


### PR DESCRIPTION
- Change build3 remotemachines from awsarm to hetzarm.
- Add build3 user to hetzarm that build3 machine can log in as when remote building.