### PR TITLE
Use 64 core builders in prod environment

### DIFF
--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -62,8 +62,8 @@ module "jenkins_controller_vm" {
       # changed.
       {
         content = join("\n", concat(
-          [for ip in toset(module.builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} x86_64-linux /etc/secrets/remote-build-ssh-key 10 1 kvm,nixos-test,benchmark,big-parallel - -"],
-          [for ip in toset(module.arm_builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} aarch64-linux /etc/secrets/remote-build-ssh-key 8 1 kvm,nixos-test,benchmark,big-parallel - -"],
+          [for ip in toset(module.builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} x86_64-linux /etc/secrets/remote-build-ssh-key 16 1 kvm,nixos-test,benchmark,big-parallel - -"],
+          [for ip in toset(module.arm_builder_vm[*].virtual_machine_ip_address) : "ssh://remote-build@${ip} aarch64-linux /etc/secrets/remote-build-ssh-key 16 1 kvm,nixos-test,benchmark,big-parallel - -"],
           local.opts[local.conf].ext_builder_machines,
         )),
         "path" = "/etc/nix/machines"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -139,7 +139,7 @@ locals {
       vm_size_builder_x86     = "Standard_D64_v3"
       vm_size_builder_aarch64 = "Standard_D64ps_v5"
       osdisk_size_builder     = "500"
-      vm_size_controller      = "Standard_E4_v5"
+      vm_size_controller      = "Standard_E16_v5"
       osdisk_size_controller  = "1000"
       num_builders_x86        = 1
       num_builders_aarch64    = 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -136,8 +136,8 @@ locals {
     prod = {
       vm_size_binarycache     = "Standard_D2_v3"
       osdisk_size_binarycache = "250"
-      vm_size_builder_x86     = "Standard_D16_v3"
-      vm_size_builder_aarch64 = "Standard_D16ps_v5"
+      vm_size_builder_x86     = "Standard_D64_v3"
+      vm_size_builder_aarch64 = "Standard_D64ps_v5"
       osdisk_size_builder     = "500"
       vm_size_controller      = "Standard_E4_v5"
       osdisk_size_controller  = "1000"


### PR DESCRIPTION
Prod is only created for the duration of the build so the cost increase is negligible. This should speed up the builds.