### PR TITLE
Monitor logs from external servers

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -9,6 +9,7 @@ keys:
   - &jrautiola age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
   - &vjuntunen age194hljejmy63ph884cnuuume7z33txlkp9an7l3yt2n3sjjere52qkvlfju
   - &cazfi age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
+  - &fayad age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
 
   # hosts
   - &binarycache age1s47a3y44j695gemcl0kqgjlxxvaa50de9s69jy2l6vc8xtmk5pcskhpknl
@@ -21,6 +22,7 @@ keys:
   - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
   - &ghaf-coverity age172azvwv5vne79mqfhvdvk9j95gn5v04uk9t3fjdfe5p7dv7kucvqpygxkx
   - &ghaf-webserver age1f643hcr8xvzm6fha93xhn6dw552tfd6zvu7eulxk7vedgt09d9ysljsayq
+  - &ghaf-proxy age1sv50w7ydcqxxng4nfpvretqhusfkjewtrzpu4006z685xgplha2sa9tv9v
 
 creation_rules:
   - path_regex: hosts/binarycache/secrets.yaml$
@@ -72,6 +74,12 @@ creation_rules:
     - age:
       - *ghaf-coverity
       - *jrautiola
+  - path_regex: hosts/ghaf-proxy/secrets.yaml$
+    key_groups:
+    - age:
+      - *ghaf-proxy
+      - *jrautiola
+      - *fayad
   - path_regex: hosts/ghaf-webserver/secrets.yaml$
     key_groups:
     - age:

--- a/hosts/binarycache/configuration.nix
+++ b/hosts/binarycache/configuration.nix
@@ -25,7 +25,6 @@
       service-openssh
       service-binary-cache
       service-nginx
-      service-monitoring
       user-jrautiola
       user-cazfi
       user-hydra

--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -7,9 +7,6 @@
   ...
 }:
 {
-  sops.defaultSopsFile = ./secrets.yaml;
-  sops.secrets.ssh_private_key.owner = "root";
-
   imports =
     [
       ../ficolo.nix
@@ -27,7 +24,15 @@
       user-remote-build # Remove when all jenkins builds moved to build4
     ]);
 
-  # build3 specific configuration
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets.ssh_private_key.owner = "root";
+  };
+
+  services.monitoring = {
+    metrics.enable = true;
+    logs.enable = true;
+  };
 
   networking.hostName = "build3";
 

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -17,4 +17,8 @@
 
   networking.hostName = "build4";
 
+  services.monitoring = {
+    metrics.enable = true;
+    logs.enable = true;
+  };
 }

--- a/hosts/builders/ficolo.nix
+++ b/hosts/builders/ficolo.nix
@@ -16,7 +16,6 @@
       common
       ficolo-common
       service-openssh
-      service-monitoring
       user-cazfi
       user-hrosten
       user-jrautiola
@@ -30,11 +29,6 @@
   hardware = {
     enableRedistributableFirmware = true;
     cpu.intel.updateMicrocode = true;
-  };
-
-  services.monitoring = {
-    metrics.enable = true;
-    logs.enable = true;
   };
 
   boot = {

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -4,11 +4,10 @@
   self,
   inputs,
   lib,
+  config,
   ...
 }:
 {
-  sops.defaultSopsFile = ./secrets.yaml;
-
   imports =
     [
       ./disk-config.nix
@@ -32,6 +31,13 @@
       user-remote-build
     ]);
 
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets = {
+      loki_password.owner = "promtail";
+    };
+  };
+
   nixpkgs.hostPlatform = lib.mkDefault "aarch64-linux";
   hardware.enableRedistributableFirmware = true;
 
@@ -40,7 +46,17 @@
     useDHCP = true;
   };
 
-  services.monitoring.metrics.enable = true;
+  services.monitoring = {
+    metrics = {
+      enable = true;
+      ssh = true;
+    };
+    logs = {
+      enable = true;
+      lokiAddress = "https://monitoring.vedenemo.dev";
+      auth.password_file = config.sops.secrets.loki_password.path;
+    };
+  };
 
   boot = {
     initrd.availableKernelModules = [
@@ -55,22 +71,12 @@
     };
   };
 
