### PR TITLE
terraform/jenkins-controller: add static builders

### DIFF
--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -63,7 +63,11 @@ module "jenkins_controller_vm" {
       {
         content = join("\n", concat(
           [for ip in toset(module.builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} x86_64-linux /etc/secrets/remote-build-ssh-key 10 1 kvm,nixos-test,benchmark,big-parallel - -"],
-          [for ip in toset(module.arm_builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} aarch64-linux /etc/secrets/remote-build-ssh-key 8 1 kvm,nixos-test,benchmark,big-parallel - -"]
+          [for ip in toset(module.arm_builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} aarch64-linux /etc/secrets/remote-build-ssh-key 8 1 kvm,nixos-test,benchmark,big-parallel - -"],
+          (var.envtype == "dev" || var.envtype == "priv") ? [
+            "ssh://remote-build@builder.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 64 3 kvm,nixos-test,benchmark,big-parallel - -",
+            "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 80 3 kvm,nixos-test,benchmark,big-parallel - -"
+          ] : []
         )),
         "path" = "/etc/nix/machines"
       },
@@ -71,7 +75,8 @@ module "jenkins_controller_vm" {
       {
         content = join("\n", toset(concat(
           module.builder_vm[*].virtual_machine_ip_address,
-          module.arm_builder_vm[*].virtual_machine_ip_address
+          module.arm_builder_vm[*].virtual_machine_ip_address,
+          (var.envtype == "dev" || var.envtype == "priv") ? ["builder.vedenemo.dev", "hetzarm.vedenemo.dev"] : []
         ))),
         "path" = "/var/lib/builder-keyscan/scanlist"
       },


### PR DESCRIPTION
This adds builder.vedenemo.dev and hetzarm.vedenemo.dev as static builders to /etc/nix/machines, as well as the keyscan machinery.

https://github.com/tiiuae/ghaf-infra/pull/171 already ensured that ssh key works.

maxJobs is set to the number of cores the system sees, and speedFactor is set to 3, making it more attractive than the other builders.