### PR TITLE
jenkins-controller: Rename test pipeline

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -187,7 +187,7 @@ in
         }
         {
           job = {
-            name = "ghaf-test-boot";
+            name = "ghaf-hw-test";
             project-type = "pipeline";
             pipeline-scm = {
               scm = [
@@ -199,7 +199,7 @@ in
                   };
                 }
               ];
-              script-path = "ghaf-test-boot.groovy";
+              script-path = "ghaf-hw-test.groovy";
               lightweight-checkout = true;
             };
           };


### PR DESCRIPTION
Rename `ghaf-test-boot` to `ghaf-hw-test` after https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/45