### PR TITLE
Update monitoring, remove awsarm

### DIFF
--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -142,6 +142,10 @@ in {
             labels = {machine_name = "gerrit";};
           }
           {
+            targets = ["172.18.20.108:9100"];
+            labels = {machine_name = "monitoring";};
+          }
+          {
             targets = ["172.18.20.109:9100"];
             labels = {machine_name = "binarycache";};
           }

--- a/pkgs/sshified/default.nix
+++ b/pkgs/sshified/default.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule rec {
   pname = "sshified";
-  version = "1.1.15";
+  version = "v1.1.19";
 
   src = fetchFromGitHub {
     owner = "hoffie";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-zbgwCWs+DNJ1ZmAl9h0PuJvLO3yMhE/t6T1aqpwYOgk=";
+    rev = version;
+    hash = "sha256-LgR2U0xcY/852ddSsPhaVJEWaKA2O8t0mpjM/PM9gn0=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
- awsarm is no longer being monitored
- now monitoring the monitoring server itself
- sshified updated to [v1.1.19](https://github.com/hoffie/sshified/releases/tag/v1.1.19) for security updates and bug fixes