-  users.users = {
-    # sshified user for monitoring server to log in as
-    sshified = {
-      isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEKd30t0EFmMyULGlecaUX6puIAF4IjynZUo+X9k8h69 monitoring"
-      ];
-    };
-
-    # build3 can use this as remote builder
-    build3 = {
-      isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf56a3ISY64w0Y0BmoLu+RyTIWQrXG6ugla6if9RteT build3"
-      ];
-    };
+  # build3 can use this as remote builder
+  users.users.build3 = {
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPf56a3ISY64w0Y0BmoLu+RyTIWQrXG6ugla6if9RteT build3"
+    ];
   };
 
   nix.settings.trusted-users = [

--- a/hosts/builders/hetzarm/secrets.yaml
+++ b/hosts/builders/hetzarm/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:UTXKJoJTMT1Wk4UIC6wAaUs5vm3c1FWuTNqzOYkU1l1t57rrFLj3I9ZogClvWMdxZ/Y1rWtUX8845IKYoUEyKjenJg1OATjSB2kMJeF0WKVUtEsIuSstpvSIFk2H65+ABLrzNXiPJhqiUaL+3I7DvVDAWXNnt7dLKsmoxnmG7f9psVJVd6tR1Wx4orBeZjJHRO3YPq4uk7xy/CrJg45UzYZAbNnVw/pKPN19oRXwWYVRRJirEWrj+ECjbDNudtgwRfcIBJtrWGuAxdjiPlFxl7HWucHqs3M+5ziJyycTbM/zG+QEIdhv5bAIk+tsP0tcrKbAWlaXBU1JypOe9N2EBCCRI9VaGwsMFmabgtgo6jU8GvT2qxukOgnBDkLclBmBIhNvgBDDmLObZCgmdhA+wgsy3pDuvBJlwmj0sdKCFxyRENPxoowD2jcibxJI79evUoaLMDayLCGRfxkZgiCcbIG+3dPaprT8vs20YijFbAEKQiiTYohs6ZttIx22jBBdHbwOAwh4I4ywZVAmWMtNWYh7+E0LtriZQGnKJYuPnTTaUFiRRsUY98EtzhNmo8Kt,iv:U7tpw+Ce4DuGhnO2RIUjsgpJ6I0j0vmdqI4zk8RoHec=,tag:nyxaLHy20C6uMcxZLVUWiw==,type:str]
+loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -23,8 +24,8 @@ sops:
             eFBKZkQxN1FnblRRekxKa2dFM0NMQ1kK4gaqw9P+R2kYOrKQFLiDzNIJqIqeJLXi
             aek/otKL5wG7Nvj3aMtyl4TrZCXLqZ8Jk9qzXQ9th5j/tklJXTG6uA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-05-08T16:06:07Z"
