### PR TITLE
Run multiple Jenkins agent services simultaneously

### DIFF
--- a/hosts/testagent-dev/configuration.nix
+++ b/hosts/testagent-dev/configuration.nix
@@ -4,12 +4,87 @@
   self,
   inputs,
   pkgs,
+  config,
   ...
 }:
 let
   # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
   # https://github.com/NixOS/nixpkgs/pull/313643
   brainstem = pkgs.callPackage ../../pkgs/brainstem { };
+
+  mkAgent =
+    device:
+    let
+      # Temporary url for development
+      controllerUrl = "https://ghaf-jenkins-controller-joonasrautiola.northeurope.cloudapp.azure.com";
+      workDir = "/var/lib/jenkins/agents/${device}";
+
+      jenkins-connection-script =
+        pkgs.writeScript "jenkins-connect.sh" # sh
+          ''
+            #!/usr/bin/env bash
+            set -eu
+
+            mkdir -p "${workDir}"
+
+            # get agent.jar
+            if [ ! -f agent.jar ]; then
+              wget "${controllerUrl}/jnlpJars/agent.jar"
+            fi
+
+            # TODO: get secret from jenkins api here, right now it's manual process
+            if [ ! -f "secret_${device}" ]; then echo "Error: /var/lib/jenkins/secret_${device} not found"; exit 1; fi;
+
+            ${pkgs.jdk}/bin/java \
+              -jar agent.jar \
+              -url "${controllerUrl}" \
+              -name "testagent_${device}" \
+              -secret "@secret_${device}" \
+              -workDir "${workDir}" \
+              -webSocket
+          '';
+    in
+    {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      # Give up if it fails more than 5 times in 60 second interval
+      startLimitBurst = 5;
+      startLimitIntervalSec = 60;
+
+      path =
+        [
+          brainstem
+          inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+        ]
+        ++ (with pkgs; [
+          wget
+          jdk
+          git
+          bashInteractive
+          coreutils
+          util-linux
+          nix
+          zstd
+          jq
+          csvkit
+          sudo
+          openssh
+          iputils
+          netcat
+          python3
+          usbsdmux
+        ]);
+
+      serviceConfig = {
+        Type = "simple";
+        User = "jenkins";
+        WorkingDirectory = "/var/lib/jenkins";
+        ExecStart = "${jenkins-connection-script}";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
 in
 {
   imports =
@@ -64,19 +139,11 @@ in
     cpu.intel.updateMicrocode = true;
   };
 
-  services.udev = {
-    # Enable Acroname USB Smart switch, as well as LXA USB-SD-Mux support.
-    packages = [
-      brainstem
-      pkgs.usbsdmux
-    ];
-
-    # udev rules for test devices serial connections
-    extraRules = ''
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD1BQQS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="0642246B630C149011EC987B167DB04", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
-    '';
-  };
+  # Enable Acroname USB Smart switch, as well as LXA USB-SD-Mux support.
+  services.udev.packages = [
+    brainstem
+    pkgs.usbsdmux
+  ];
 
   environment.systemPackages =
     [
@@ -88,6 +155,48 @@ in
       usbsdmux
     ]);
 
+  # The Jenkins slave service is very barebones
+  # it only installs java and sets up jenkins user
+  services.jenkinsSlave.enable = true;
+
+  # Jenkins needs sudo and serial rights to perform the HW tests
+  users.users.jenkins.extraGroups = [
+    "wheel"
+    "dialout"
+    "tty"
+  ];
+
+  # Agent services per hardware test device
+  systemd.services = {
+    agent-orin-agx = mkAgent "orin-agx";
+    agent-orin-nx = mkAgent "orin-nx";
+  };
+
   # Details of the hardware devices connected to this host
-  environment.etc."jenkins/test_config.json".text = builtins.toJSON { addresses = { }; };
+  environment.etc."jenkins/test_config.json".text =
+    let
+      location = config.networking.hostName;
+    in
+    builtins.toJSON {
+      addresses = {
+        OrinAGX1 = {
+          inherit location;
+          serial_port = "/dev/ttyACM0";
+          device_ip_address = "172.18.16.54";
+          socket_ip_address = "172.18.16.74";
+          plug_type = "TAPOP100v2";
+          usbhub_serial = "0x2954223B";
+          threads = 8;
+        };
+        OrinNX1 = {
+          inherit location;
+          serial_port = "/dev/ttyUSB0";
+          device_ip_address = "172.18.16.61";
+          socket_ip_address = "172.18.16.95";
+          plug_type = "TAPOP100v2";
+          usbhub_serial = "0xEE92E4FD";
+          threads = 8;
+        };
+      };
+    };
 }


### PR DESCRIPTION
Run one agent for each hardware test device connected to the testagent-dev machine. This enables future work for running the tests in parallel by utilizing different nodes (jenkins side still in progress).