### PR TITLE
Reduce scrape interval to fix dashboards mismatch

### DIFF
--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -113,6 +113,8 @@ in {
     webExternalUrl = "http://${public-ip}:${toString config.services.prometheus.port}";
     checkConfig = true;
 
+    globalConfig.scrape_interval = "15s";
+
     scrapeConfigs = [
       {
         job_name = "ficolo-internal-monitoring";


### PR DESCRIPTION
Fixes issue where monitoring dashboard graphs would show "no data" in timeframes lower than 24 hours, due to scrape interval being `1m` in prometheus and `15s` in grafana datasource