-    mac: ENC[AES256_GCM,data:CClwWEZr3YW5sVD952FJTMGCqI7/r7cZy/VavKCvjI1nj8zc+sidkhRWcnphi6flnqR+2fo5dbINGI1qldFrbR+N2ncW6llvu6yLk9T2QH/thkDcfYNRnpyt+ykFBpzy83HWxzj416CaXQqR3Cc8Z0Nff8xhVGdZzTTTMfO1eE4=,iv:GFQGJRG+HS0jcsyYTc3dVf22HpQSfRfBCswGHllUqXc=,tag:axJUMtBYSh58izaWc+uTIg==,type:str]
+    lastmodified: "2024-11-11T09:27:30Z"
+    mac: ENC[AES256_GCM,data:dJ4sixRMFeoZl25M+rykO4VVh2K29eECvDNPWl8otg10JusAen8j+i1uCWOus0ny4+6q4g0FEai+9BT1JSrv8y32AzJsz12dm+PSypQFG7RqVdzLC03LxSn0bseoJ6pLTxDfuxq2MsGybxjmkWQrjriotbpPMtvXy/emy7w7F68=,iv:p6HSeUKo4pdOzClY/fBg/g9CqjDyx5wDqMz/RqXloIY=,tag:luY/k6J9tdRxfbUXSzG1eA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/ficolo-common.nix
+++ b/hosts/ficolo-common.nix
@@ -1,10 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
+{ self, lib, ... }:
 {
+  imports = [ self.nixosModules.service-monitoring ];
+
   # Use ci-server as primary DNS and pfsense as secondary
   networking.nameservers = [
     "172.18.20.100"
     "172.18.20.1"
   ];
+
+  services.monitoring = {
+    metrics.openFirewall = true;
+    logs.lokiAddress = lib.mkDefault "http://172.18.20.108";
+  };
 }

--- a/hosts/ghaf-log/secrets.yaml
+++ b/hosts/ghaf-log/secrets.yaml
@@ -2,6 +2,7 @@ ssh_host_ed25519_key: ENC[AES256_GCM,data:2nCYQcgjV6SLUZIulp3FcL4rRwXW83RqyozdtN
 loki_basic_auth: ENC[AES256_GCM,data:WjRlJGwp1OYIfZYDd1tvAoW+yxko49NX4onrKY21tWJ20PTiEEfxpXJO,iv:eCXRu7tGyuZheQSz4k94nyQWRr0sndQOS5RPM7a5ZVE=,tag:Kw2WFYN2X5jbJfgL7e6K+A==,type:str]
 github_client_id: ENC[AES256_GCM,data:KhQtPeuMATu122vSb9kUrtICcWI=,iv:+8X1B31h8tqW5nHsKIxsy/Eh49faMfYC0CVcbqyhVes=,tag:7XODRd6NRo5vk5vIdOZ79Q==,type:str]
 github_client_secret: ENC[AES256_GCM,data:AY/1NgKgNOw8SrZb+T1C1vZCK9CV/lMEykY6lTPeycXW4vp4d0putQ==,iv:AqofLZQ1AG/FCHIo3jRDp3Xih1Envq6yugDDHlqD9/o=,tag:PPPdyQZZ1eRDFlXwVJcoYQ==,type:str]
+vedenemo_loki_password: ENC[AES256_GCM,data:8OFLIBdNo2IaB4UiC6N2OljR8g==,iv:ZmKwPGozJOzh3T5gxFUTmis0zsZrXVpcr6D2ZR1hPoU=,tag:ujuncHYbCMq0OYapV1NWhQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -26,8 +27,8 @@ sops:
             RE8rU2lmakJRenVqemhjWUpxeUttRzgKFqd0iVZgbhib0J4eLaCg07xmTJ8uAk6G
             XuEHIrV/3T34BttUo7boc/48caRjfvATYG3JWDotqJNyfDfAerGjgA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-08-15T07:33:54Z"
-    mac: ENC[AES256_GCM,data:Bt7VSB6HdVxh8ziTTMAdSW+eMrK6aS47gxPDAXrXqOTLsmo2Ckg5eWgwG7g+adPZIxGL64o+9BCd7mU7hKFCHMBliv+0LhoAa4H+f+YpIyeX3kh2aaloMTrjXvMokOMptlKj+XuHKKv8x4dyqoAMrGUIg2b8QRXAz1vAIdeEeUo=,iv:A1pFbB18P+lZ0selOAxwP/JSKup4WZchPWBJfI3+ycM=,tag:MzgqrnS3atvpsZg0HXcN8g==,type:str]
+    lastmodified: "2024-11-11T09:29:49Z"
+    mac: ENC[AES256_GCM,data:4ZL4ZHcKU9jV187WKSB6cusvnSilWs2pjxXDUZA8hFx/moAMfJhw7lqfnqvE5pIX5B0nnraKbzPM5Bl2YVZj7GOzQgihH7e/xqFgugSsa4XHKyYvxWjgJFibp7u/sfJTRMhRbegoOg1Pwogk/TyK18T6O6tNVVQDxMkNUU0uUnc=,iv:3hCHPtT+QUh7QCkILed2plrTzYAPtYD2dFks/KQAL9w=,tag:dPKuoSy2YZP8VvuH+saDhA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/ghaf-proxy/configuration.nix
+++ b/hosts/ghaf-proxy/configuration.nix
@@ -6,11 +6,10 @@
   inputs,
   modulesPath,
   lib,
+  config,
   ...
 }:
 {
-  sops.defaultSopsFile = ./secrets.yaml;
-
   imports =
     [
       ./disk-config.nix
@@ -21,6 +20,7 @@
     ++ (with self.nixosModules; [
       common
       service-openssh
+      service-monitoring
       user-jrautiola
       user-fayad
       user-cazfi
@@ -40,6 +40,25 @@
 
   nixpkgs.hostPlatform = "x86_64-linux";
   hardware.enableRedistributableFirmware = true;
+
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets = {
+      loki_password.owner = "promtail";
+    };
+  };
+
+  services.monitoring = {
+    metrics = {
+      enable = true;
+      ssh = true;
+    };
+    logs = {
+      enable = true;
+      lokiAddress = "https://monitoring.vedenemo.dev";
+      auth.password_file = config.sops.secrets.loki_password.path;
+    };
+  };
 
   networking = {
     hostName = "ghaf-proxy";

--- a/hosts/ghaf-proxy/secrets.yaml
+++ b/hosts/ghaf-proxy/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:oeYLXKvcYeyZ205mLhbHG1/dlDoKABH9pva1RbdlscvWoeVxDqzm3qsPe6HsDEuipfQtuZLXmdqle96Vxblq2goUC4WmZLKi+x7a2SZfhCeyqSCaQJqlzTwuTx2hrBQTLVRolHQBTC2xOdida645qWwc0JOB7xNtM8CFu83slGcgzel5IR32QVI2iHaXmdZXS6HMK1NMqQSf07nGxb0q3XZCdPbeAzlo+aJlqGL3ZyR5WTGEvihPKYCPNbdrpZjPWreW/JQQ8Lg69I8ZH8+4BXmD3Dy18M2RMIqs6Zs+IkneVSD1F08MAvWTTtP/QdQ7RwnLtGZqIqb3lW8QDHzB3Pz6mMD8uv03MUenGKHAiQ69yADKm8LHMLC6nb/HC6UZNx8gslj3adCexKHggE2+IhvOOVbglZWTWPTEhL+VeeCcozL1f5LnwjaXw/bObvCZXdFY8wk/A1I2jCyLClJk6TUfruGkoyw/orczLC7BxMwSDKFc2Xvo5XzN/+/wQ97HwhBABBPmPUts5OLX/1WwPcV2IBJRHlX7pE29,iv:ofPi/QQlYy01sRgbu6SqWY0aiNiCBtWG/80rvYaxsSY=,tag:K3cu3d0LXthA7iw7RkIm2g==,type:str]
+loki_password: ENC[AES256_GCM,data:O41JIKrxkpk4Jz+cEcapSVc3Zg==,iv:A8IKTalKCdtbL+MUmsFmPkhDuFpZAqTnyLZklzkJU4k=,tag:cA9KHKHur871iK8n4jM6IA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -32,8 +33,8 @@ sops:
             cG9FTEVqODdmVS9jRXplTGxOeSt0aE0KzuYgky0yMTr8d/O3hOGnFu9WDVr0wxFK
             GZwsVzNYf0tpQRBcCbFG3GpJKbheW/zLmTqTTSY0LXgrfpJlT/qO8g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-01T02:46:39Z"
-    mac: ENC[AES256_GCM,data:i2zk5aLnKky0u+qal75thalA5q7NFyXAILTIoCsOmN0qntMPs2yz3n+8QoFLCVS8IycR/E7qRDEytKchXu2J6XxZZkxEBIYmXxnp27Z1yBENzRrDN2Y5dBE41Rpn3HELhMLaBYYU0uNFcVqolOiozeNTtlQJVeoD+ye1FAz84I8=,iv:mDuvUplmC7oa7MDtyUHNR0wi4deOcPU7vB53hHEWe48=,tag:lPFggfy6ed/5VM7XQv7AVA==,type:str]
+    lastmodified: "2024-11-11T11:55:34Z"
+    mac: ENC[AES256_GCM,data:QvVl/SBfQDf/YblONz4ydAiaHRRlXmjQUo51EpFsyaBnXLfuWyG+AWK/er44omJ8q+rRXS0u1r5P8rdmY+jxB+iLBvOoI6qNNPU3JhzadPSqXxXmGcfbj+JNRqD8iFzhNW2XbR+fQqOwIYWrUhSj8EOJF/TijomRWLvtMDSbq0c=,iv:KTl4lcP+f4VfUCYh5b0mTQ+ht4xtOKPRHJUwx9KbyWk=,tag:UljRBpyj+jsM5eETNlxrvg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/himalia/configuration.nix
+++ b/hosts/himalia/configuration.nix
@@ -20,15 +20,16 @@
       qemu-common
       ficolo-common
       service-openssh
-      service-nginx
-      service-monitoring
       user-jrautiola
       user-cazfi
       user-karim
       user-barna
       user-mika
     ]);
+
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  networking.hostName = "himalia";
+
   # List packages installed in system profile
   environment.systemPackages = with pkgs; [
     git
@@ -43,33 +44,12 @@
       ]
     ))
   ];
+
   # docker daemon running
   virtualisation.docker.enable = true;
-
-  networking = {
-    hostName = "himalia";
-  };
-
-  security.acme = {
-    acceptTerms = true;
-    defaults.email = "trash@unikie.com";
-  };
 
   services.monitoring = {
     metrics.enable = true;
     logs.enable = true;
-  };
-
-  services.nginx = {
-    virtualHosts = {
-      "himalia.vedenemo.dev" = {
-        enableACME = true;
-        forceSSL = true;
-        default = true;
-        locations."/" = {
-          proxyPass = "http://127.0.0.1:3015";
-        };
-      };
-    };
   };
 }

--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -52,6 +52,7 @@ in
   services.openssh.knownHosts = {
     "65.21.20.242".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
     "95.217.177.197".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
+    "95.216.200.85".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
   };
 
   # runs a tiny webserver on port 8888 that tunnels requests through ssh connection
@@ -243,6 +244,12 @@ in
             targets = [ "95.217.177.197:9100" ];
             labels = {
               machine_name = "ghaf-log";
+            };
+          }
+          {
+            targets = [ "95.216.200.85:9100" ];
+            labels = {
+              machine_name = "ghaf-proxy";
             };
           }
         ];

