### PR TITLE
Add wget to devshell

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -23,6 +23,7 @@
           sops
           ssh-to-age
           deploy-rs
+          wget
           (terraform.withPlugins (p: [
             # We need to override the azurerm version to fix the issue described
             # in https://ssrc.atlassian.net/browse/SP-4926.


### PR DESCRIPTION
wget is assumed to be installed when running `scripts/get-artifacts.sh`:

```
Error: command 'wget' is not installed (Hint: are you inside a nix-shell?)
```

but wget is not actually part of the devshell.