### PR TITLE
Automate creation of HW test nodes and fetching of secrets

### DIFF
--- a/hosts/agents-common.nix
+++ b/hosts/agents-common.nix
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{ pkgs, inputs, ... }:
+let
+  # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
+  # https://github.com/NixOS/nixpkgs/pull/313643
+  brainstem = pkgs.callPackage ../pkgs/brainstem { };
+in
+{
+  services.udev.packages = [
+    brainstem
+    pkgs.usbsdmux
+  ];
+
+  environment.systemPackages =
+    [
+      inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+      brainstem
+    ]
+    ++ (with pkgs; [
+      minicom
+      usbsdmux
+    ]);
+
+  # The Jenkins slave service is very barebones
+  # it only installs java and sets up jenkins user
+  services.jenkinsSlave.enable = true;
+
+  # Jenkins needs sudo and serial rights to perform the HW tests
+  users.users.jenkins.extraGroups = [
+    "wheel"
+    "dialout"
+    "tty"
+  ];
+
+  systemd.services =
+    let
+      # verifies that the environment file is properly configured
+      # and downloads agent.jar from the controller
+      jenkins-setup-script = pkgs.writeShellScript "jenkins-setup.sh" ''
+        if [[ ! -f jenkins.env ]]; then
+          install -m 600 /dev/null jenkins.env
+          echo "CONTROLLER=" > jenkins.env
+          echo "ADMIN_PASSWORD=" >> jenkins.env
+          echo "Please add jenkins controller details to $(pwd)/jenkins.env"
+          exit 1
+        fi
+
+        source jenkins.env
+
+        if [[ -z "$CONTROLLER" ]]; then
+          echo "Variable CONTROLLER not set in $(pwd)/jenkins.env"
+          exit 1
+        fi
+
+        if [[ -z "$ADMIN_PASSWORD" ]]; then
+          echo "Variable ADMIN_PASSWORD not set in $(pwd)/jenkins.env"
+          exit 1
+        fi
+
+        curl -O "$CONTROLLER/jnlpJars/agent.jar"
+      '';
+
+      # Helper function to create agent services for each hardware device
+      mkAgent =
+        device:
+        let
+          # opens a websocket connection to the jenkins controller from this agent
+          jenkins-connect-script = pkgs.writeShellScript "jenkins-connect.sh" ''
+            JENKINS_SECRET="$(
+              curl --proto =https -u admin:$ADMIN_PASSWORD \
+              $CONTROLLER/computer/${device}/jenkins-agent.jnlp | 
+              sed "s/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/"
+            )"
+
+            mkdir -p "/var/lib/jenkins/agents/${device}"
+
+            ${pkgs.jdk}/bin/java \
+              -jar agent.jar \
+              -url "$CONTROLLER" \
+              -name "${device}" \
+              -secret "$JENKINS_SECRET" \
+              -workDir "/var/lib/jenkins/agents/${device}" \
+              -webSocket
+          '';
+        in
+        {
+          # agents require the setup service to run without errors before starting
+          requires = [ "setup-agents.service" ];
+          wantedBy = [ "setup-agents.service" ];
+          after = [ "setup-agents.service" ];
+
+          path =
+            [
+              brainstem
+              inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+            ]
+            ++ (with pkgs; [
+              curl
+              wget
+              jdk
+              git
+              bashInteractive
+              coreutils
+              util-linux
+              nix
+              zstd
+              jq
+              csvkit
+              sudo
+              openssh
+              iputils
+              netcat
+              python3
+              usbsdmux
+            ]);
+
+          serviceConfig = {
+            Type = "simple";
+            User = "jenkins";
+            EnvironmentFile = "/var/lib/jenkins/jenkins.env";
+            WorkingDirectory = "/var/lib/jenkins";
+            ExecStart = "${jenkins-connect-script}";
+          };
+        };
+    in
+    {
+      # the setup service does not start automatically or it would fail activation
+      # of the system since jenkins.env is empty before manually set up
+      setup-agents = {
+        path = with pkgs; [ curl ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = "jenkins";
+          RemainAfterExit = "yes";
+          WorkingDirectory = "/var/lib/jenkins";
+          ExecStart = "${jenkins-setup-script}";
+        };
+      };
+
+      # one agent per unique hardware device to act as a lock
+      agent-orin-agx = mkAgent "orin-agx";
+      agent-orin-nx = mkAgent "orin-nx";
+      agent-riscv = mkAgent "riscv";
+      agent-nuc = mkAgent "nuc";
+      agent-lenovo-x1 = mkAgent "lenovo-x1";
+    };
+}

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -7,6 +7,7 @@ jenkins:
   agentProtocols:
   - "JNLP4-connect"
   - "Ping"
