### PR TITLE
terraform-azurerm: Use azurerm v3.9.85

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -20,7 +20,23 @@
         sops
         ssh-to-age
         (terraform.withPlugins (p: [
-          p.azurerm
+          # We need to override the azurerm version to fix the issue described
+          # in https://ssrc.atlassian.net/browse/SP-4926.
+          # TODO:
+          # Below override is no longer needed when the azurerm version we
+          # get from the nixpkgs pinned in ghaf-infra flake includes a fix for
+          # https://github.com/hashicorp/terraform-provider-azurerm/issues/24444.
+          # At the time of writing, ghaf-infra flake pins to
+          # nixos-24.05, that ships with azurerm v3.97.1 which is broken.
+          # For more information on the available azurerm versions, see:
+          # https://registry.terraform.io/providers/hashicorp/azurerm.
+          (p.azurerm.override {
+            owner = "hashicorp";
+            repo = "terraform-provider-azurerm";
+            rev = "v3.85.0";
+            hash = "sha256-YXVSApUnJlwxIldDoijl72rA9idKV/vGRf0tAiaH8cc=";
+            vendorHash = null;
+          })
           p.external
           p.local
           p.null


### PR DESCRIPTION
Use azurerm version v3.9.85 which is the current latest version not impacted by the issue described in:
https://github.com/hashicorp/terraform-provider-azurerm/issues/24444.

As soon as there's an azurerm upstream fix for the issue, we should move the override to that version. The override will no longer be needed when the azurerm version we get from the nixpkgs pinned in ghaf-infra ships with azurerm version that includes the fix.