### PR TITLE
Use more specific disk names in hetzner

### DIFF
--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -30,7 +30,7 @@
       user-vunnyso
     ]);
 
-  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  nixpkgs.hostPlatform = "x86_64-linux";
   hardware.enableRedistributableFirmware = true;
 
   networking = {
@@ -46,4 +46,7 @@
       efiInstallAsRemovable = true;
     };
   };
+
+  # this server has been reinstalled with 24.05
+  system.stateVersion = lib.mkForce "24.05";
 }

--- a/hosts/ghaf-log/disk-config.nix
+++ b/hosts/ghaf-log/disk-config.nix
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   disko.devices.disk = {
-    sda = {
-      device = "/dev/sda";
+    os = {
+      device = "/dev/disk/by-path/pci-0000:06:00.0-scsi-0:0:0:0";
       type = "disk";
       content = {
         type = "gpt";


### PR DESCRIPTION
When hetzner cloud box is rebooted with a block volume attached, the block volume can become `/dev/sda` and the root disk change to `/dev/sdb`. Trying to deploy after this bricks the server as it tries to install grub onto the mounted block volume. 

Fix is to use more specific name for the disk. `pci-0000:06:00.0-scsi-0:0:0:0` should always point to the root disk.