+
   authorizationStrategy: "loggedInUsersCanDoAnything"
   crumbIssuer:
     standard:
@@ -14,6 +15,44 @@ jenkins:
   disableRememberMe: false
   labelAtoms:
   - name: "built-in"
+  - name: "lenovo-x1"
+  - name: "nuc"
+  - name: "orin-agx"
+  - name: "orin-nx"
+  - name: "riscv"
+
+  nodes:
+  - permanent:
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      name: "lenovo-x1"
+      remoteFS: "/var/lib/jenkins/agents/lenovo-x1"
+      retentionStrategy: "always"
+  - permanent:
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      name: "nuc"
+      remoteFS: "/var/lib/jenkins/agents/nuc"
+      retentionStrategy: "always"
+  - permanent:
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      name: "orin-agx"
+      remoteFS: "/var/lib/jenkins/agents/orin-agx"
+      retentionStrategy: "always"
+  - permanent:
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      name: "orin-nx"
+      remoteFS: "/var/lib/jenkins/agents/orin-nx"
+      retentionStrategy: "always"
+  - permanent:
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      name: "riscv"
+      remoteFS: "/var/lib/jenkins/agents/riscv"
+      retentionStrategy: "always"
+
   markupFormatter:
     rawHtml:
       disableSyntaxHighlighting: false

--- a/hosts/testagent-dev/configuration.nix
+++ b/hosts/testagent-dev/configuration.nix
@@ -11,80 +11,6 @@ let
   # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
   # https://github.com/NixOS/nixpkgs/pull/313643
   brainstem = pkgs.callPackage ../../pkgs/brainstem { };
-
-  mkAgent =
-    device:
-    let
-      # Temporary url for development
-      controllerUrl = "https://ghaf-jenkins-controller-villepekkajuntun.northeurope.cloudapp.azure.com";
-      workDir = "/var/lib/jenkins/agents/${device}";
-
-      jenkins-connection-script =
-        pkgs.writeScript "jenkins-connect.sh" # sh
-          ''
-            #!/usr/bin/env bash
-            set -eu
-
-            mkdir -p "${workDir}"
-
-            # get agent.jar
-            if [ ! -f agent.jar ]; then
-              wget "${controllerUrl}/jnlpJars/agent.jar"
-            fi
-
-            # TODO: get secret from jenkins api here, right now it's manual process
-            if [ ! -f "secret_${device}" ]; then echo "Error: /var/lib/jenkins/secret_${device} not found"; exit 1; fi;
-
-            ${pkgs.jdk}/bin/java \
-              -jar agent.jar \
-              -url "${controllerUrl}" \
-              -name "${device}" \
-              -secret "@secret_${device}" \
-              -workDir "${workDir}" \
-              -webSocket
-          '';
-    in
-    {
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-
-      # Give up if it fails more than 5 times in 60 second interval
-      startLimitBurst = 5;
-      startLimitIntervalSec = 60;
-
-      path =
-        [
-          brainstem
-          inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-        ]
-        ++ (with pkgs; [
-          wget
-          jdk
-          git
-          bashInteractive
-          coreutils
-          util-linux
-          nix
-          zstd
-          jq
-          csvkit
-          sudo
-          openssh
-          iputils
-          netcat
-          python3
-          usbsdmux
-        ]);
-
-      serviceConfig = {
-        Type = "simple";
-        User = "jenkins";
-        WorkingDirectory = "/var/lib/jenkins";
-        ExecStart = "${jenkins-connection-script}";
-        Restart = "on-failure";
-        RestartSec = 5;
-      };
-    };
 in
 {
   imports =
@@ -176,14 +102,117 @@ in
     "tty"
   ];
 
