### PR TITLE
devshell.nix: add nixfmt-rfc-style

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -10,6 +10,7 @@
           git
           jq
           nix
+          nixfmt-rfc-style
           nixos-rebuild
           python3.pkgs.black
           python3.pkgs.colorlog


### PR DESCRIPTION
This ensures `nixfmt` is in $PATH too, which ensures text editors pick it up in case they're configured to use `nixfmt`.