### PR TITLE
Mitigate CVE-2024-6387

### DIFF
--- a/services/openssh/default.nix
+++ b/services/openssh/default.nix
@@ -13,6 +13,7 @@
       KbdInteractiveAuthentication = false;
       PasswordAuthentication = false;
       ClientAliveInterval = lib.mkDefault 60;
+      LoginGraceTime = 0;
     };
 
     # Only allow ed25519 keys


### PR DESCRIPTION
This is temp fix for [CVE-2024-6387](https://github.com/advisories/GHSA-2x8c-95vh-gfv4) before we can update to nixos 24.05