### PR TITLE
hosts/testagent: add usbsdmux 

### DIFF
--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -10,7 +10,8 @@
   pkgs,
   ...
 }: let
-  # Vendored in until our nixpkgs pin includes https://github.com/NixOS/nixpkgs/pull/302833.
+  # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
+  # https://github.com/NixOS/nixpkgs/pull/313643
   brainstem = pkgs.callPackage ./brainstem.nix {};
   jenkins-connection-script = pkgs.writeScript "jenkins-connect.sh" ''
     #!/usr/bin/env bash

--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -55,13 +55,14 @@ in {
     useNetworkd = true;
   };
 
-  # Enable Acroname USB Smart switch support.
-  services.udev.packages = [brainstem];
+  # Enable Acroname USB Smart switch, as well as LXA USB-SD-Mux support.
+  services.udev.packages = [brainstem pkgs.usbsdmux];
 
   environment.systemPackages = [
     inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
     brainstem
     pkgs.minicom
+    pkgs.usbsdmux
   ];
 
   # Disable suspend and hibernate - systemd settings


### PR DESCRIPTION
    We need it both in udev packages and systemPackages, as the package
    brings binaries to interact with it, and udev rules to control
    permissions.
    
    We still might need to tweak these, as they make use of the `uaccess`
    tag, which didn't seem to work for jenkins.