### PR TITLE
Add workflow version updater

### DIFF
--- a/.github/workflows/schedule-update-actions.yml
+++ b/.github/workflows/schedule-update-actions.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+name: GitHub Actions Version Updater
+on:
+  workflow_dispatch:
+  schedule:
+    # Automatically run on every Sunday at 00:00 UTC.
+    - cron:  '0 0 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3.5.2
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.PAT }}
+      
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.8.1
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.PAT }}
+          pull_request_title: "Update GitHub Actions to Latest Version"


### PR DESCRIPTION
Adding GitHub Actions workflow to automatically update the versions of actions used in the ghaf-infra. The workflow runs on a weekly schedule and uses the 'saadmk11/github-actions-version-updater' action.

FYI: A pull request will be created with the title "ci: Update GitHub Actions to Latest Version" if updates are available.

