### PR TITLE
jenkins-controller: Changes to support hw-testing

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -173,6 +173,25 @@ in {
             };
           };
         }
+        {
+          job = {
+            name = "ghaf-test-boot";
+            project-type = "pipeline";
+            pipeline-scm = {
+              scm = [
+                {
+                  git = {
+                    url = "https://github.com/tiiuae/ghaf-jenkins-pipeline.git";
+                    clean = true;
+                    branches = ["*/main"];
+                  };
+                }
+              ];
+              script-path = "ghaf-test-boot.groovy";
+              lightweight-checkout = true;
+            };
+          };
+        }
       ];
     };
   };

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -220,7 +220,9 @@ in {
       # Install plugins
       jenkins-cli ${jenkins-auth} install-plugin \
         "workflow-aggregator" "github" "timestamper" "pipeline-stage-view" "blueocean" \
-        "pipeline-graph-view" "github-pullrequest" "antisamy-markup-formatter" "configuration-as-code" "slack"
+        "pipeline-graph-view" "github-pullrequest" "antisamy-markup-formatter" \
+        "configuration-as-code" "slack" "pipeline-utility-steps" "pipeline-build-step" \
+        "robot"
 
       # Disable initial install
       jenkins-cli ${jenkins-auth} groovy = < ${jenkins-groovy}

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -104,6 +104,9 @@ in {
     extraJavaOptions = [
       # Useful when the 'sh' step fails:
       "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"
+      # If we want to allow robot framework reports, we need to adjust Jenkins CSP:
+      # https://plugins.jenkins.io/robot/#plugin-content-log-file-not-showing-properly
+      "-Dhudson.model.DirectoryBrowserSupport.CSP=\"sandbox allow-scripts; default-src 'none'; img-src 'self' data: ; style-src 'self' 'unsafe-inline' data: ; script-src 'self' 'unsafe-inline' 'unsafe-eval';\""
       # Point to configuration-as-code config
       "-Dcasc.jenkins.config=${jenkins-casc}"
     ];


### PR DESCRIPTION
This PR implements the jenkins-controller VM changes required to support jenkins HW-testing pipelines.

This change depends on the pipeline changes from: https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/34.

Note: running the HW-tests requires setting-up a testagent as described in: https://ssrc.atlassian.net/wiki/x/IoAXRQ - currently, such testagent setup will be done on the 'dev' instance. Other instances are still able to run the pipelines, but the HW-tests will obviously not be run unless testagent is connected.
