### PR TITLE
Add aarch64 checks and auth to workflow

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -1,23 +1,62 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-name: Test ghaf-infra
+name: Run pre-push checks
 
 on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
 jobs:
-  tests:
+  # Checks if the author of pull request is in our predefined list of authorized users
+  check-identity:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized_user: ${{ steps.check-authorized-user.outputs.authorized_user}}
+    environment: 'internal'
+    steps:
+      - name: Check identity
+        id: check-authorized-user
+        shell: bash
+        run: |
+          # AUTHORIZED_USERS is a newline separated list of usernames
+          if echo "${{ vars.AUTHORIZED_USERS }}" | grep -F -x -q "${{ github.actor }}"; then
+            echo "authorized_user=True" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized_user=False" >> "$GITHUB_OUTPUT"
+          fi
+  
+  # Authorization passes without approval if
+  # - the event is not a pull request (eg. push to main)
+  # - pull request comes from another branch in the same repo
+  # - author is in our predefined list of authorized users
+  # If none of these conditions are met, the workflow requires 
+  # manual approval from a maintainer with write permissions to continue
+  authorize:
+    needs: [check-identity]
+    environment: ${{ 
+      ( github.event_name != 'pull_request_target' ||
+        github.event.pull_request.head.repo.full_name == github.repository || 
+        needs.check-identity.outputs.authorized_user == 'True' )
+      && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - run: true
 
-      - uses: cachix/install-nix-action@v22
+  tests:
+    # Don't run unless authorization was successful
+    needs: [authorize]
+    if: ${{ always() && needs.authorize.result == 'success' }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             trusted-public-keys = cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -4,7 +4,6 @@
 name: Test ghaf-infra
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -28,11 +27,13 @@ jobs:
             builders-use-substitutes = true
             builders = @/etc/nix/machines
 
-      - name: Configure remote builder
+      - name: Configure remote builders
         run: |
           sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"
           sudo sh -c "echo 'hetzarm.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK' >>/etc/ssh/ssh_known_hosts"
+          sudo sh -c "echo 'builder.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSI8s/wefXiD2h3I3mIRdK+d9yDGMn0qS5fpKDnSGqj' >>/etc/ssh/ssh_known_hosts"
           sudo sh -c "echo 'ssh://github@hetzarm.vedenemo.dev aarch64-linux /etc/nix/id_builder_key 40 1 nixos-test,benchmark,big-parallel,kvm - -' >/etc/nix/machines"
+          sudo sh -c "echo 'ssh://github@builder.vedenemo.dev x86_64-linux,i686-linux /etc/nix/id_builder_key 32 1 kvm,benchmark,big-parallel,nixos-test - -' >>/etc/nix/machines"
 
       - name: Run ghaf-infra CI tests
         run: nix develop --command inv pre-push

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -4,6 +4,7 @@
 name: Test ghaf-infra
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -16,6 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: cachix/install-nix-action@v22
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.vedenemo.dev https://cache.nixos.org
+            connect-timeout = 5
+            system-features = nixos-test benchmark big-parallel kvm
+            builders-use-substitutes = true
+            builders = @/etc/nix/machines
+
+      - name: Configure remote builder
+        run: |
+          sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"
+          sudo sh -c "echo 'hetzarm.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK' >>/etc/ssh/ssh_known_hosts"
+          sudo sh -c "echo 'ssh://github@hetzarm.vedenemo.dev aarch64-linux /etc/nix/id_builder_key 40 1 nixos-test,benchmark,big-parallel,kvm - -' >/etc/nix/machines"
+
       - name: Run ghaf-infra CI tests
         run: nix develop --command inv pre-push

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -45,7 +45,36 @@ jobs:
       && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: echo "Auth OK"
+
+  # Send a warning and fail this job if the workflow file was changed.
+  # Rest of the workflow continues as normal but the job failure will grab author's attention.
+  no-workflow-changes:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request_target' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Check if workflow is modified
+        id: workflow-changed
+        uses: tj-actions/changed-files@v40
+        with:
+          files: .github/workflows/test-ghaf-infra.yml
+
+      - name: Send warning
+        run: |
+          if [ "${{ steps.workflow-changed.outputs.any_changed }}" == "true" ]; then
+            echo "::error::"\
+                 "This change edits workflow file '.github/workflows/test-ghaf-infra.yml'."\
+                 "Raising this error to notify that the workflow change will only take impact after merge."\
+                 "Therefore, you need to manually test the change (perhaps in a forked repo) "\
+                 "before merging to make sure the change does not break anything."
+
+            exit 1
+          fi
 
   tests:
     # Don't run unless authorization was successful
@@ -55,6 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+            ref: ${{ github.event.pull_request.head.sha || github.ref }}
+            fetch-depth: 0
 
       - uses: cachix/install-nix-action@v27
         with:

--- a/hosts/builders/developers.nix
+++ b/hosts/builders/developers.nix
@@ -277,6 +277,13 @@
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2rhqSdifRmTwyrc3rvXWyDMznrIAAkVwhEsufLYiTp"
       ];
     }
+    {
+      desc = "Github actions runners can use this user to remote build";
+      name = "github";
+      keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/KOBOKqZwugt7Yi6ZFhr6ZF2j9kzyqnl+v7eRlxPoq"
+      ];
+    }
   ];
 in {
   users = {

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -63,7 +63,15 @@
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf56a3ISY64w0Y0BmoLu+RyTIWQrXG6ugla6if9RteT build3"
       ];
     };
+
+    # github actions runners can use this user to remote build
+    github = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/KOBOKqZwugt7Yi6ZFhr6ZF2j9kzyqnl+v7eRlxPoq"
+      ];
+    };
   };
 
-  nix.settings.trusted-users = ["@wheel" "build3"];
+  nix.settings.trusted-users = ["@wheel" "build3" "github"];
 }

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -63,15 +63,7 @@
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf56a3ISY64w0Y0BmoLu+RyTIWQrXG6ugla6if9RteT build3"
       ];
     };
-
-    # github actions runners can use this user to remote build
-    github = {
-      isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/KOBOKqZwugt7Yi6ZFhr6ZF2j9kzyqnl+v7eRlxPoq"
-      ];
-    };
   };
 
-  nix.settings.trusted-users = ["@wheel" "build3" "github"];
+  nix.settings.trusted-users = ["@wheel" "build3"];
 }

--- a/tasks.py
+++ b/tasks.py
@@ -95,6 +95,10 @@ TARGETS = OrderedDict(
             hostname="172.18.16.60",
             nixosconfig="testagent",
         ),
+        "hetzarm": TargetHost(
+            hostname="65.21.20.242",
+            nixosconfig="hetzarm",
+        ),
     }
 )
 


### PR DESCRIPTION
- Added hetzarm as remote builder so aarch64 configs can be built.
- Added build3 as remote builder to speed up building of the x86 targets.
- Added authentication steps to the workflow now that we are dealing with secrets and have to use `pull_request_target`. The auth steps are similar what is being used in ghaf repo but simplified. Reasoning explained here https://ssrc.atlassian.net/wiki/x/OABjMg

FYI the checks for this PR will fail as it's not able to use the secrets yet.

Tests done in my fork using alt account to make different PRs https://github.com/joinemm/ghaf-infra/pulls