### PR TITLE
az-jenkins-controller: jenkins-config needs mount

### DIFF
--- a/hosts/azure/binary-cache/configuration.nix
+++ b/hosts/azure/binary-cache/configuration.nix
@@ -42,7 +42,7 @@ in
   # Due to an implicit RequiresMountsFor=$state-dir, systemd
   # will block starting the service until this mounted.
   fileSystems."/var/lib/caddy" = {
-    device = "/dev/disk/by-lun/10";
+    device = "/dev/disk/azure/scsi1/lun10";
     fsType = "ext4";
     options = [
       "x-systemd.makefs"

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -71,7 +71,7 @@ in
   # Due to an implicit RequiresMountsFor=$state-dir, systemd
   # will block starting the service until this mounted.
   fileSystems."/var/lib/jenkins" = {
-    device = "/dev/disk/by-lun/10";
+    device = "/dev/disk/azure/scsi1/lun10";
     fsType = "ext4";
     options = [
       "x-systemd.makefs"
@@ -83,7 +83,7 @@ in
   # Due to an implicit RequiresMountsFor=$state-dir, systemd
   # will block starting the service until this mounted.
   fileSystems."/var/lib/caddy" = {
-    device = "/dev/disk/by-lun/11";
+    device = "/dev/disk/azure/scsi1/lun11";
     fsType = "ext4";
     options = [
       "x-systemd.makefs"

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -274,6 +274,7 @@ in
     serviceConfig = {
       Restart = "on-failure";
       RestartSec = 5;
+      RequiresMountsFor = "/var/lib/jenkins";
     };
     script =
       let


### PR DESCRIPTION
Add RequiresMountsFor=/var/lib/jenkins to jenkins-config.service.

There's no point starting this before /var/lib/jenkins is mounted, as we read the admin password from there to interact with the jenkins API.