### PR TITLE
testagent: Prepare for HW-testing in 'dev'

### DIFF
--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -19,7 +19,7 @@
     if [ ! -f secret-file ]; then echo "Error: /var/lib/jenkins/secret-file not found"; exit 1; fi;
     ${pkgs.jdk}/bin/java \
       -jar agent.jar \
-      -jnlpUrl https://ghaf-jenkins-controller-villepekkajuntun.northeurope.cloudapp.azure.com/computer/testagent/jenkins-agent.jnlp \
+      -jnlpUrl https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/computer/testagent/jenkins-agent.jnlp \
       -secret @secret-file \
       -workDir "/var/lib/jenkins"
   '';

--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -100,6 +100,7 @@ in {
       pkgs.iputils
       pkgs.netcat
       pkgs.python3
+      pkgs.wget
       brainstem
       inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
     ];


### PR DESCRIPTION
Includes the following testagent changes, preparing it to run HW-tests for the Azure ghaf-infra 'dev' instance:
- Make wget available for the jenkins agent
- Move the jenkins-connection service's exec start to it's own script
- Add some basic error checks for the jenkins-connection service
- Configure start rate limiting for the jenkins-connection service
- Connect testagent to dev jenkins-controller

