### PR TITLE
Specify the Jenkins URL with JCasC

### DIFF
--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -98,6 +98,7 @@ unclassified:
     storage: "file"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
+    url: "${file:/var/lib/jenkins-casc/url}"
   mailer:
     charset: "UTF-8"
     useSsl: false

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -80,6 +80,13 @@ module "jenkins_controller_vm" {
       {
         content = "SITE_ADDRESS=ghaf-jenkins-controller-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com",
         "path"  = "/var/lib/caddy/caddy.env"
+      },
+      # JENKINS_URL is read from this file by JCasC plugin
+      # Configuration: hosts/azure/jenkins-controller/jenkins-casc.yaml
+      # Value: jenkins: unclassified: location: url
+      {
+        content = "https://ghaf-jenkins-controller-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com",
+        "path"  = "/var/lib/jenkins-casc/url"
       }
     ]
   })])


### PR DESCRIPTION
Specify the HTTP address of the Jenkins installation.

The address is written to a file when jenkins-controller VM is created.
Jenkins Configuration as Code plugin (JCasC) reads the address from that file.
