### PR TITLE
Increase image storage timeouts

### DIFF
--- a/terraform/modules/azurerm-nix-vm-image/main.tf
+++ b/terraform/modules/azurerm-nix-vm-image/main.tf
@@ -9,6 +9,9 @@ resource "azurerm_storage_blob" "default" {
   source                 = "${data.external.nix_build.result.outPath}/disk.vhd"
   timeouts {
     create = "1h"
+    update = "1h"
+    read   = "1h"
+    delete = "1h"
   }
 }
 


### PR DESCRIPTION
Increase image blob storage timeouts that were not increased by: https://github.com/tiiuae/ghaf-infra/pull/220

See: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_blob#timeouts