### PR TITLE
Add initial configuration for ghaf-coverity server

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -17,6 +17,7 @@ keys:
   - &build3 age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
   - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
+  - &ghaf-coverity age172azvwv5vne79mqfhvdvk9j95gn5v04uk9t3fjdfe5p7dv7kucvqpygxkx
 
 creation_rules:
   - path_regex: terraform/azarm/secrets.yaml$
@@ -61,4 +62,9 @@ creation_rules:
     key_groups:
     - age:
       - *ghaf-log
+      - *jrautiola
+  - path_regex: hosts/ghaf-coverity/secrets.yaml$
+    key_groups:
+    - age:
+      - *ghaf-coverity
       - *jrautiola

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -53,6 +53,7 @@ in
     nixos-testagent = ./testagent/configuration.nix;
     nixos-testagent-dev = ./testagent-dev/configuration.nix;
     nixos-ghaf-log = ./ghaf-log/configuration.nix;
+    nixos-ghaf-coverity = ./ghaf-coverity/configuration.nix;
   };
 
   # Expose as flake.lib.mkNixOS.
@@ -81,6 +82,7 @@ in
         "testagent"
         "testagent-dev"
         "ghaf-log"
+        "ghaf-coverity"
       ]
   );
 }

--- a/hosts/ghaf-coverity/configuration.nix
+++ b/hosts/ghaf-coverity/configuration.nix
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  inputs,
+  modulesPath,
+  lib,
+  ...
+}:
+{
+  sops.defaultSopsFile = ./secrets.yaml;
+
+  imports =
+    [
+      ./disk-config.nix
+      (modulesPath + "/profiles/qemu-guest.nix")
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
+      common
+      service-openssh
+      user-jrautiola
+      user-ktu
+    ]);
+
+  # this server has been installed with 24.05
+  system.stateVersion = lib.mkForce "24.05";
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  hardware.enableRedistributableFirmware = true;
+
+  networking = {
+    hostName = "ghaf-coverity";
+    useDHCP = true;
+  };
+
+  boot = {
+    # use predictable network interface names (eth0)
+    kernelParams = [ "net.ifnames=0" ];
+    loader.grub = {
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+    };
+  };
+}

--- a/hosts/ghaf-coverity/configuration.nix
+++ b/hosts/ghaf-coverity/configuration.nix
@@ -22,6 +22,7 @@
       service-openssh
       user-jrautiola
       user-ktu
+      user-fayad
     ]);
 
   # this server has been installed with 24.05

