### PR TITLE
Add initial ghaf logging server configuration

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -16,6 +16,7 @@ keys:
   - &testagent age12nrv5a9rk9vqvx2tqvghn4kt9ps6gdszmmynhjegl2ewefkh03fsexuy9y
   - &build3 age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
+  - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
 
 creation_rules:
   - path_regex: terraform/azarm/secrets.yaml$
@@ -50,3 +51,8 @@ creation_rules:
     - age:
       - *jrautiola
       - *hetzarm
+  - path_regex: hosts/ghaf-log/secrets.yaml$
+    key_groups:
+    - age:
+      - *jrautiola
+      - *ghaf-log

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -46,6 +46,7 @@ in {
     nixos-monitoring = ./monitoring/configuration.nix;
     nixos-himalia = ./himalia/configuration.nix;
     nixos-testagent = ./testagent/configuration.nix;
+    nixos-ghaf-log = ./ghaf-log/configuration.nix;
   };
 
   # Expose as flake.lib.mkNixOS.
@@ -70,5 +71,6 @@ in {
       "monitoring"
       "himalia"
       "testagent"
+      "ghaf-log"
     ]);
 }

--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  inputs,
+  modulesPath,
+  lib,
+  ...
+}: {
+  sops.defaultSopsFile = ./secrets.yaml;
+
+  imports =
+    [
+      ./disk-config.nix
+      (modulesPath + "/profiles/qemu-guest.nix")
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
+      common
+      service-openssh
+      user-jrautiola
+      user-cazfi
+      user-hrosten
+      user-karim
+      user-mkaapu
+      user-ktu
+      user-bmg
+      user-vilvo
+      user-vunnyso
+    ]);
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.enableRedistributableFirmware = true;
+
+  networking = {
+    hostName = "ghaf-log";
+    useDHCP = true;
+  };
+
+  boot = {
+    # use predictable network interface names (eth0)
+    kernelParams = ["net.ifnames=0"];
+    loader.grub = {
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+    };
+  };
+}

--- a/hosts/ghaf-log/disk-config.nix
+++ b/hosts/ghaf-log/disk-config.nix
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  disko.devices.disk = {
+    sda = {
+      device = "/dev/sda";
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          boot = {
+            type = "EF02";
+            size = "1M";
+          };
+          ESP = {
+            type = "EF00";
+            size = "512M";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+            };
+          };
+          root = {
+            size = "100%";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
+            };
+          };
+        };
+      };
+    };
+    # hetzner block storage, must be attached from cloud gui
+    block = {
+      device = "/dev/disk/by-id/scsi-0HC_Volume_100874627";
+      type = "disk";
+      content = {
+        type = "filesystem";
+        format = "ext4";
+        mountpoint = "/data";
+      };
+    };
+  };
+}

