### PR TITLE
Add restart trigger for sshified

### DIFF
--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -54,6 +54,7 @@ in {
 
   services.openssh.knownHosts = {
     "65.21.20.242".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    "95.217.177.197".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
   };
 
   # runs a tiny webserver on port 8888 that tunnels requests through ssh connection
@@ -73,6 +74,9 @@ in {
         -v
       '';
     };
+    restartTriggers = [
+      config.environment.etc."ssh/ssh_known_hosts".source
+    ];
   };
 
   services.grafana = {


### PR DESCRIPTION
Add missing public key for ghaf-log monitoring target and make the sshiefied service restart when known_hosts is changed.