### PR TITLE
Increase sshd MaxStartups to 100 on builders

### DIFF
--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -15,6 +15,7 @@
       ../cross-compilation.nix
       ../developers.nix
       ../yubikey.nix
+      ../builders-common.nix
       inputs.sops-nix.nixosModules.sops
     ]
     ++ (with self.nixosModules; [

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -6,6 +6,7 @@
       ../ficolo.nix
       ../cross-compilation.nix
       ../yubikey.nix
+      ../builders-common.nix
     ]
     ++ (with self.nixosModules; [
       user-themisto

--- a/hosts/builders/builders-common.nix
+++ b/hosts/builders/builders-common.nix
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  # Specifies the maximum number of concurrent unauthenticated connections to the SSH daemon.
+  # The default of 10 is not enough when multiple clients are building
+  # at the same time and can result in dropped connections
+  services.openssh.settings = {
+    MaxStartups = 100;
+  };
+}

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -12,6 +12,7 @@
     [
       ./disk-config.nix
       ../developers.nix
+      ../builders-common.nix
       inputs.disko.nixosModules.disko
       inputs.sops-nix.nixosModules.sops
     ]


### PR DESCRIPTION
Fixes occasional build failures when the builders are being used by many clients at the same time and >10 ssh connections are authenticating simultaneously.

`journalctl -u sshd | grep MaxStartups` shows that the issue happens every few days on hetzarm:
```
Jun 24 04:01:33 hetzarm sshd[2072]: exited MaxStartups throttling after 00:02:10, 31 connections dropped
Jun 24 11:53:18 hetzarm sshd[2072]: error: beginning MaxStartups throttling
Jun 24 11:53:18 hetzarm sshd[2072]: drop connection #17 from [112.6.161.100]:52488 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:53:49 hetzarm sshd[2072]: drop connection #18 from [112.6.161.100]:32798 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:54:14 hetzarm sshd[2072]: drop connection #19 from [112.6.161.100]:48962 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:55:00 hetzarm sshd[2072]: drop connection #19 from [138.197.1.130]:48116 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:55:47 hetzarm sshd[2072]: drop connection #14 from [88.114.253.196]:48638 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:56:10 hetzarm sshd[2072]: drop connection #10 from [180.101.88.200]:34987 on [65.21.20.242]:22 past MaxStartups
Jun 24 11:56:49 hetzarm sshd[2072]: exited MaxStartups throttling after 00:03:31, 6 connections dropped
Jun 25 08:23:07 hetzarm sshd[2072]: error: beginning MaxStartups throttling
Jun 25 08:23:07 hetzarm sshd[2072]: drop connection #18 from [95.214.27.139]:56812 on [65.21.20.242]:22 past MaxStartups
Jun 25 08:23:08 hetzarm sshd[2072]: drop connection #16 from [95.214.27.139]:56906 on [65.21.20.242]:22 past MaxStartups
Jun 25 08:23:08 hetzarm sshd[2072]: drop connection #15 from [95.214.27.139]:56956 on [65.21.20.242]:22 past MaxStartups
Jun 25 08:23:08 hetzarm sshd[2072]: drop connection #15 from [95.214.27.139]:56970 on [65.21.20.242]:22 past MaxStartups
Jun 25 08:26:06 hetzarm sshd[2072]: exited MaxStartups throttling after 00:02:58, 4 connections dropped
```
Similar behavior was found on build3 and build4 as well. Needs further monitoring after this PR is merged to see whether it happens again.