### PR TITLE
terraform: Prevent accidental destroy/deployment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,6 +53,12 @@ variable "envfile" {
   }
 }
 
+variable "convince" {
+  type        = bool
+  description = "Protect against accidental dev or prod environment deployment"
+  default     = false
+}
+
 # Use azure_region module to get the short name of the Azure region,
 # see: https://registry.terraform.io/modules/claranet/regions/azurerm/latest
 module "azure_region" {
@@ -140,6 +146,12 @@ locals {
   # If workspace name is "dev" or "prod" use the workspace name as
   # envtype, otherwise, use the value from var.envtype.
   conf = local.ws == "dev" || local.ws == "prod" ? local.ws : var.envtype
+
+  # Protect against accidental dev or prod environment deployment by requiring
+  # variable -var="convince=true".
+  assert_accidental_deployment = regex(
+    ("${local.conf}" != "priv" && !(var.convince)) ?
+  "((Force invalid regex pattern\n\nERROR: Deployment to 'prod' or 'dev' requires variable 'convince'" : "", "")
 
   # Selects the persistent data (see ./persistent) used in the ghaf-infra
   # instance; currently either "dev" or "prod" based on the environment type:

--- a/terraform/persistent/main.tf
+++ b/terraform/persistent/main.tf
@@ -53,6 +53,11 @@ locals {
 resource "azurerm_resource_group" "persistent" {
   name     = "ghaf-infra-persistent-${local.ws}"
   location = var.location
+  lifecycle {
+    # Fails any plan that requires this resource to be destroyed.
+    # This only protects from Terraform accidental client-side destruction.
+    prevent_destroy = true
+  }
 }
 
 # Current signed-in user

--- a/terraform/state-storage/tfstate-storage.tf
+++ b/terraform/state-storage/tfstate-storage.tf
@@ -37,6 +37,9 @@ locals {
 resource "azurerm_resource_group" "rg" {
   name     = "ghaf-infra-state-${local.ws}"
   location = var.location
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Storage container
@@ -54,4 +57,7 @@ resource "azurerm_storage_container" "tfstate" {
   name                  = "ghaf-infra-tfstate-container"
   storage_account_name  = azurerm_storage_account.tfstate.name
   container_access_type = "private"
+  lifecycle {
+    prevent_destroy = true
+  }
 }


### PR DESCRIPTION
Fail terraform plans that require ghaf-infra-persistent or azure state storage to be destroyed. This only protects against accidental client-side destruction.

Also, protect against accidental dev or prod environment deployment by requiring variable -var="convince=true" when deploying to environment types other than priv.