### PR TITLE
Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Check if workflow is modified
         id: workflow-changed
-        uses: tj-actions/changed-files@v45.0.3
+        uses: tj-actions/changed-files@v45.0.4
         with:
           files: .github/workflows/test-ghaf-infra.yml
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v45.0.4](https://github.com/tj-actions/changed-files/releases/tag/v45.0.4)** on 2024-11-08T04:34:20Z
