### PR TITLE
Remove cache.vedenemo.dev usage

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -93,8 +93,8 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |
-            trusted-public-keys = cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.vedenemo.dev https://cache.nixos.org
+            trusted-public-keys = prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://prod-cache.vedenemo.dev https://cache.nixos.org
             connect-timeout = 5
             max-jobs = 4
             system-features = nixos-test benchmark big-parallel kvm
@@ -110,9 +110,9 @@ jobs:
         run: |
           sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"
           sudo sh -c "echo 'hetzarm.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK' >>/etc/ssh/ssh_known_hosts"
-          sudo sh -c "echo 'builder.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSI8s/wefXiD2h3I3mIRdK+d9yDGMn0qS5fpKDnSGqj' >>/etc/ssh/ssh_known_hosts"
+          sudo sh -c "echo 'build4.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSI8s/wefXiD2h3I3mIRdK+d9yDGMn0qS5fpKDnSGqj' >>/etc/ssh/ssh_known_hosts"
           sudo sh -c "echo 'ssh://github@hetzarm.vedenemo.dev aarch64-linux /etc/nix/id_builder_key 40 1 nixos-test,benchmark,big-parallel,kvm - -' >/etc/nix/machines"
-          sudo sh -c "echo 'ssh://github@builder.vedenemo.dev x86_64-linux,i686-linux /etc/nix/id_builder_key 32 1 kvm,benchmark,big-parallel,nixos-test - -' >>/etc/nix/machines"
+          sudo sh -c "echo 'ssh://github@build4.vedenemo.dev x86_64-linux,i686-linux /etc/nix/id_builder_key 32 1 kvm,benchmark,big-parallel,nixos-test - -' >>/etc/nix/machines"
 
       - name: Run ghaf-infra CI tests
         run: nix develop --command inv pre-push

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -32,13 +32,11 @@ in
       # Subsituters
       trusted-public-keys = [
         "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="
-        "cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E="
-        "cache.ssrcdevops.tii.ae:oOrzj9iCppf+me5/3sN/BxEkp5SaFkHfKTPPZ97xXQk="
+        "prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI="
       ];
       substituters = [
         "https://ghaf-dev.cachix.org?priority=20"
-        "https://cache.vedenemo.dev"
-        "https://cache.ssrcdevops.tii.ae"
+        "https://prod-cache.vedenemo.dev"
       ];
       # Avoid copying unecessary stuff over SSH
       builders-use-substitutes = true;

--- a/scripts/test-nix-cache.sh
+++ b/scripts/test-nix-cache.sh
@@ -44,8 +44,8 @@ usage () {
     echo ""
     echo "  sudo ./$MYNAME \\"
     echo "    -f github:tiiuae/ghaf#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 \\"
-    echo "    -b https://dev-cache.vedenemo.dev \\"
-    echo "    -k 'ghaf-infra-dev:EdgcUJsErufZitluMOYmoJDMQE+HFyveI/D270Cr84I='"
+    echo "    -b https://prod-cache.vedenemo.dev \\"
+    echo "    -k 'prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI='"
     echo ""
 }
 


### PR DESCRIPTION
- Remove ghaf-infra references to decommissioned cache `cache.vedenemo.dev`, replacing it with `prod-cache.vedenemo.dev`
- Remove cache `cache.ssrcdevops.tii.ae`, which we should not need in our builders
- Start using `build4` as a x86 remote builder from the `test-ghaf-infra.yml` workflow
- This PR does not remove the nix configuration for [cache.vedenemo.dev](https://github.com/tiiuae/ghaf-infra/blob/c54a784f4819be6343d9cdbf54e2aaba3b7c381b/hosts/binarycache/configuration.nix#L62). This should be removed in a follow-up, together with re-purposing the current `cache.vedenemo.dev` host.

The change to github action was tested in a fork: https://github.com/henrirosten/ghaf-infra/pull/3.