### PR TITLE
Make test credentials available on the testagents

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -72,9 +72,16 @@ creation_rules:
     - age:
       - *ghaf-coverity
       - *jrautiola
-
   - path_regex: hosts/ghaf-webserver/secrets.yaml$
     key_groups:
     - age:
       - *ghaf-webserver
       - *cazfi
+  - path_regex: hosts/testagent/credentials.yaml$
+    key_groups:
+    - age:
+      - *testagent-dev
+      - *testagent-prod
+      - *testagent-release
+      - *jrautiola
+      - *vjuntunen

--- a/hosts/testagent/agents-common.nix
+++ b/hosts/testagent/agents-common.nix
@@ -13,6 +13,22 @@ let
   brainstem = pkgs.callPackage ../../pkgs/brainstem { };
 in
 {
+  sops.secrets =
+    let
+      credential = {
+        sopsFile = ./credentials.yaml;
+        owner = "jenkins";
+      };
+    in
+    {
+      dut-pass = credential;
+      plug-pass = credential;
+      switch-token = credential;
+      switch-secret = credential;
+      wifi-ssid = credential;
+      wifi-password = credential;
+    };
+
   services.udev.packages = [
     brainstem
     pkgs.usbsdmux

--- a/hosts/testagent/credentials.yaml
+++ b/hosts/testagent/credentials.yaml
@@ -1,0 +1,62 @@
+dut-pass: ENC[AES256_GCM,data:4fS/Iw==,iv:0rIn1oS3pQMoOoWGDU5/h+xhuLZq/9TNSZ82fzdUHR8=,tag:BxmcXJvcmKbx8keSb+iHHQ==,type:str]
+plug-pass: ENC[AES256_GCM,data:um3XSXZe9Pk=,iv:Is3izFUi9yzo/Oy9gcrDK07RV6gn1MfGcj9fc3fPKpQ=,tag:Of+afJN+OYz9uhAqotnnow==,type:str]
+switch-token: ENC[AES256_GCM,data:Ma6nainXouxFGA45eRghRLrawT3pNHjelQkN3hlR0+yZ2RM8Q8bjxJefgcdMz49L+ia5e7zgK/7GCaoU+k+p/R3vtmEmSPffDS5qVIyLJCluF6pvEiIcD807rRBBkMiY,iv:b1Bbw0kYzBFcCquQajGLK06g7OUNHPgjLZEiwHF5RBY=,tag:Ehho7Yl8KChsINaq8gMgqQ==,type:str]
+switch-secret: ENC[AES256_GCM,data:+AYLwIvtGzizKYbzoe+BatUfwIP8jCLuqhkphZ/XgUs=,iv:St7XiR6jpT3hgK4aeSMn2tEqTsYsGCOwVrhP7xHT5eU=,tag:97gVj3YxIoPx8sof2X0j4g==,type:str]
+wifi-ssid: ENC[AES256_GCM,data:lQGD6S2mqOS3h08M0D3SGtyN,iv:W6eZN/KMo1R6cUyhC4QaBHBLb1jPB0Y06MbW05Eha70=,tag:XRaOz8XKGWoaOMk4TGX0fQ==,type:str]
+wifi-password: ENC[AES256_GCM,data:UB5yvZypdBt3GE73irSR9Q==,iv:HNRBkoGAdlOC4Sy/C3wMBX2oPCJm7FZKmW+Wyw0Mim8=,tag:IysEBTZmdSzYYLl8ZyJBTw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1qjhxuh80tg2vq32kmwu2ne4vqvd8q2up7css30x0yefkrhq9jd0sxju3fa
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwMWRQaXMvVzc1T1J6eW5T
+            eUFGVkVCWVkveXpWMy9UdHRGTTVJSVM0WEE4CmlKZEZSVnBmTTNCbnNYakVibVFY
+            d083bnBuT2Z3WEc1N1VhTU1JRExESU0KLS0tIFl1VEJaYlJvcHJiVjNkaTZ0dFR6
+            TWcyRzV3dnM3TnduNWpSWGUzeldLVXMKicaTIPMC5H4qwcp8SBHxncNdh6dyzn7l
+            Rd2IZ9XY+uQ2s+XtUYB8OUDoBsZgDH6BJZKRIh8Pfb0J7gJi6nZatw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12nrv5a9rk9vqvx2tqvghn4kt9ps6gdszmmynhjegl2ewefkh03fsexuy9y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUUtEcFMzU29sbENmcHlt
+            RjRtWDNGcDFKQnpSbGpjV09xekMyVk5KUndzCkVWTmZrSllqWVk2NmFpRFd6VVEy
+            MkVHNVNTajhlZmd0TzlBYVBXWTBWMXMKLS0tIER3N3pNRk1XVU5DKzZkOUlhMitl
+            dkZKaS96RkwwSlNwSzBPb2Q2cU5pdm8K0BmtB5qh5M0PF0firRm+edx6DbWCS4D/
+            Myoqh6Iu9Lj7ecDFPnFeOtB7OoQ77SyU3J/LIjXEheU/ISAZSDs1QQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1pkd7crz3c0axuy4nnesjjzmklmqptx9fq5v8ndjevfgr5lqg8cgskhfyt7
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkYnlrN0hnaDNxQzZucDFo
+            ZTY3emVvUERFVEhPUEgyVElmNkdqenNKRUhvCm5hN2p4SFlDZXdHbi9PN3NBNEJt
+            MWJhZDVPUEJ1RG9ZNzVxNW45OVJ6eTQKLS0tIFc4c1B5REVLeGRmSlJzQWc0RTd3
+            V0lUeFNoOWF6RFN6cERlc0d5RGlkb1EKtWpR3MrENYcPqIu1Hhk8atElgKfz1VSP
+            hohb026vJEyaoLh6gSaMZ/5tWBBBVHSw56A/GaqEkEFdn+Vo0d4MAA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvVzR1MStId0dTd241bDFq
+            dnA1L2M0eDR2Y2lvelcvZTQxNFE5ZUdUVEJvCnhKSTRyQkt1ZjRSWGRGbENQNUtY
+            dE1oYXAxWFVNM0xXSDFjLy9vTklVWUEKLS0tIHRpUVY0SEJjc0JWdllSeUV4ekdx
+            NnFOUC9pMnRkUE9nU0VBNmVQaGZlQW8KUMY910K73OlVBowht/4X8jDLPCsfwkO0
+            qMcGiAu8dQEaXztQCOFcX5NcQDQze9aRB6HFwPQr+AxIUQ+hB4z1FQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age194hljejmy63ph884cnuuume7z33txlkp9an7l3yt2n3sjjere52qkvlfju
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkSmRYTUNZWHlGVnA1SHpa
+            T2kzeHExdEJUVXU4NG1xMStaN2ZIOUdsdGs4CjA3cVJtVkNFZmM0VkhBZzkzUTZw
+            Tm1qTjdiQUFCeGh1OXJjNEcvdG9xd28KLS0tIHJwR042Z3R6blBIVHpMdzhiWHV4
+            Y3NMTmt0aHdPZFNqcG01SjJqZE9RNjAKESw0+5vpv+1WBLRlo4foDaybm8ky75Oo
+            GiYQdw1NyzfwZTJ9womiRbKJCb4tkRuZP+ZlQ6F3nHyJRV4J7HbcTg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-11-05T14:24:21Z"
+    mac: ENC[AES256_GCM,data:5U8oFAnGhlXgJh1bob6Mth10x6whjCNdkBCf03ZWnuH2VXoIBiUTn4YQsGeXfRUvGEV4RRoOBpg7afiagFN9K805leOf+O6SJs9gnxXalJghBb4jJgw/1bFxpnKDPHd1Kvzka3jVV4gxdN5d0iiwPMu5NRcQt92T0f8RI70et9E=,iv:7/h5mlG5L+OD1zsaETI03OiFA80giH222VddZZxxD4A=,tag:VGRGl9En+V4rQVQOO9pxag==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
Adds new encrypted secret file `credentials.yaml` which is imported by all of the testagent machines. It contains the secrets that are currently manually configured into jenkins controller.

After this change, the ghaf-robot tests need to be updated to actually read these secrets from `/run/secrets/`, only then can these credentials be removed from the jenkins side.