### PR TITLE
Start using build4 as x86 external builder in Azure infra

### DIFF
--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -23,7 +23,8 @@
       user-themisto
       user-ktu
       user-avnik
-      user-github
+      user-github # Remove when all GhA workflows moved to build4
+      user-remote-build # Remove when all jenkins builds moved to build4
     ]);
 
   # build3 specific configuration

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -2,11 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 { self, ... }:
 {
-  imports = [
-    ../ficolo.nix
-    ../cross-compilation.nix
-    ../builders-common.nix
-  ] ++ (with self.nixosModules; [ user-github ]);
+  imports =
+    [
+      ../ficolo.nix
+      ../cross-compilation.nix
+      ../builders-common.nix
+    ]
+    ++ (with self.nixosModules; [
+      user-github
+      user-remote-build
+    ]);
 
   # build4 specific configuration
 

--- a/hosts/builders/developers.nix
+++ b/hosts/builders/developers.nix
@@ -352,11 +352,6 @@ let
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAJ0DcYPvtUwVh/D/fXphnhPpKX9j4JvgES1o0UeP+kY maarit.harkonen@unikie.com"
       ];
     }
-    {
-      desc = "Temporary user for Azure dev remote builds on hetzarm and ficolo";
-      name = "remote-build";
-      keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2rhqSdifRmTwyrc3rvXWyDMznrIAAkVwhEsufLYiTp" ];
-    }
   ];
 in
 {

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -29,6 +29,7 @@
       user-mika
       user-themisto
       user-github
+      user-remote-build
     ]);
 
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -76,10 +76,10 @@ locals {
   ws = substr(replace(lower(terraform.workspace), "/[^a-z0-9]/", ""), 0, 16)
 
   ext_builder_machines = [
-    "ssh://remote-build@builder.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 32 3 kvm,nixos-test,benchmark,big-parallel - -",
+    "ssh://remote-build@build4.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 32 3 kvm,nixos-test,benchmark,big-parallel - -",
     "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 40 3 kvm,nixos-test,benchmark,big-parallel - -"
   ]
-  ext_builder_keyscan     = ["builder.vedenemo.dev", "hetzarm.vedenemo.dev"]
+  ext_builder_keyscan     = ["build4.vedenemo.dev", "hetzarm.vedenemo.dev"]
   binary_cache_url_common = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
   # TODO: adding multiple urls as comma-and-whitespace separated
   # string is more or less a hack. If we plan to have multiple domains

--- a/users/default.nix
+++ b/users/default.nix
@@ -24,5 +24,6 @@
     user-bmg = import ./bmg.nix;
     user-fayad = import ./fayad.nix;
     user-github = import ./github.nix;
+    user-remote-build = import ./remote-build.nix;
   };
 }

--- a/users/remote-build.nix
+++ b/users/remote-build.nix
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  users.users = {
+    remote-build = {
+      description = "Azure ghaf infra runs external remote builds as this user";
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM2rhqSdifRmTwyrc3rvXWyDMznrIAAkVwhEsufLYiTp"
+      ];
+      extraGroups = [ ];
+    };
+  };
+  nix.settings.trusted-users = [ "remote-build" ];
+}


### PR DESCRIPTION
- Move user-remote-build out of developers.nix: explicitly import user-remote-build on hosts that may be used from Azure jenkins-controller initiated 'external' builds.
- Start using `remote-build@build4.vedenemo.dev` as external x86 builder from jenkins-controller
- We need to keep remote-build user on build3 until all currently deployed ghaf-infra jenkins-controller instances that make use of external builders, have been migrated to a version of ghaf-infra including the changes from this PR.