### PR TITLE
jenkins-controller: Set job concurrency enabled

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -150,6 +150,7 @@ in
               inherit display-name;
               name = script;
               project-type = "pipeline";
+              concurrent = true;
               pipeline-scm = {
                 script-path = "${script}.groovy";
                 lightweight-checkout = true;


### PR DESCRIPTION
Jenkins Job Builder sets the `concurrent=false` by default. We need to set it to `true` by default to match the Jenkins default and to allow parallel pipelines.

On pipelines that should not run in parallel, we already explicitly set the `disableConcurrentBuilds()` in the declarative pipeline properties.

Reference:
https://jenkins-job-builder.readthedocs.io/en/latest/definition.html