### PR TITLE
Invoke terraform init with upgrade option

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,12 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
+      # Make sure this matches the version in ../nix/devshell.nix.
+      # This will not pin the version (it's pinned in devshell.nix),
+      # but makes terraform emit an error message in case the azurerm
+      # version cached in local .terraform directory for one reason
+      # or another does not match what is stated below.
+      version = "=3.85.0"
     }
     secret = {
       source = "numtide/secret"

--- a/terraform/terraform-init.sh
+++ b/terraform/terraform-init.sh
@@ -115,7 +115,7 @@ init_state_storage () {
     echo -e "storage_account_rg_name=$STATE_RG\nstorage_account_name=$STATE_ACCOUNT" >"$MYDIR/.env"
     # See: ./state-storage
     pushd "$MYDIR/state-storage" >"$OUT"
-    terraform init >"$OUT"
+    terraform init -upgrade >"$OUT"
     terraform workspace select "$SHORTLOC" &>"$OUT" || terraform workspace new "$SHORTLOC" >"$OUT"
     if ! terraform apply -var="location=$LOCATION" -auto-approve &>"$OUT"; then
         echo "[+] State storage is already initialized"
@@ -144,7 +144,7 @@ init_persistent () {
     # Init persistent, setting the backend resource group and storage account
     # names from command-line:
     # https://developer.hashicorp.com/terraform/language/settings/backends/azurerm#backend-azure-ad-user-via-azure-cli
-    terraform init -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
+    terraform init -upgrade -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
     terraform workspace select "$SHORTLOC" &>"$OUT" || terraform workspace new "$SHORTLOC" >"$OUT"
     import_bincache_sigkey "prod"
     import_bincache_sigkey "dev"
@@ -155,7 +155,7 @@ init_persistent () {
     echo "[+] Initializing workspace-specific persistent"
     # See: ./persistent/workspace-specific
     pushd "$MYDIR/persistent/workspace-specific" >"$OUT"
-    terraform init -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
+    terraform init -upgrade -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
     echo "[+] Applying possible changes in ./persistent/workspace-specific"
     for ws in "dev${SHORTLOC}" "prod${SHORTLOC}" "$WORKSPACE"; do
         terraform workspace select "$ws" &>"$OUT" || terraform workspace new "$ws" >"$OUT"
@@ -197,7 +197,7 @@ init_persistent () {
 init_terraform () {
     echo "[+] Running terraform init"
     pushd "$MYDIR" >"$OUT"
-    terraform init -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
+    terraform init -upgrade -backend-config="resource_group_name=$STATE_RG" -backend-config="storage_account_name=$STATE_ACCOUNT" >"$OUT"
     # By default, switch to the private workspace
     activate_workspace
     popd >"$OUT"

--- a/terraform/terraform-playground.sh
+++ b/terraform/terraform-playground.sh
@@ -112,7 +112,7 @@ main () {
     generate_azure_private_workspace_name
 
     # It is safe to run terraform init multiple times
-    terraform init
+    terraform init -upgrade
 
     # Run the given command
     if [ "$1" == "activate" ]; then


### PR DESCRIPTION
Make terraform emit an error message in case the azurerm version cached in local `.terraform` directory on the main terraform module does not match the version we require.

Make `terraform-init.sh` invoke the command `terraform init` with `-upgrage` option so the terraform plugin versions cached in local `.terraform` directory would be updated on updating the pinned terraform plugin versions - they are pinned in ghaf-infra flake devshell and should be updated when flake updates.