--- a/hosts/ghaf-log/secrets.yaml
+++ b/hosts/ghaf-log/secrets.yaml
@@ -1,0 +1,30 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:2nCYQcgjV6SLUZIulp3FcL4rRwXW83RqyozdtN9qtzGtM3qdMO99t1PTGthRnT5i9q3LXkdgs2+VgXZ582IZX2HQDlJK9Zg2W2+At9W9y+2Mph6yPm57vQspPmJS1hQdoAab0L843Z2p6BNQH9/ZpHhdrIyW5e/oJ6mVmpJHGcNs86I2QoRvgi4EWDpluShpso0pNjrEUxw6G37luMIGo+u64wZ0+/VDpDFUmvg4kwbioFtnFPmd5frQAm/sw5murBziTGh8dCwdezWqCQDs9igYSOfbpFtCDn2Vhl4A32vLaOiQX/ay7m2PYVlLTZz2SK7C6QLfutx0rgLTf0hy0XlHo43jif2gANMH3lzIV5TpBSbleG+94qAUkL66+pZ48lZUSP57DojvertASvFcYv6qECTP9L51cb051XGWU3Auo7IY2o8L0xLQRWvjxLUfYMiZTSCe8Zlu3KFSI8neJHLqdEnFqit6ZeRFFcpeNxbi3JDzt8MHGLwJJJMAP6s4wgJmaAGTP9Mrb28scEYE,iv:dpKqu22dIhe5w3PziEPpZqTSgaC9la3LDdmiOnvdXLU=,tag:R+r5iDGDy0cPhYh/yGreNQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBocEZaZXBHcWdyRmgwRG1p
+            aGZRWlJCeGdobHZsMWpsNVoxTmlMOXJBVFdrCmllVzJONFZZYmozS0hyRHBmelhz
+            ODBiZi84MUhLMGRDSnpnelNUT2dzWmMKLS0tIHhBR21vUFM4ZWRRYTkyMjIvKzFz
+            K2Qwa3ZSSTFpNjZveUVvZis2NWY0S0UKx/1s6rZE6W8tl3+W/NrrITqHw900MHmA
+            FoJaw77oYKjeLdd7yG8FL6xMkJBTB1Ivj1KOhAQ2W2EZ0OlZoFOo3w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17s9sc2cgt9t30cyl65zya8p4zmwnndrx2r896e7gzgl08sjn0qmq3t6shs
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaYjh2YjJ0NVJoMWl1Tnpy
+            U3NERkJPdXkvc2JoOVM3Slkwb3hrdjl4TlhnCjIvZWVVamZsZFRIc3ppVmFHbUcw
+            VWpweStiZFFRNU1YUmZGUEprUWxiYnMKLS0tIHF6citVcHJ0c3NsYWM0NWZsNi9n
+            Um56VGNaWmloWDNiWEVKZUhBd1VhdTQKrho7ofe8BhWFcqPDHjC5sdS7C2GR1wbv
+            4777q4QGXC3go+rL4AtY4uMHd5NuiuSr5SMI3YIKb/Q/o4j5h266oQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-06-19T10:13:52Z"
+    mac: ENC[AES256_GCM,data:/YaK/0NDBghEpLHBVyR/Kh+I+VE+IBM2aLYBfubbV8SKGoB63ic58fP+aYIJAsZQteoHVB2T/5QG3uhuJn1YG2MbF0/czOhiKRxYmxv2gUOmKFgeD8fmT2/z3Rr5Yoamxg1DAZKmaUeOZMhoiv7pPXFho4kJAt+oQwvH3Br22Ck=,iv:RvNE9HAAhsLgMS/ApK/ylAmTUI+eKfsf43Jm1ekkmoI=,tag:5upzy6NY2mAvvhO3boyVDA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/tasks.py
+++ b/tasks.py
@@ -99,6 +99,10 @@ TARGETS = OrderedDict(
             hostname="65.21.20.242",
             nixosconfig="hetzarm",
         ),
+        "ghaf-log": TargetHost(
+            hostname="95.217.177.197",
+            nixosconfig="ghaf-log",
+        ),
     }
 )
 

--- a/users/bmg.nix
+++ b/users/bmg.nix
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    bmg = {
+      description = "Brian McGillion";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEJ9ewKwo5FLj6zE30KnTn8+nw7aKdei9SeTwaAeRdJDAAAABHNzaDo="
+        "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIA/pwHnzGNM+ZU4lANGROTRe2ZHbes7cnZn72Oeun/MCAAAABHNzaDo="
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILu6O3swRVWAjP7J8iYGT6st7NAa+o/XaemokmtKdpGa builder key"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}

--- a/users/default.nix
+++ b/users/default.nix
@@ -19,5 +19,8 @@
     user-flokli = import ./flokli.nix;
     user-vjuntunen = import ./vjuntunen.nix;
     user-mariia = import ./mariia.nix;
+    user-vilvo = import ./vilvo.nix;
+    user-vunnyso = import ./vunnyso.nix;
+    user-bmg = import ./bmg.nix;
   };
 }

--- a/users/vilvo.nix
+++ b/users/vilvo.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    vilvo = {
+      description = "Ville Ilvonen";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFWXZk/ZFUaNAW+jeeTtDqu+9DS0BuBeLYwvZqpaLXQ8 vilvo@carrie"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}

--- a/users/vunnyso.nix
+++ b/users/vunnyso.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    vunnyso = {
+      description = "Vunny Sodhi";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIstCgKDX1vVWI8MgdVwsEMhju6DQJubi3V0ziLcU/2h vunny.sodhi@unikie.com"
+      ];
+      extraGroups = ["wheel" "networkmanager"];
+    };
+  };
+}


### PR DESCRIPTION
Barebones hetzner configuration. Server is CX32 with 100gb block volume attached. User details for bmg, vilvo and vunnyso copied from `developers.nix` into admin user modules.