--- a/hosts/ghaf-coverity/disk-config.nix
+++ b/hosts/ghaf-coverity/disk-config.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_52101387";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "512M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/ghaf-coverity/secrets.yaml
+++ b/hosts/ghaf-coverity/secrets.yaml
@@ -1,0 +1,30 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:ilXl33AwzQmAzaVtGK6FcPwLgI/9Cr79ah6ToRzKmg7meHPEt+aAKhmKBHHW0Pu5G+Ga4woWLkydveUpuMqA4YSQFfGgBsroNnPQ20BnKMC8exXdh0GR+35O0JvMvMxYQx1fN7d9x8bI4C30qIpWNxyV6uwrA+hoPt1HT+hrTNf0jyfwz4UsEfcd7yH8AjrS/oJvlep19M7ZWicfcUb6AFQmLNR20UE24IHIozptFv2QKndmjFr9SEbgDetc1Y75R2JAW545vp6ZvFxHOtf3GVPmhOhIXlkdBnPNrVZ8c+Ygq0VGAkGFRQagSG1fHZArwRFnXShZT/npYW5xelKlJgZiRCR8KF31Gn0UfJsw/WLxCJ60unFwd8qTVkEFpjB4e/JI7ybjd1NqlkwWa0EDBa+xjKh4/VshtxZl4XoCfwoJRkzC8ML93HA2LgOmvdfVMhZpMLpoCHiFr0ACLzsIEICShFFNCk6iMJJXjotwid1FuXvro2W+qKRWAep+qKwoFsBIsySoiAMmaXhcwV3Wd5oXW4xHge++1G0/,iv:pw443wskOHT5z8jS0wV+D4FgqVkhESa4TQqjKB1LjT8=,tag:L+ntfxoM8WLmwbI8OVo8jw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age172azvwv5vne79mqfhvdvk9j95gn5v04uk9t3fjdfe5p7dv7kucvqpygxkx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvY0Rxa0hJTXBpaGhQME9w
+            SzZTdHlrVFFaeVhDTUxzYjB1VHIxNUhLSWdnCkxxY2Jpd0cvTWFTOFJCQkZQNHFu
+            K3RwY3dDKy9DL3g2TWIxT1BVYlhPalUKLS0tIFhNd3Rpc3BKRVdSSnJiTHFKTkFm
+            UXB3eVI2cUNacm4xWnltc2pxTFFIalkK4LMlFdwqjggE05rPQdxMfpDP0ezCWsQI
+            wbR72DGVQcr901mmpIryE3qY6ACkBLF8r5pJOtIa2PxYXcnOFkPfYQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwUXdBeWVzYXB5NE1EN01P
+            aWhVSVhlUFpPRGEwMWdrUkd5UlBNYklqUEd3ClBTVWRER1pkRFpzOC9nTlkwUGNz
+            b2pvdG5oZnVzMDdlcUp0ZCtLbXJ0Y2sKLS0tIDMrKzY2MWI4QVlsUWxzd1ZwNFdw
+            U1p2c2FVRVk1Tlh5bjR2bWxhUnVTQkEKmAtSSrPdSBVQB5tMIQvgljqxb9Hd8WV8
+            c//R9nH5xcwIUqU9V0XDRqtF/g4zTEbw/NvnUcFy36qko4DBxl05+A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-09-11T11:38:32Z"
+    mac: ENC[AES256_GCM,data:r/7H97Vxzom8vK3DMp+BaVASCoDefCY4JOVyTYAI8jIfOpPGkFm1sB4LgmcYM+u2aqqxyD5z3J9Ytg812gzuRK03BXhm3rVLbg7DonagBdkbEZvw2vXF8qrplvRJFOYsHRSIa3Gyqiyz0J9542SzdMnIJ0yRVcy902rQS9AeMfg=,iv:Ab+AGKlTESd48qXxiPFWcmM4s2RCqhjjIFdETCYt0bw=,tag:tqzzvzKWACkS6MRvexLe6Q==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -21,6 +21,7 @@ let
     testagent = mkDeployment "x86_64-linux" "testagent" "172.18.16.60";
     testagent-dev = mkDeployment "x86_64-linux" "testagent-dev" "172.18.16.33";
     ghaf-log = mkDeployment "x86_64-linux" "ghaf-log" "95.217.177.197";
+    ghaf-coverity = mkDeployment "x86_64-linux" "ghaf-coverity" "37.27.204.82";
   };
 
   aarch64-nodes = {

--- a/tasks.py
+++ b/tasks.py
@@ -107,6 +107,10 @@ TARGETS = OrderedDict(
             hostname="95.217.177.197",
             nixosconfig="ghaf-log",
         ),
+        "ghaf-coverity": TargetHost(
+            hostname="37.27.204.82",
+            nixosconfig="ghaf-coverity",
+        ),
     }
 )
 

--- a/users/default.nix
+++ b/users/default.nix
@@ -21,5 +21,6 @@
     user-vilvo = import ./vilvo.nix;
     user-vunnyso = import ./vunnyso.nix;
     user-bmg = import ./bmg.nix;
+    user-fayad = import ./fayad.nix;
   };
 }

--- a/users/fayad.nix
+++ b/users/fayad.nix
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    fayad = {
+      description = "Fayad Fami";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKn694TOPl6NvWsFYj2dfO4Lv083Tv7mQRPv9Ik+jxcY fayad@3seven"
+      ];
+      extraGroups = [ "wheel" ];
+    };
+  };
+}


### PR DESCRIPTION
Adds new Hetzner VM host: `ghaf-coverity`, with barebones NixOS configuration, and admin user for Fayad.