### PR TITLE
Github OAuth for ghaf-log grafana instance

### DIFF
--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -35,8 +35,13 @@
       user-vunnyso
     ]);
 
-  # basic auth credentials generated with htpasswd
-  sops.secrets.loki_basic_auth.owner = "nginx";
+  sops.secrets = {
+    # basic auth credentials generated with htpasswd
+    loki_basic_auth.owner = "nginx";
+    # github oauth app credentials
+    github_client_id.owner = "grafana";
+    github_client_secret.owner = "grafana";
+  };
 
   nixpkgs.hostPlatform = "x86_64-linux";
   hardware.enableRedistributableFirmware = true;
@@ -76,6 +81,11 @@
         http_addr = "127.0.0.1";
         domain = "ghaflogs.vedenemo.dev";
         enforce_domain = true;
+
+        # the default root_url is unaware of our nginx reverse proxy,
+        # and tries using http with port 3000 as the redirect url for auth.
+        # https://github.com/grafana/grafana/issues/11817#issuecomment-387131608
+        root_url = "https://%(domain)s/";
       };
 
       # disable telemetry
@@ -87,9 +97,32 @@
       # https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-security-hardening
       security = {
         cookie_secure = true;
-        cookie_samesite = "strict";
+        # we cannot use 'strict' here or github oauth cannot set the login cookie
+        cookie_samesite = "lax";
         login_cookie_name = "__Host-grafana_session";
         strict_transport_security = true;
+      };
+
+      # github OIDC
+      "auth.github" = {
+        enabled = true;
+        client_id = "$__file{${config.sops.secrets.github_client_id.path}}";
+        client_secret = "$__file{${config.sops.secrets.github_client_secret.path}}";
+
+        # only these orgs and teams are allowed login
+        # team IDs can be found with github api:
+        # $ curl -H "Authorization: $PAT" "https://api.github.com/orgs/tiiuae/teams?per_page=100" | jq '.[] | {name, id}'
+        allowed_organizations = [ "tiiuae" ];
+        team_ids = lib.strings.concatStringsSep "," [
+          "7362549" # devenv-fi
+          "4067903" # phone
+        ];
+
+        # map github teams to grafana roles
+        role_attribute_path = lib.strings.concatStringsSep " || " [
+          "contains(groups[*], '@tiiuae/devenv-fi') && 'GrafanaAdmin'"
+          "contains(groups[*], '@tiiuae/phone') && 'Editor'"
+        ];
       };
     };
 

--- a/hosts/ghaf-log/secrets.yaml
+++ b/hosts/ghaf-log/secrets.yaml
@@ -1,5 +1,7 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:2nCYQcgjV6SLUZIulp3FcL4rRwXW83RqyozdtN9qtzGtM3qdMO99t1PTGthRnT5i9q3LXkdgs2+VgXZ582IZX2HQDlJK9Zg2W2+At9W9y+2Mph6yPm57vQspPmJS1hQdoAab0L843Z2p6BNQH9/ZpHhdrIyW5e/oJ6mVmpJHGcNs86I2QoRvgi4EWDpluShpso0pNjrEUxw6G37luMIGo+u64wZ0+/VDpDFUmvg4kwbioFtnFPmd5frQAm/sw5murBziTGh8dCwdezWqCQDs9igYSOfbpFtCDn2Vhl4A32vLaOiQX/ay7m2PYVlLTZz2SK7C6QLfutx0rgLTf0hy0XlHo43jif2gANMH3lzIV5TpBSbleG+94qAUkL66+pZ48lZUSP57DojvertASvFcYv6qECTP9L51cb051XGWU3Auo7IY2o8L0xLQRWvjxLUfYMiZTSCe8Zlu3KFSI8neJHLqdEnFqit6ZeRFFcpeNxbi3JDzt8MHGLwJJJMAP6s4wgJmaAGTP9Mrb28scEYE,iv:dpKqu22dIhe5w3PziEPpZqTSgaC9la3LDdmiOnvdXLU=,tag:R+r5iDGDy0cPhYh/yGreNQ==,type:str]
 loki_basic_auth: ENC[AES256_GCM,data:WjRlJGwp1OYIfZYDd1tvAoW+yxko49NX4onrKY21tWJ20PTiEEfxpXJO,iv:eCXRu7tGyuZheQSz4k94nyQWRr0sndQOS5RPM7a5ZVE=,tag:Kw2WFYN2X5jbJfgL7e6K+A==,type:str]
+github_client_id: ENC[AES256_GCM,data:KhQtPeuMATu122vSb9kUrtICcWI=,iv:+8X1B31h8tqW5nHsKIxsy/Eh49faMfYC0CVcbqyhVes=,tag:7XODRd6NRo5vk5vIdOZ79Q==,type:str]
+github_client_secret: ENC[AES256_GCM,data:AY/1NgKgNOw8SrZb+T1C1vZCK9CV/lMEykY6lTPeycXW4vp4d0putQ==,iv:AqofLZQ1AG/FCHIo3jRDp3Xih1Envq6yugDDHlqD9/o=,tag:PPPdyQZZ1eRDFlXwVJcoYQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -24,8 +26,8 @@ sops:
             RE8rU2lmakJRenVqemhjWUpxeUttRzgKFqd0iVZgbhib0J4eLaCg07xmTJ8uAk6G
             XuEHIrV/3T34BttUo7boc/48caRjfvATYG3JWDotqJNyfDfAerGjgA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-07-26T11:55:57Z"
-    mac: ENC[AES256_GCM,data:cTyt3s+yeROJDEmYYfQKpc5cfOwxi9PFEQS7BNITpWowUZKESlnzYtofm4T3JvTnhut5JN0SgryMjccotKVmXBE8J6WKw6EmtWGHxiXoEBZ47kYxORUmJcrkLDb0K5xfAVA/xwF94BKLp8hL0bqTw2edXM7/q2mX/urmPYsFhHU=,iv:mWlU5/3n34rlTS31aWI7xAnvdDQhFwY3L5m85jP0OC8=,tag:RZ/yn9G5TFwybHgQbAH6XQ==,type:str]
+    lastmodified: "2024-08-15T07:33:54Z"
+    mac: ENC[AES256_GCM,data:Bt7VSB6HdVxh8ziTTMAdSW+eMrK6aS47gxPDAXrXqOTLsmo2Ckg5eWgwG7g+adPZIxGL64o+9BCd7mU7hKFCHMBliv+0LhoAa4H+f+YpIyeX3kh2aaloMTrjXvMokOMptlKj+XuHKKv8x4dyqoAMrGUIg2b8QRXAz1vAIdeEeUo=,iv:A1pFbB18P+lZ0selOAxwP/JSKup4WZchPWBJfI3+ycM=,tag:MzgqrnS3atvpsZg0HXcN8g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1


### PR DESCRIPTION
Navigating to https://ghaflogs.vedenemo.dev now presents the user with "Sign in with Github" button. If the logged in Github user is part of the `tiiuae` org, and the `devenv-fi` or `phone` teams, they are allowed access to the grafana instance. ~~The default grafana login with username and password is no longer possible.~~

Grafana account is created for every user when they first log in: 
![image](https://github.com/user-attachments/assets/85192d90-24fe-4db5-a7b0-e0e437cf21ae)
