### PR TITLE
hosts/azure: explicitly disable caddy reloads

### DIFF
--- a/hosts/azure/binary-cache/configuration.nix
+++ b/hosts/azure/binary-cache/configuration.nix
@@ -71,6 +71,7 @@ in
   # keys only, disallowing listing too.
   services.caddy = {
     enable = true;
+    enableReload = false;
     configFile = pkgs.writeText "Caddyfile" ''
       # Disable the admin API, we don't want to reconfigure Caddy at runtime.
       {

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -503,6 +503,7 @@ in
 
   services.caddy = {
     enable = true;
+    enableReload = false;
     configFile = pkgs.writeText "Caddyfile" ''
       # Disable the admin API, we don't want to reconfigure Caddy at runtime.
       {


### PR DESCRIPTION
This option defaults to true, but we disable the admin API.

When manually copying new system closures and activating them (for testing purposes), this causes the activation to hang.