-  # Agent services per hardware test device
-  systemd.services = {
-    agent-orin-agx = mkAgent "orin-agx";
-    agent-orin-nx = mkAgent "orin-nx";
-    agent-riscv = mkAgent "riscv";
-    agent-nuc = mkAgent "nuc";
-    agent-lenovo-x1 = mkAgent "lenovo-x1";
-  };
+  systemd.services =
+    let
+      # verifies that the environment file is properly configured
+      # and downloads agent.jar from the controller
+      jenkins-setup-script = pkgs.writeShellScript "jenkins-setup.sh" ''
+        if [[ ! -f jenkins.env ]]; then
+          echo "Please add jenkins controller details to $(pwd)/jenkins.env"
+          echo "CONTROLLER=" > jenkins.env
+          echo "ADMIN_PASSWORD=" >> jenkins.env
+          exit 1
+        fi
+
+        source jenkins.env
+
+        if [[ -z "$CONTROLLER" ]]; then
+          echo "Variable CONTROLLER not set in $(pwd)/jenkins.env"
+          exit 1
+        fi
+
+        if [[ -z "$ADMIN_PASSWORD" ]]; then
+          echo "Variable ADMIN_PASSWORD not set in $(pwd)/jenkins.env"
+          exit 1
+        fi
+
+        wget "$CONTROLLER/jnlpJars/agent.jar"
+      '';
+
+      # Helper function to create agent services for each hardware device
+      mkAgent =
+        device:
+        let
+          # opens a websocket connection to the jenkins controller from this agent
+          jenkins-connect-script = pkgs.writeShellScript "jenkins-connect.sh" ''
+            JENKINS_SECRET="$(
+              curl -L -s -u admin:$ADMIN_PASSWORD \
+              $CONTROLLER/computer/${device}/jenkins-agent.jnlp | 
+              sed "s/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/"
+            )"
+
+            mkdir -p "/var/lib/jenkins/agents/${device}"
+
+            ${pkgs.jdk}/bin/java \
+              -jar agent.jar \
+              -url "$CONTROLLER" \
+              -name "${device}" \
+              -secret "$JENKINS_SECRET" \
+              -workDir "/var/lib/jenkins/agents/${device}" \
+              -webSocket
+          '';
+        in
+        {
+          # agents require the setup service to run without errors before starting
+          requires = [ "setup-agents.service" ];
+          wantedBy = [ "setup-agents.service" ];
+          after = [ "setup-agents.service" ];
+
+          path =
+            [
+              brainstem
+              inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+            ]
+            ++ (with pkgs; [
+              curl
+              wget
+              jdk
+              git
+              bashInteractive
+              coreutils
+              util-linux
+              nix
+              zstd
+              jq
+              csvkit
+              sudo
+              openssh
+              iputils
+              netcat
+              python3
+              usbsdmux
+            ]);
+
+          serviceConfig = {
+            Type = "simple";
+            User = "jenkins";
+            EnvironmentFile = "/var/lib/jenkins/jenkins.env";
+            WorkingDirectory = "/var/lib/jenkins";
+            ExecStart = "${jenkins-connect-script}";
+          };
+        };
+    in
+    {
+      # the setup service does not start automatically or it would fail activation
+      # of the system since jenkins.env is empty before manually set up
+      setup-agents = {
+        path = with pkgs; [ wget ];
+        serviceConfig = {
+          Type = "oneshot";
+          User = "jenkins";
+          RemainAfterExit = "yes";
+          WorkingDirectory = "/var/lib/jenkins";
+          ExecStart = "${jenkins-setup-script}";
+        };
+      };
+
+      # one agent per unique hardware device to act as a lock
+      agent-orin-agx = mkAgent "orin-agx";
+      agent-orin-nx = mkAgent "orin-nx";
+      agent-riscv = mkAgent "riscv";
+      agent-nuc = mkAgent "nuc";
+      agent-lenovo-x1 = mkAgent "lenovo-x1";
+    };
 
   # Details of the hardware devices connected to this host
   environment.etc."jenkins/test_config.json".text =

