### PR TITLE
Nix trusted public key in persistent

### DIFF
--- a/terraform/arm-builder.tf
+++ b/terraform/arm-builder.tf
@@ -46,7 +46,7 @@ module "arm_builder_vm" {
   virtual_machine_name        = "ghaf-builder-aarch64-${count.index}-${local.ws}"
   virtual_machine_size        = local.opts[local.conf].vm_size_builder_aarch64
   virtual_machine_osdisk_size = local.opts[local.conf].osdisk_size_builder
-  binary_cache_public_key     = local.opts[local.conf].binary_cache_public_key
+  binary_cache_public_key     = local.binary_cache_public_key
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({
     users = [{

--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -7,7 +7,7 @@ module "binary_cache_image" {
   nix_attrpath   = ""
   nix_entrypoint = "${path.module}/custom-nixos.nix"
   nix_argstr = {
-    extraNixPublicKey = local.opts[local.conf].binary_cache_public_key
+    extraNixPublicKey = local.binary_cache_public_key
     systemName        = "az-binary-cache"
   }
 
@@ -43,7 +43,7 @@ module "binary_cache_vm" {
         "path"  = "/var/lib/azure-nix-cache-proxy/env"
       },
       {
-        content = "SITE_ADDRESS=${local.opts[local.conf].binary_cache_url}"
+        content = "SITE_ADDRESS=${local.binary_cache_url}"
         "path"  = "/var/lib/caddy/caddy.env"
       },
     ],

--- a/terraform/builder.tf
+++ b/terraform/builder.tf
@@ -8,7 +8,7 @@ module "builder_image" {
   nix_attrpath   = ""
   nix_entrypoint = "${path.module}/custom-nixos.nix"
   nix_argstr = {
-    extraNixPublicKey = local.opts[local.conf].binary_cache_public_key
+    extraNixPublicKey = local.binary_cache_public_key
     systemName        = "az-builder"
   }
 

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -8,7 +8,7 @@ module "jenkins_controller_image" {
   nix_attrpath   = ""
   nix_entrypoint = "${path.module}/custom-nixos.nix"
   nix_argstr = {
-    extraNixPublicKey = local.opts[local.conf].binary_cache_public_key
+    extraNixPublicKey = local.binary_cache_public_key
     systemName        = "az-jenkins-controller"
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -88,7 +88,8 @@ locals {
   # Such alternative names need to be manually configured for each instance
   # (once) in the relevant host's caddy config at /var/lib/caddy/caddy.env,
   # setting the SITE_ADDRESS accordingly.
-  binary_cache_url_common = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
+  binary_cache_url        = "https://ghaf-binary-cache-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com"
+  binary_cache_public_key = data.azurerm_key_vault_secret.binary_cache_signing_key_pub.value
 
   # Environment-specific configuration options.
   # See Azure vm sizes and specs at:
@@ -107,8 +108,6 @@ locals {
       osdisk_size_controller  = "150"
       num_builders_x86        = 0
       num_builders_aarch64    = 0
-      binary_cache_public_key = "priv-cache.vedenemo.dev~1:FmJGfAkx+2fhqpzHGT/V3M35VcPm2pfkCuiTo8xQD0A="
-      binary_cache_url        = local.binary_cache_url_common
       ext_builder_machines    = local.ext_builder_machines
       ext_builder_keyscan     = local.ext_builder_keyscan
     }
@@ -124,9 +123,6 @@ locals {
       osdisk_size_controller  = "1000"
       num_builders_x86        = 0
       num_builders_aarch64    = 0
-      # 'dev' and 'prod' use the same binary cache storage and key
-      binary_cache_public_key = "prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI="
-      binary_cache_url        = local.binary_cache_url_common
       ext_builder_machines    = local.ext_builder_machines
       ext_builder_keyscan     = local.ext_builder_keyscan
     }
@@ -142,9 +138,6 @@ locals {
       osdisk_size_controller  = "1000"
       num_builders_x86        = 0
       num_builders_aarch64    = 0
-      # 'dev' and 'prod' use the same binary cache storage and key
-      binary_cache_public_key = "prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI="
-      binary_cache_url        = local.binary_cache_url_common
       ext_builder_machines    = local.ext_builder_machines
       ext_builder_keyscan     = local.ext_builder_keyscan
     }
@@ -160,8 +153,6 @@ locals {
       osdisk_size_controller  = "1000"
       num_builders_x86        = 1
       num_builders_aarch64    = 1
-      binary_cache_public_key = "release-cache.vedenemo.dev~1:kxSUdZvNF8ax7hpJMu+PexEBQGUkZDqeugu+pwz/ACk="
-      binary_cache_url        = local.binary_cache_url_common
       ext_builder_machines    = []
       ext_builder_keyscan     = []
     }
@@ -294,6 +285,12 @@ data "azurerm_key_vault" "binary_cache_signing_key" {
 
 data "azurerm_key_vault_secret" "binary_cache_signing_key" {
   name         = "binary-cache-signing-key-priv"
+  key_vault_id = data.azurerm_key_vault.binary_cache_signing_key.id
+  provider     = azurerm
+}
+
+data "azurerm_key_vault_secret" "binary_cache_signing_key_pub" {
+  name         = "binary-cache-signing-key-pub"
   key_vault_id = data.azurerm_key_vault.binary_cache_signing_key.id
   provider     = azurerm
 }

--- a/terraform/persistent/binary-cache-sigkey/binary-cache-sigkey.tf
+++ b/terraform/persistent/binary-cache-sigkey/binary-cache-sigkey.tf
@@ -17,7 +17,13 @@ variable "location" {
   type = string
 }
 
-variable "secret_resource" {
+variable "signing_key" {
+  type = object({
+    value = string
+  })
+}
+
+variable "signing_key_pub" {
   type = object({
     value = string
   })
@@ -44,13 +50,21 @@ resource "azurerm_key_vault" "binary_cache_signing_key" {
 # Upload the binary cache signing key as a vault secret
 resource "azurerm_key_vault_secret" "binary_cache_signing_key" {
   name         = "binary-cache-signing-key-priv"
-  value        = var.secret_resource.value
+  value        = var.signing_key.value
   key_vault_id = azurerm_key_vault.binary_cache_signing_key.id
 
   # Each of the secrets needs an explicit dependency on the access policy.
   # Otherwise, Terraform may attempt to create the secret before creating the
   # access policy.
   # https://stackoverflow.com/a/74747333
+  depends_on = [
+    azurerm_key_vault_access_policy.binary_cache_signing_key_terraform
+  ]
+}
+resource "azurerm_key_vault_secret" "binary_cache_signing_key_pub" {
+  name         = "binary-cache-signing-key-pub"
+  value        = var.signing_key_pub.value
+  key_vault_id = azurerm_key_vault.binary_cache_signing_key.id
   depends_on = [
     azurerm_key_vault_access_policy.binary_cache_signing_key_terraform
   ]

--- a/terraform/persistent/resources/main.tf
+++ b/terraform/persistent/resources/main.tf
@@ -69,6 +69,8 @@ resource "secret_resource" "binary_cache_signing_key" {
     prevent_destroy = true
   }
 }
+resource "secret_resource" "binary_cache_signing_key_pub" {
+}
 
 module "builder_ssh_key" {
   source = "../builder-ssh-key"
@@ -83,7 +85,8 @@ module "binary_cache_sigkey" {
   source = "../binary-cache-sigkey"
   # Must be globally unique, max 24 characters
   bincache_keyvault_name = "bchek-id0${local.ws}"
-  secret_resource        = secret_resource.binary_cache_signing_key
+  signing_key            = secret_resource.binary_cache_signing_key
+  signing_key_pub        = secret_resource.binary_cache_signing_key_pub
   resource_group_name    = data.azurerm_resource_group.persistent.name
   location               = data.azurerm_resource_group.persistent.location
   tenant_id              = data.azurerm_client_config.current.tenant_id

--- a/terraform/terraform-init.sh
+++ b/terraform/terraform-init.sh
@@ -158,6 +158,7 @@ import_bincache_sigkey () {
     nix-store --generate-binary-cache-key "$key_name" sigkey-secret.tmp "sigkey-public-$key_name.tmp"
     var_rg="-var=persistent_resource_group=$PERSISTENT_RG"
     terraform import "$var_rg" secret_resource.binary_cache_signing_key "$(< ./sigkey-secret.tmp)"
+    terraform import "$var_rg" secret_resource.binary_cache_signing_key_pub "$(< ./sigkey-public-"$key_name".tmp)"
     terraform apply "$var_rg" -auto-approve >"$OUT"
     rm -f sigkey-secret.tmp
 }


### PR DESCRIPTION
- Store nix trusted public key in persistent storage
- Read the public key from the persistent storage instead of hard-coding the expected value in the terraform main module
- Change `test-deployment.sh` to support changed configuration: expected trusted public key values for eun location are pre-defined in the script - it also now supports providing the trusted public key from the command line with a new option `-p`