### PR TITLE
Use cachix cache to speed up checks

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -96,6 +96,7 @@ jobs:
             trusted-public-keys = cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.vedenemo.dev https://cache.nixos.org
             connect-timeout = 5
+            max-jobs = 4
             system-features = nixos-test benchmark big-parallel kvm
             builders-use-substitutes = true
             builders = @/etc/nix/machines

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -100,6 +100,11 @@ jobs:
             builders-use-substitutes = true
             builders = @/etc/nix/machines
 
+      - uses: cachix/cachix-action@v15
+        with:
+          name: ghaf-dev
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Configure remote builders
         run: |
           sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"


### PR DESCRIPTION
- Added `ghaf-dev` cachix cache to be used in the test workflow. Derivations that were always built again and again, such as terraform, are now pushed to the cache and will be copied on subsequent runs of the workflow.
- Increased max-jobs to 4. Github runners have 4 cores and most of the jobs are only copying or doing small builds so this should be fine.

With these changes, the average workflow duration for a small change dropped from ~15 minutes to ~7 minutes; making it 200% faster.