### PR TITLE
Stop using TerraformAdminsGHAFInfra group

### DIFF
--- a/terraform/persistent/binary-cache-sigkey/binary-cache-sigkey.tf
+++ b/terraform/persistent/binary-cache-sigkey/binary-cache-sigkey.tf
@@ -33,6 +33,9 @@ variable "tenant_id" {
   type = string
 }
 
+variable "object_id" {
+  type = string
+}
 
 ################################################################################
 
@@ -73,8 +76,7 @@ resource "azurerm_key_vault_secret" "binary_cache_signing_key_pub" {
 resource "azurerm_key_vault_access_policy" "binary_cache_signing_key_terraform" {
   key_vault_id = azurerm_key_vault.binary_cache_signing_key.id
   tenant_id    = var.tenant_id
-  # "TerraformAdminsGHAFInfra" group
-  object_id = "f80c2488-2301-4de8-89d6-4954b77f453e"
+  object_id    = var.object_id
 
   secret_permissions = [
     "Get",

--- a/terraform/persistent/builder-ssh-key/builder-ssh-key.tf
+++ b/terraform/persistent/builder-ssh-key/builder-ssh-key.tf
@@ -21,6 +21,10 @@ variable "tenant_id" {
   type = string
 }
 
+variable "object_id" {
+  type = string
+}
+
 ################################################################################
 
 # Create a ED25519 key, which the jenkins master will use to authenticate with
@@ -70,8 +74,7 @@ resource "azurerm_key_vault_secret" "ssh_remote_build_pub" {
 resource "azurerm_key_vault_access_policy" "ssh_remote_build_terraform" {
   key_vault_id = azurerm_key_vault.ssh_remote_build.id
   tenant_id    = var.tenant_id
-  # "TerraformAdminsGHAFInfra" group
-  object_id = "f80c2488-2301-4de8-89d6-4954b77f453e"
+  object_id    = var.object_id
 
   secret_permissions = [
     "Get",

--- a/terraform/persistent/main.tf
+++ b/terraform/persistent/main.tf
@@ -75,6 +75,7 @@ module "builder_ssh_key" {
   resource_group_name       = azurerm_resource_group.persistent.name
   location                  = azurerm_resource_group.persistent.location
   tenant_id                 = data.azurerm_client_config.current.tenant_id
+  object_id                 = data.azurerm_client_config.current.object_id
 }
 
 ################################################################################

--- a/terraform/persistent/resources/main.tf
+++ b/terraform/persistent/resources/main.tf
@@ -79,6 +79,7 @@ module "builder_ssh_key" {
   resource_group_name       = data.azurerm_resource_group.persistent.name
   location                  = data.azurerm_resource_group.persistent.location
   tenant_id                 = data.azurerm_client_config.current.tenant_id
+  object_id                 = data.azurerm_client_config.current.object_id
 }
 
 module "binary_cache_sigkey" {
@@ -90,6 +91,7 @@ module "binary_cache_sigkey" {
   resource_group_name    = data.azurerm_resource_group.persistent.name
   location               = data.azurerm_resource_group.persistent.location
   tenant_id              = data.azurerm_client_config.current.tenant_id
+  object_id              = data.azurerm_client_config.current.object_id
 }
 
 module "binary_cache_storage" {


### PR DESCRIPTION
Stop using hard-coded `TerraformAdminsGHAFInfra` group `object_id`, replacing it with `azurerm_client_config.current.object_id`.