### PR TITLE
common: Stop automatic daily gc

### DIFF
--- a/hosts/binarycache/configuration.nix
+++ b/hosts/binarycache/configuration.nix
@@ -40,9 +40,6 @@
     trusted-users = ["hydra"];
   };
 
-  # do not run garbage collection, we have enough disk space
-  nix.gc.automatic = lib.mkForce false;
-
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 
   networking = {

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -56,10 +56,6 @@ in {
       # The default at 10 is rarely enough.
       log-lines = lib.mkDefault 25;
     };
-    # Garbage collection
-    gc.automatic = true;
-    gc.options = pkgs.lib.mkDefault "--delete-older-than 7d";
-
     daemonCPUSchedPolicy = lib.mkDefault "batch";
     daemonIOSchedClass = lib.mkDefault "idle";
     daemonIOSchedPriority = lib.mkDefault 7;


### PR DESCRIPTION
This is the same garbage-collection change that was earlier done for Azure hosts in PR: https://github.com/tiiuae/ghaf-infra/pull/145:

> Before this change, gc automatically ran daily at [03:15](https://search.nixos.org/options?channel=unstable&show=nix.gc.dates&from=0&size=50&sort=relevance&type=packages&query=nix.gc).
We don't want to run it automatically, but only when /nix/store storage drops below certain threshold. For that, we already have nix.settings.min-free and nix.settings.max-free, the values of which are also adjusted in this PR.
>
> Before this change, the nigthly gc would effectively clean the /nix/store unnecessarily removing earlier local build results. Thus, the configuration before this change triggered unnecessary downloads from the Azure blob storage when the nix store was re-populated on the first build after the daily cleanup. The [--delete-older-than 7d](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage#opt-delete-older-than) only applied to profiles, not to nix store objects in general.
