### PR TITLE
Remove azure builders

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -59,5 +59,6 @@ in {
     git
     vim
     htop
+    tree
   ];
 }

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -64,10 +64,7 @@ module "jenkins_controller_vm" {
         content = join("\n", concat(
           [for ip in toset(module.builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} x86_64-linux /etc/secrets/remote-build-ssh-key 10 1 kvm,nixos-test,benchmark,big-parallel - -"],
           [for ip in toset(module.arm_builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} aarch64-linux /etc/secrets/remote-build-ssh-key 8 1 kvm,nixos-test,benchmark,big-parallel - -"],
-          (var.envtype == "dev" || var.envtype == "priv") ? [
-            "ssh://remote-build@builder.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 64 3 kvm,nixos-test,benchmark,big-parallel - -",
-            "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 80 3 kvm,nixos-test,benchmark,big-parallel - -"
-          ] : []
+          local.opts[local.conf].ext_builder_machines,
         )),
         "path" = "/etc/nix/machines"
       },
@@ -76,7 +73,7 @@ module "jenkins_controller_vm" {
         content = join("\n", toset(concat(
           module.builder_vm[*].virtual_machine_ip_address,
           module.arm_builder_vm[*].virtual_machine_ip_address,
-          (var.envtype == "dev" || var.envtype == "priv") ? ["builder.vedenemo.dev", "hetzarm.vedenemo.dev"] : []
+          local.opts[local.conf].ext_builder_keyscan,
         ))),
         "path" = "/var/lib/builder-keyscan/scanlist"
       },

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -103,11 +103,16 @@ locals {
       osdisk_size_builder     = "150"
       vm_size_controller      = "Standard_E4_v5"
       osdisk_size_controller  = "150"
-      num_builders_x86        = 1
-      num_builders_aarch64    = 1
+      num_builders_x86        = 0
+      num_builders_aarch64    = 0
       # 'priv' and 'dev' environments use the same binary cache signing key
       binary_cache_public_key = "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="
       binary_cache_url        = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
+      ext_builder_machines = [
+        "ssh://remote-build@builder.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 64 3 kvm,nixos-test,benchmark,big-parallel - -",
+        "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 80 3 kvm,nixos-test,benchmark,big-parallel - -"
+      ]
+      ext_builder_keyscan = ["builder.vedenemo.dev", "hetzarm.vedenemo.dev"]
     }
     dev = {
       vm_size_binarycache     = "Standard_D2_v3"
@@ -117,11 +122,16 @@ locals {
       osdisk_size_builder     = "250"
       vm_size_controller      = "Standard_E4_v5"
       osdisk_size_controller  = "1000"
-      num_builders_x86        = 1
-      num_builders_aarch64    = 1
+      num_builders_x86        = 0
+      num_builders_aarch64    = 0
       # 'priv' and 'dev' environments use the same binary cache signing key
       binary_cache_public_key = "ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I="
       binary_cache_url        = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
+      ext_builder_machines = [
+        "ssh://remote-build@builder.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 64 3 kvm,nixos-test,benchmark,big-parallel - -",
+        "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 80 3 kvm,nixos-test,benchmark,big-parallel - -"
+      ]
+      ext_builder_keyscan = ["builder.vedenemo.dev", "hetzarm.vedenemo.dev"]
     }
     prod = {
       vm_size_binarycache     = "Standard_D2_v3"
@@ -135,6 +145,8 @@ locals {
       num_builders_aarch64    = 1
       binary_cache_public_key = "ghaf-infra-prod:DIrhJsqehIxjuUQ93Fqx6gmo4cDgn5srW5dedvMbqD0="
       binary_cache_url        = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
+      ext_builder_machines    = []
+      ext_builder_keyscan     = []
     }
   }
 


### PR DESCRIPTION
Azure builders are no longer needed on 'priv' and 'dev' environments after https://github.com/tiiuae/ghaf-infra/pull/173.

This change also moves the external builder configuration to the environment-specific configuration options to anticipate ghaf-infra deployments on locations that might not want to use the vedenemo.dev builders we are using with Ghaf.

Adds the `tree` package since it would be nice to have on the Azure hosts, but also to make sure this change triggers an update in the terraform infra, see: https://ssrc.atlassian.net/browse/SP-3899 which still needs fixing. 
