### PR TITLE
testagent: Fix riscv support

### DIFF
--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -66,6 +66,7 @@ in
   # udev rules for test devices serial connections
   services.udev.extraRules = ''
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD1BQQS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="0642246B630C149011EC987B167DB04", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
   '';
 
   environment.systemPackages = [
@@ -175,7 +176,7 @@ in
         threads = 20;
       };
       Polarfire1 = {
-        serial_port = "/dev/ttyUSB3";
+        serial_port = "/dev/ttyRISCV1";
         device_ip_address = "";
         socket_ip_address = "172.18.16.45";
         plug_type = "TAPOP100v2";

--- a/hosts/testagent/hardware-configuration.nix
+++ b/hosts/testagent/hardware-configuration.nix
@@ -25,7 +25,10 @@
     "rtsx_pci_sdmmc"
   ];
   boot.initrd.kernelModules = [ ];
-  boot.kernelModules = [ "kvm-intel" ];
+  boot.kernelModules = [
+    "kvm-intel"
+    "sg"
+  ];
   boot.extraModulePackages = [ ];
 
   fileSystems."/" = {


### PR DESCRIPTION
This commit includes the following changes based on intial testing with the riscv HW on `testagent`:

- Add udev rule for riscv serial connection symlinking it to `/dev/ttyRISCV1`
- Change jenkins test config to make it use the new `/dev/ttyRISCV1` serial port for `Polarfire1` configuration
- Add kernel module `sg` to testagent configuration, this is needed by usbsdmux: https://github.com/linux-automation/usbsdmux#troubleshooting