### PR TITLE
rclone: refer to rclone version including patches

### DIFF
--- a/pkgs/rclone/default.nix
+++ b/pkgs/rclone/default.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 { pkgs, ... }:
 pkgs.rclone.overrideAttrs (oldAttrs: {
+  # These will be included in rclone v1.68.0
   patches = (oldAttrs.patches or [ ]) ++ [
     # https://github.com/rclone/rclone/pull/7801
     ./http-socket-activation.patch


### PR DESCRIPTION
This links to the comment, so once we bump nixpkgs to a version including rclong 1.68.0 we know we can just drop this entirely.