--- a/hosts/monitoring/secrets.yaml
+++ b/hosts/monitoring/secrets.yaml
@@ -1,5 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:3syc79zImKOJ85pvTNTFN1HWC4cX2aguP8OtlbxiElZWVC6nanJ6boAhjaO/sdIh9tppmrUdBID6QJsLnFABwtEwUj2O0oGYUddtZxerXnyEeP4EncSubJQDtmJxdVWMT7lnu0nseZT54CozbhQ+7EdX6kEOGwLR2Hm0nbaGNnHQLZKaxN37gKycG2csLs1Z2pI03dutFk4E7z1bD0QMnp2V6fzl1Gig4F4eip47nuWC76YDcVDLn8lrOsn5Hsbdbf63OfGqfw4HzEZrXrtf2TWkUgsek6zGJGZeAOMvEZHOFrzj9ojYpKuBtTcG6Dw2XgKIdld96ujwhiHzm8sWjBSp0XQs2lU0W7LndNypOA5PwZwVrQguh1fVTJlcCLJPqSi0DlIbdjpUaZAdAWwxsHkB2Mj1z9sh3K9CA/Ia045VbVixXZUobxERIkvqkhCmoF5WubaMwZFLBE2pF2VaRwm9pHXg9bbDh9PPoACsTgyFYBtmOJKgPk5uik7uj3+KyxeNhp09Lc34XzrATx6z,iv:M9WhCLuUDyo4w44R1AQovxNRSYaAQWtlYQK2EHkRubY=,tag:GyceOfzblQnH6WPCXlsgQg==,type:str]
 sshified_private_key: ENC[AES256_GCM,data:Z2u1AruKYtHTjoXrYJNqwWQjnISGkm3+C2CMYcXF7s+h2Zw9uREqJaYUcxOUtSh4D3u5uiKrPyBObkEPQT+mHPG3W2m1kl5SezTowlW9Pno5ABK4FKtT//45oFt5UcN+eH1cnslkNlA0xRuvpCMVDGamfKt6NWmkKWH4aDJHas0KVGGbwVcttHW0LJtFvmu/jbt6W37X0yvg/XrkAEWFH1x5INox0ksI/EQhbKl3GxHGlHz2JoyuoviIPF6I+wMQ1AzQ50mqYEnnPYhaUa/phEVCH4S39/77vN/AlIT7JYchBalls5XnPJJq5zAJoiSEbLZw/Zyz2YO9R3vBEo8OzRkSz767flNhNndlIVHRCO4gux+vUb/26lGdFeDx5OsGTB4dPhP3GD9myvbD3cfBSixfkKNLuxrR6yRH3Tc4eizwxKP3nxAEPl1oEPDSf2pCbYGQ0UIyw1cABVn+kbpr5p+8tA+aj7o7R/GchZo5TnF22WfiXwiZgWZX6E15JHEEoCHoCtleb6h82MXesp7j,iv:6bUMuH0y+Jw7EN+dwnbYgXFzPtXCWLIM2uXW3ROkLEc=,tag:pRO8rtR3gNnkF5u9U1XxRg==,type:str]
+loki_basic_auth: ENC[AES256_GCM,data:STjTyfmYhUzwigMIoorvMbKeZa9/m6bT1fcKO3tWM8aHYt8+cW6zSE4OBV4=,iv:LMmvBPXzGu0I65GbfTNUHP18NqCUNiM29sQHgllugKk=,tag:ta5Acv9bxaiV0w2QZzJ6vQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -24,8 +25,8 @@ sops:
             Um56VGNaWmloWDNiWEVKZUhBd1VhdTQKrho7ofe8BhWFcqPDHjC5sdS7C2GR1wbv
             4777q4QGXC3go+rL4AtY4uMHd5NuiuSr5SMI3YIKb/Q/o4j5h266oQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-12-12T14:02:00Z"
-    mac: ENC[AES256_GCM,data:cwGky75oCZ3HrXv8joXFp3gEM9c+pJtxU9STDwOjKyquQpRrqJ4ttaw35S/x9Ag6VKdiOXQeowH5Ci+8zNK3Z8FU+UbTEi8IG5tx18aOlqDfyXi3w66VYtPY0aYiN8OqaebOGcom6BEznfrZ/zU3HXELLqXuVpf25TNfn9WPBIA=,iv:7jUopaqyjeEFc86YpOhi9/KdT7kfaDsK2YluoG9TxEk=,tag:WO3ixikWrKe9isktLdNkFQ==,type:str]
+    lastmodified: "2024-10-24T07:06:31Z"
+    mac: ENC[AES256_GCM,data:GgPwGUSiCWrdyu82qD7o6+pR6lFG+D9SpgTyXy+0dp8Nce45oEdIzj7p3eav7lV0eWIN+tX5isQr9+wSS4362OppDDFTNMzh+scFnjvyVG8rhjTZS7/pSGH6VuUzxsNKbzimd2nYZXlGD0W3D29B8lKnddrTuWI9Rf4Bo8yG1Tc=,iv:IGedT2PkbXsTbHgrXcgHcKLRjSMRCljdF8AkD9cTTDI=,tag:t3ifPpi4OyYHBTvq5euMRQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1


### PR DESCRIPTION
- Monitoring server now available at https://monitoring.vedenemo.dev
- Anonymous access removed, needs grafana account to log in
- Loki api endpoint has basic auth, except when used from within ficolo internal network
- New options added to monitoring module
- Hetzner servers can now push logs by using basic auth password