### PR TITLE
testagent: Fix OrinAGX1 plug_type

### DIFF
--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -144,7 +144,7 @@ in {
         serial_port = "/dev/ttyACM0";
         device_ip_address = "172.18.16.36";
         socket_ip_address = "172.18.16.31";
-        plug_type = "TAPOP100";
+        plug_type = "TAPOP100v2";
         location = "testagent";
         usbhub_serial = "92D8AEB7";
         threads = 8;


### PR DESCRIPTION
Commit 7d960b8523eafcb2cb9be1e438ee2c248a4dcee0 changed the OrinAGX1 plug configuration type from TAPOP100v2 to TAPOP100, which apparently broke the boot tests on OrinAGX. This commit reverts the OrinAGX1 plug_type to what it was before 7d960b8523eafcb2cb9be1e438ee2c248a4dcee0.

Plug type TAPOP100 needs a fix in `ci-test-automation` repo, which will be done later with a separate PR: https://github.com/tiiuae/ci-test-automation/pull/125.