### PR TITLE
Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -90,7 +90,7 @@ jobs:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
             fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@V28
         with:
           extra_nix_config: |
             trusted-public-keys = cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cachix/install-nix-action](https://github.com/cachix/install-nix-action)** published a new release **[V28](https://github.com/cachix/install-nix-action/releases/tag/V28)** on 2024-09-12T10:19:18Z
