### PR TITLE
jenkins-controller: Increase stage view rows

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -121,6 +121,8 @@ in
       "-Dhudson.model.DirectoryBrowserSupport.CSP=\"sandbox allow-scripts; default-src 'none'; img-src 'self' data: ; style-src 'self' 'unsafe-inline' data: ; script-src 'self' 'unsafe-inline' 'unsafe-eval';\""
       # Point to configuration-as-code config
       "-Dcasc.jenkins.config=${jenkins-casc}"
+      # Increase the number of rows shown in Stage View (default is 10)
+      "-Dcom.cloudbees.workflow.rest.external.JobExt.maxRunsPerJob=32"
     ];
     # Configure jenkins job(s):
     # https://jenkins-job-builder.readthedocs.io/en/latest/project_pipeline.html


### PR DESCRIPTION
Increase the number of rows shown in the 'Stage View' for all pipelines. The default seems to be 10 rows, this commit changes it to 32 rows to be able to glance the Stage View build history a bit further.