### PR TITLE
Security hardening for ghaf logging server

### DIFF
--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -73,12 +73,22 @@
       server = {
         http_port = 3000;
         http_addr = "127.0.0.1";
+        domain = "ghaflogs.vedenemo.dev";
+        enforce_domain = true;
       };
 
       # disable telemetry
       analytics = {
         reporting_enabled = false;
         feedback_links_enabled = false;
+      };
+
+      # https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-security-hardening
+      security = {
+        cookie_secure = true;
+        cookie_samesite = "strict";
+        login_cookie_name = "__Host-grafana_session";
+        strict_transport_security = true;
       };
     };
 
@@ -99,7 +109,7 @@
 
   services.nginx = {
     virtualHosts = {
-      "ghaflogs.vedenemo.dev" = {
+      "${config.services.grafana.settings.server.domain}" = {
         enableACME = true;
         forceSSL = true;
         default = true;
@@ -108,7 +118,8 @@
           proxyWebsockets = true;
         };
       };
-      "loki.ghaflogs.vedenemo.dev" = {
+
+      "loki.${config.services.grafana.settings.server.domain}" = {
         enableACME = true;
         forceSSL = true;
         basicAuthFile = config.sops.secrets.loki_basic_auth.path;

--- a/hosts/ghaf-log/loki.nix
+++ b/hosts/ghaf-log/loki.nix
@@ -13,6 +13,7 @@ in {
       auth_enabled = false;
       server = {
         http_listen_port = 3100;
+        http_listen_address = "127.0.0.1";
         log_level = "warn";
       };
 

--- a/hosts/ghaf-log/secrets.yaml
+++ b/hosts/ghaf-log/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:2nCYQcgjV6SLUZIulp3FcL4rRwXW83RqyozdtN9qtzGtM3qdMO99t1PTGthRnT5i9q3LXkdgs2+VgXZ582IZX2HQDlJK9Zg2W2+At9W9y+2Mph6yPm57vQspPmJS1hQdoAab0L843Z2p6BNQH9/ZpHhdrIyW5e/oJ6mVmpJHGcNs86I2QoRvgi4EWDpluShpso0pNjrEUxw6G37luMIGo+u64wZ0+/VDpDFUmvg4kwbioFtnFPmd5frQAm/sw5murBziTGh8dCwdezWqCQDs9igYSOfbpFtCDn2Vhl4A32vLaOiQX/ay7m2PYVlLTZz2SK7C6QLfutx0rgLTf0hy0XlHo43jif2gANMH3lzIV5TpBSbleG+94qAUkL66+pZ48lZUSP57DojvertASvFcYv6qECTP9L51cb051XGWU3Auo7IY2o8L0xLQRWvjxLUfYMiZTSCe8Zlu3KFSI8neJHLqdEnFqit6ZeRFFcpeNxbi3JDzt8MHGLwJJJMAP6s4wgJmaAGTP9Mrb28scEYE,iv:dpKqu22dIhe5w3PziEPpZqTSgaC9la3LDdmiOnvdXLU=,tag:R+r5iDGDy0cPhYh/yGreNQ==,type:str]
+loki_basic_auth: ENC[AES256_GCM,data:WjRlJGwp1OYIfZYDd1tvAoW+yxko49NX4onrKY21tWJ20PTiEEfxpXJO,iv:eCXRu7tGyuZheQSz4k94nyQWRr0sndQOS5RPM7a5ZVE=,tag:Kw2WFYN2X5jbJfgL7e6K+A==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -8,23 +9,23 @@ sops:
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBocEZaZXBHcWdyRmgwRG1p
-            aGZRWlJCeGdobHZsMWpsNVoxTmlMOXJBVFdrCmllVzJONFZZYmozS0hyRHBmelhz
-            ODBiZi84MUhLMGRDSnpnelNUT2dzWmMKLS0tIHhBR21vUFM4ZWRRYTkyMjIvKzFz
-            K2Qwa3ZSSTFpNjZveUVvZis2NWY0S0UKx/1s6rZE6W8tl3+W/NrrITqHw900MHmA
-            FoJaw77oYKjeLdd7yG8FL6xMkJBTB1Ivj1KOhAQ2W2EZ0OlZoFOo3w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEMUt5TDJ1NWtWUS9ZNW5S
+            RzZCc1ZMNENYNmc1RWhucUNNbjh5bHc2ZkRjClJKWWowU2lGRS9HTWxEU3ljNXRZ
+            NXlaTllJOWpYMmxlc2tKT25MVUZUY1kKLS0tICtrRW4vcXBickU0Qk9LZXBjSVFS
+            VjJxUlNUeTlBY0w1aW5TZlFGY0NRMWcKyLjBIstV/hph1wxaCvmr1u+2tTsjEacG
+            Q0wtkZZ9bYlDcXlabkuG7x9DSd+clxTKZM6aRMaZ+1gj2cp+y6Vxug==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age17s9sc2cgt9t30cyl65zya8p4zmwnndrx2r896e7gzgl08sjn0qmq3t6shs
+        - recipient: age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaYjh2YjJ0NVJoMWl1Tnpy
-            U3NERkJPdXkvc2JoOVM3Slkwb3hrdjl4TlhnCjIvZWVVamZsZFRIc3ppVmFHbUcw
-            VWpweStiZFFRNU1YUmZGUEprUWxiYnMKLS0tIHF6citVcHJ0c3NsYWM0NWZsNi9n
-            Um56VGNaWmloWDNiWEVKZUhBd1VhdTQKrho7ofe8BhWFcqPDHjC5sdS7C2GR1wbv
-            4777q4QGXC3go+rL4AtY4uMHd5NuiuSr5SMI3YIKb/Q/o4j5h266oQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDcWdxVzRxVkVodUkyNlJG
+            N2h2bURWcjRpMC9RZjV6cUxOZzBzZHJycGs0CnFYMlhWb0wyNlNWYmE4R2l6RmlP
+            ekRKekFKbS9Nb2V6Y3Q0bnhBbjNZMjAKLS0tIGd1d1FWaG96eTV3T1poZjgvYjgw
+            RE8rU2lmakJRenVqemhjWUpxeUttRzgKFqd0iVZgbhib0J4eLaCg07xmTJ8uAk6G
+            XuEHIrV/3T34BttUo7boc/48caRjfvATYG3JWDotqJNyfDfAerGjgA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-19T10:13:52Z"
-    mac: ENC[AES256_GCM,data:/YaK/0NDBghEpLHBVyR/Kh+I+VE+IBM2aLYBfubbV8SKGoB63ic58fP+aYIJAsZQteoHVB2T/5QG3uhuJn1YG2MbF0/czOhiKRxYmxv2gUOmKFgeD8fmT2/z3Rr5Yoamxg1DAZKmaUeOZMhoiv7pPXFho4kJAt+oQwvH3Br22Ck=,iv:RvNE9HAAhsLgMS/ApK/ylAmTUI+eKfsf43Jm1ekkmoI=,tag:5upzy6NY2mAvvhO3boyVDA==,type:str]
+    lastmodified: "2024-07-26T11:55:57Z"
+    mac: ENC[AES256_GCM,data:cTyt3s+yeROJDEmYYfQKpc5cfOwxi9PFEQS7BNITpWowUZKESlnzYtofm4T3JvTnhut5JN0SgryMjccotKVmXBE8J6WKw6EmtWGHxiXoEBZ47kYxORUmJcrkLDb0K5xfAVA/xwF94BKLp8hL0bqTw2edXM7/q2mX/urmPYsFhHU=,iv:mWlU5/3n34rlTS31aWI7xAnvdDQhFwY3L5m85jP0OC8=,tag:RZ/yn9G5TFwybHgQbAH6XQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
- Grafana available at `https://ghaflogs.vedenemo.dev`, requires login to view.
- Loki push endpoint available at `https://loki.ghaflogs.vedenemo.dev`, behind basic auth username and password.
- Access using insecure ip:port and http no longer possible, firewall gaps closed.
- Applied security hardening options for Grafana.