### PR TITLE
Enable GitHub builds on build4

### DIFF
--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -23,6 +23,7 @@
       user-themisto
       user-ktu
       user-avnik
+      user-github
     ]);
 
   # build3 specific configuration

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -2,15 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 { self, ... }:
 {
-  imports =
-    [
-      ../ficolo.nix
-      ../cross-compilation.nix
-      ../builders-common.nix
-    ]
-    ++ (with self.nixosModules; [
-      user-themisto
-    ]);
+  imports = [
+    ../ficolo.nix
+    ../cross-compilation.nix
+    ../builders-common.nix
+  ] ++ (with self.nixosModules; [ user-github ]);
 
   # build4 specific configuration
 

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -6,37 +6,14 @@
     [
       ../ficolo.nix
       ../cross-compilation.nix
-      ../yubikey.nix
       ../builders-common.nix
     ]
     ++ (with self.nixosModules; [
       user-themisto
-      service-nginx
     ]);
 
   # build4 specific configuration
 
   networking.hostName = "build4";
 
-  users.users.yubimaster.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA2BcpFzSXOuK9AzN+J1HBVnuVV8D3wgdEwPuILNy2aM signer"
-  ];
-
-  security.acme = {
-    acceptTerms = true;
-    defaults.email = "trash@unikie.com";
-  };
-
-  services.nginx = {
-    virtualHosts = {
-      "pandia.vedenemo.dev" = {
-        enableACME = true;
-        forceSSL = true;
-        default = true;
-        locations."/" = {
-          proxyPass = "http://127.0.0.1:3015";
-        };
-      };
-    };
-  };
 }

--- a/hosts/builders/developers.nix
+++ b/hosts/builders/developers.nix
@@ -357,11 +357,6 @@ let
       name = "remote-build";
       keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2rhqSdifRmTwyrc3rvXWyDMznrIAAkVwhEsufLYiTp" ];
     }
-    {
-      desc = "Github actions runners can use this user to remote build";
-      name = "github";
-      keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/KOBOKqZwugt7Yi6ZFhr6ZF2j9kzyqnl+v7eRlxPoq" ];
-    }
   ];
 in
 {

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -28,6 +28,7 @@
       user-karim
       user-mika
       user-themisto
+      user-github
     ]);
 
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";

--- a/users/default.nix
+++ b/users/default.nix
@@ -23,5 +23,6 @@
     user-vunnyso = import ./vunnyso.nix;
     user-bmg = import ./bmg.nix;
     user-fayad = import ./fayad.nix;
+    user-github = import ./github.nix;
   };
 }

--- a/users/github.nix
+++ b/users/github.nix
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    github = {
+      description = "Github actions runners can use this user to remote build";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH/KOBOKqZwugt7Yi6ZFhr6ZF2j9kzyqnl+v7eRlxPoq"
+      ];
+      extraGroups = [ ];
+    };
+  };
+  nix.settings.trusted-users = [ "github" ];
+}


### PR DESCRIPTION
- Cleanup build4 configuration: remove `nginx` and obsolete yubikey `signer` configurations which are no longer needed on build4.
- Move `user-github` out of `developers.nix`: explicitly import `user-github` on hosts that may be used from github actions.
- We need to keep `github-user` on build3 until all curent github actions are changed to start using build4 as their remote builder. Currently, build3 is still used as a remote builder from [ghaf](https://github.com/tiiuae/ghaf/blob/285596115982fd3eb53ebd358b1dbcc3c5128414/.github/workflows/build.yml#L161) and [ghaf-infra](https://github.com/tiiuae/ghaf-infra/blob/da8a2c6ed8c534d54217c4e99cd97febf4eb5f75/.github/workflows/test-ghaf-infra.yml#L114-L115).