### PR TITLE
Add nix-eval-jobs to jenkins path

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -107,6 +107,7 @@ in
         jq
         csvkit
         curl
+        nix-eval-jobs
       ]
       ++ [
         rclone # used to copy artifacts


### PR DESCRIPTION
Required for parallel building