--- a/hosts/testagent-dev/configuration.nix
+++ b/hosts/testagent-dev/configuration.nix
@@ -3,19 +3,14 @@
 {
   self,
   inputs,
-  pkgs,
   config,
   ...
 }:
-let
-  # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
-  # https://github.com/NixOS/nixpkgs/pull/313643
-  brainstem = pkgs.callPackage ../../pkgs/brainstem { };
-in
 {
   imports =
     [
       ./disk-config.nix
+      ../agents-common.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
     ]
@@ -66,153 +61,12 @@ in
     cpu.intel.updateMicrocode = true;
   };
 
-  services.udev = {
-    # Enable Acroname USB Smart switch, as well as LXA USB-SD-Mux support.
-    packages = [
-      brainstem
-      pkgs.usbsdmux
-    ];
-
-    # udev rules for test devices serial connections
-    extraRules = ''
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0WF8Y", SYMLINK+="ttyNUC1", MODE="0666", GROUP="dialout"
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="04A629B8AB87AB8111ECB2A38815028", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
-    '';
-  };
-
-  environment.systemPackages =
-    [
-      inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-      brainstem
-    ]
-    ++ (with pkgs; [
-      minicom
-      usbsdmux
-    ]);
-
-  # The Jenkins slave service is very barebones
-  # it only installs java and sets up jenkins user
-  services.jenkinsSlave.enable = true;
-
-  # Jenkins needs sudo and serial rights to perform the HW tests
-  users.users.jenkins.extraGroups = [
-    "wheel"
-    "dialout"
-    "tty"
-  ];
-
-  systemd.services =
-    let
-      # verifies that the environment file is properly configured
-      # and downloads agent.jar from the controller
-      jenkins-setup-script = pkgs.writeShellScript "jenkins-setup.sh" ''
-        if [[ ! -f jenkins.env ]]; then
-          echo "Please add jenkins controller details to $(pwd)/jenkins.env"
-          echo "CONTROLLER=" > jenkins.env
-          echo "ADMIN_PASSWORD=" >> jenkins.env
-          exit 1
-        fi
-
-        source jenkins.env
-
-        if [[ -z "$CONTROLLER" ]]; then
-          echo "Variable CONTROLLER not set in $(pwd)/jenkins.env"
-          exit 1
-        fi
-
-        if [[ -z "$ADMIN_PASSWORD" ]]; then
-          echo "Variable ADMIN_PASSWORD not set in $(pwd)/jenkins.env"
-          exit 1
-        fi
-
-        wget "$CONTROLLER/jnlpJars/agent.jar"
-      '';
-
-      # Helper function to create agent services for each hardware device
-      mkAgent =
-        device:
-        let
-          # opens a websocket connection to the jenkins controller from this agent
-          jenkins-connect-script = pkgs.writeShellScript "jenkins-connect.sh" ''
-            JENKINS_SECRET="$(
-              curl -L -s -u admin:$ADMIN_PASSWORD \
-              $CONTROLLER/computer/${device}/jenkins-agent.jnlp | 
-              sed "s/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/"
-            )"
-
-            mkdir -p "/var/lib/jenkins/agents/${device}"
-
-            ${pkgs.jdk}/bin/java \
-              -jar agent.jar \
-              -url "$CONTROLLER" \
-              -name "${device}" \
-              -secret "$JENKINS_SECRET" \
-              -workDir "/var/lib/jenkins/agents/${device}" \
-              -webSocket
-          '';
-        in
-        {
-          # agents require the setup service to run without errors before starting
-          requires = [ "setup-agents.service" ];
-          wantedBy = [ "setup-agents.service" ];
-          after = [ "setup-agents.service" ];
-
-          path =
-            [
-              brainstem
-              inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-            ]
-            ++ (with pkgs; [
-              curl
-              wget
-              jdk
-              git
-              bashInteractive
-              coreutils
-              util-linux
-              nix
-              zstd
-              jq
-              csvkit
-              sudo
-              openssh
-              iputils
-              netcat
-              python3
-              usbsdmux
-            ]);
-
-          serviceConfig = {
-            Type = "simple";
-            User = "jenkins";
-            EnvironmentFile = "/var/lib/jenkins/jenkins.env";
-            WorkingDirectory = "/var/lib/jenkins";
-            ExecStart = "${jenkins-connect-script}";
-          };
-        };
-    in
-    {
-      # the setup service does not start automatically or it would fail activation
-      # of the system since jenkins.env is empty before manually set up
-      setup-agents = {
-        path = with pkgs; [ wget ];
-        serviceConfig = {
-          Type = "oneshot";
-          User = "jenkins";
-          RemainAfterExit = "yes";
-          WorkingDirectory = "/var/lib/jenkins";
-          ExecStart = "${jenkins-setup-script}";
-        };
-      };
-
-      # one agent per unique hardware device to act as a lock
-      agent-orin-agx = mkAgent "orin-agx";
-      agent-orin-nx = mkAgent "orin-nx";
-      agent-riscv = mkAgent "riscv";
-      agent-nuc = mkAgent "nuc";
-      agent-lenovo-x1 = mkAgent "lenovo-x1";
-    };
+  # udev rules for test devices serial connections
+  services.udev.extraRules = ''
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0WF8Y", SYMLINK+="ttyNUC1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="04A629B8AB87AB8111ECB2A38815028", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
+  '';
 
   # Details of the hardware devices connected to this host
   environment.etc."jenkins/test_config.json".text =

