### PR TITLE
Add wheel to nix trusted users for all hosts

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -22,9 +22,11 @@ in
     nixPath = lib.mapAttrsToList (key: value: "${key}=${value.to.path}") config.nix.registry;
 
     settings = {
-      # root is trusted by default, but only when other users aren't specified.
-      # this line is here to merge the arrays when additional users are added
-      trusted-users = [ "root" ];
+      # We can trust root and any users with sudo rights
+      trusted-users = [
+        "root"
+        "@wheel"
+      ];
       # Enable flakes and new 'nix' command
       experimental-features = "nix-command flakes";
       # Subsituters


### PR DESCRIPTION
Add any wheel users as nix trusted users, this fixes trusted key issues that occasionally show up when deploying locally built changes on remote machines:

```
copying path '/nix/store/...' to 'ssh://xxx'
error: cannot add path '/nix/store/...' because it lacks a signature by a trusted key
```

https://github.com/NixOS/nixpkgs/issues/159082#issuecomment-1118968571