### PR TITLE
Fix test-deployment.sh: Remove rclone restart

### DIFF
--- a/terraform/test-deployment.sh
+++ b/terraform/test-deployment.sh
@@ -178,9 +178,6 @@ test_build_end_to_end () {
     # Trigger a build on jenkins-controller, returning the build output hash
     hash=$(trigger_build "$controller" "$arch")
     if [ -z "$hash" ]; then exit 1; fi
-    # Restart rclone-http to make sure the uploaded build result is available
-    # in the exposed binary cache API
-    exec_ssh_cmd "sudo systemctl restart rclone-http" "$bincache"
     # Request narinfo given the build hash we just generated
     narinfo=$(get_narinfo "$bincache" "$hash")
     if [ -z "$narinfo" ]; then exit 1; fi


### PR DESCRIPTION
After https://github.com/tiiuae/ghaf-infra/pull/228, Azure binary-cache no longer runs rclone-http. This change removes the manual rclone-http service restart from the test-deployment.sh script as it is no longer needed (and triggers an error in the test script).