--- a/hosts/testagent/configuration.nix
+++ b/hosts/testagent/configuration.nix
@@ -1,99 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-#
-# Edit this configuration file to define what should be installed on
-# your system.  Help is available in the configuration.nix(5) man page
-# and in the NixOS manual (accessible by running ‘nixos-help’).
+
 {
   self,
   inputs,
-  pkgs,
+  config,
   ...
 }:
-let
-  # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
-  # https://github.com/NixOS/nixpkgs/pull/313643
-  brainstem = pkgs.callPackage ../../pkgs/brainstem { };
-
-  mkAgent =
-    device:
-    let
-      # Temporary url for development
-      controllerUrl = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com";
-      workDir = "/var/lib/jenkins/agents/${device}";
-
-      jenkins-connection-script =
-        pkgs.writeScript "jenkins-connect.sh" # sh
-          ''
-            #!/usr/bin/env bash
-            set -eu
-
-            mkdir -p "${workDir}"
-
-            # get agent.jar
-            if [ ! -f agent.jar ]; then
-              wget "${controllerUrl}/jnlpJars/agent.jar"
-            fi
-
-            # TODO: get secret from jenkins api here, right now it's manual process
-            if [ ! -f "secret_${device}" ]; then echo "Error: /var/lib/jenkins/secret_${device} not found"; exit 1; fi;
-
-            ${pkgs.jdk}/bin/java \
-              -jar agent.jar \
-              -url "${controllerUrl}" \
-              -name "${device}" \
-              -secret "@secret_${device}" \
-              -workDir "${workDir}" \
-              -webSocket
-          '';
-    in
-    {
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-
-      # Give up if it fails more than 5 times in 60 second interval
-      startLimitBurst = 5;
-      startLimitIntervalSec = 60;
-
-      path =
-        [
-          brainstem
-          inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-        ]
-        ++ (with pkgs; [
-          wget
-          jdk
-          git
-          bashInteractive
-          coreutils
-          util-linux
-          nix
-          zstd
-          jq
-          csvkit
-          sudo
-          openssh
-          iputils
-          netcat
-          python3
-          usbsdmux
-        ]);
-
-      serviceConfig = {
-        Type = "simple";
-        User = "jenkins";
-        WorkingDirectory = "/var/lib/jenkins";
-        ExecStart = "${jenkins-connection-script}";
-        Restart = "on-failure";
-        RestartSec = 5;
-      };
-    };
-in
 {
   imports =
     [
       # Include the results of the hardware scan.
       ./hardware-configuration.nix
+      ../agents-common.nix
     ]
     ++ (with inputs; [
       sops-nix.nixosModules.sops
@@ -120,109 +39,75 @@ in
     efi.canTouchEfiVariables = true;
   };
 
-  services.udev = {
-    # Enable Acroname USB Smart switch, as well as LXA USB-SD-Mux support.
-    packages = [
-      brainstem
-      pkgs.usbsdmux
-    ];
-
-    # udev rules for test devices serial connections
-    extraRules = ''
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD1BQQS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTC0VRXR", SYMLINK+="ttyNUC1", MODE="0666", GROUP="dialout"
-      SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="0642246B630C149011EC987B167DB04", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
-    '';
-  };
-
-  environment.systemPackages =
-    [
-      inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-      brainstem
-    ]
-    ++ (with pkgs; [
-      minicom
-      usbsdmux
-    ]);
-
-  # The Jenkins slave service is very barebones
-  # it only installs java and sets up jenkins user
-  services.jenkinsSlave.enable = true;
-
-  # Gives jenkins user sudo rights without password and serial connection rights
-  users.users.jenkins.extraGroups = [
-    "wheel"
-    "dialout"
-    "tty"
-  ];
-
-  # Agent services per hardware test device
-  systemd.services = {
-    agent-orin-agx = mkAgent "orin-agx";
-    agent-orin-nx = mkAgent "orin-nx";
-    agent-riscv = mkAgent "riscv";
-    agent-nuc = mkAgent "nuc";
-    agent-lenovo-x1 = mkAgent "lenovo-x1";
-  };
+  # udev rules for test devices serial connections
+  services.udev.extraRules = ''
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD1BQQS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTC0VRXR", SYMLINK+="ttyNUC1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="0642246B630C149011EC987B167DB04", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
+  '';
 
   # Details of the hardware devices connected to this host
-  environment.etc."jenkins/test_config.json".text = builtins.toJSON {
-    addresses = {
-      NUC1 = {
-        serial_port = "/dev/ttyNUC1";
-        device_ip_address = "172.18.16.50";
-        socket_ip_address = "172.18.16.30";
-        plug_type = "TAPOP100v2";
-        switch_bot = "NONE";
-        location = "testagent";
-        usbhub_serial = "F0A0D6CF";
-        ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNJ0TB00828W-0:0";
-        threads = 8;
-      };
-      OrinAGX1 = {
-        serial_port = "/dev/ttyACM0";
-        device_ip_address = "172.18.16.36";
-        socket_ip_address = "172.18.16.31";
-        plug_type = "TAPOP100v2";
-        switch_bot = "NONE";
-        location = "testagent";
-        usbhub_serial = "92D8AEB7";
-        ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WXNS0W300153T-0:0";
-        threads = 8;
-      };
-      LenovoX1-1 = {
-        serial_port = "NONE";
-        device_ip_address = "172.18.16.66";
-        socket_ip_address = "NONE";
-        plug_type = "NONE";
-        switch_bot = "LenovoX1-prod";
-        location = "testagent";
-        usbhub_serial = "641B6D74";
-        ext_drive_by-id = "usb-Samsung_PSSD_T7_S7MLNS0X532696T-0:0";
-        threads = 20;
-      };
-      Polarfire1 = {
-        serial_port = "/dev/ttyRISCV1";
-        device_ip_address = "NONE";
-        socket_ip_address = "172.18.16.45";
-        plug_type = "TAPOP100v2";
-        switch_bot = "NONE";
-        location = "testagent";
-        usb_sd_mux_port = "/dev/sg1";
-        ext_drive_by-id = "usb-LinuxAut_sdmux_HS-SD_MMC_000000001184-0:0";
-        threads = 4;
-      };
-      OrinNX1 = {
-        serial_port = "/dev/ttyORINNX1";
-        device_ip_address = "172.18.16.44";
-        socket_ip_address = "172.18.16.43";
-        plug_type = "TAPOP100v2";
-        switch_bot = "NONE";
-        location = "testagent";
-        usbhub_serial = "5220564F";
-        ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0T918984B-0:0";
-        threads = 8;
+  environment.etc."jenkins/test_config.json".text =
+    let
+      location = config.networking.hostName;
+    in
+    builtins.toJSON {
+      addresses = {
+        NUC1 = {
+          inherit location;
+          serial_port = "/dev/ttyNUC1";
+          device_ip_address = "172.18.16.50";
+          socket_ip_address = "172.18.16.30";
+          plug_type = "TAPOP100v2";
+          switch_bot = "NONE";
+          usbhub_serial = "F0A0D6CF";
+          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNJ0TB00828W-0:0";
+          threads = 8;
+        };
+        OrinAGX1 = {
+          inherit location;
+          serial_port = "/dev/ttyACM0";
+          device_ip_address = "172.18.16.36";
+          socket_ip_address = "172.18.16.31";
+          plug_type = "TAPOP100v2";
+          switch_bot = "NONE";
+          usbhub_serial = "92D8AEB7";
+          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WXNS0W300153T-0:0";
+          threads = 8;
+        };
+        LenovoX1-1 = {
+          inherit location;
+          serial_port = "NONE";
+          device_ip_address = "172.18.16.66";
+          socket_ip_address = "NONE";
+          plug_type = "NONE";
+          switch_bot = "LenovoX1-prod";
+          usbhub_serial = "641B6D74";
+          ext_drive_by-id = "usb-Samsung_PSSD_T7_S7MLNS0X532696T-0:0";
+          threads = 20;
+        };
+        Polarfire1 = {
+          inherit location;
+          serial_port = "/dev/ttyRISCV1";
+          device_ip_address = "NONE";
+          socket_ip_address = "172.18.16.45";
+          plug_type = "TAPOP100v2";
+          switch_bot = "NONE";
+          usb_sd_mux_port = "/dev/sg1";
+          ext_drive_by-id = "usb-LinuxAut_sdmux_HS-SD_MMC_000000001184-0:0";
+          threads = 4;
+        };
+        OrinNX1 = {
+          inherit location;
+          serial_port = "/dev/ttyORINNX1";
+          device_ip_address = "172.18.16.44";
+          socket_ip_address = "172.18.16.43";
+          plug_type = "TAPOP100v2";
+          switch_bot = "NONE";
+          usbhub_serial = "5220564F";
+          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0T918984B-0:0";
+          threads = 8;
+        };
       };
     };
-  };
 }


### PR DESCRIPTION
Greatly simplifies the setup of testing environment or moving it to a different controller.

After this change, all you need to do to connect the test setup to a jenkins environment is to supply the controller url and admin password in `/var/lib/jenkins/jenkins.env`, and (re)start `setup-agents.service`. This service will then start the hardware agents.

Agent services creation moved to a separate file so it can be imported from all testagent configurations.