### PR TITLE
 Start using nix-fast-build in github action CI

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -36,13 +36,13 @@ jobs:
   # - the event is not a pull request (eg. push to main)
   # - pull request comes from another branch in the same repo
   # - author is in our predefined list of authorized users
-  # If none of these conditions are met, the workflow requires 
+  # If none of these conditions are met, the workflow requires
   # manual approval from a maintainer with write permissions to continue
   authorize:
     needs: [check-identity]
-    environment: ${{ 
+    environment: ${{
       ( github.event_name != 'pull_request_target' ||
-        github.event.pull_request.head.repo.full_name == github.repository || 
+        github.event.pull_request.head.repo.full_name == github.repository ||
         needs.check-identity.outputs.authorized_user == 'True' )
       && 'internal' || 'external' }}
     runs-on: ubuntu-latest
@@ -78,41 +78,53 @@ jobs:
             exit 1
           fi
 
-  tests:
+  build_matrix:
+    name: "build"
     # Don't run unless authorization was successful
     needs: [authorize]
-    if: ${{ always() && needs.authorize.result == 'success' }}
-
     runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64-linux
+          - arch: aarch64-linux
+    if: ${{ always() && needs.authorize.result == 'success' }}
+    concurrency:
+      # Cancel any in-progress workflow runs from the same PR or branch,
+      # allowing matrix jobs to run concurrently:
+      group: ${{ github.workflow }}.${{ github.event.pull_request.number || github.ref }}.${{ matrix.arch }}
+      cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4.2.2
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
         with:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
             fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v30
-        with:
-          extra_nix_config: |
-            trusted-public-keys = prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://prod-cache.vedenemo.dev https://cache.nixos.org
-            connect-timeout = 5
-            max-jobs = 4
-            system-features = nixos-test benchmark big-parallel kvm
-            builders-use-substitutes = true
-            builders = @/etc/nix/machines
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
 
       - uses: cachix/cachix-action@v15
         with:
           name: ghaf-dev
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Configure remote builders
+      - name: Prepare build
         run: |
-          sudo sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >/etc/nix/id_builder_key"
-          sudo sh -c "echo 'hetzarm.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK' >>/etc/ssh/ssh_known_hosts"
-          sudo sh -c "echo 'build4.vedenemo.dev ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSI8s/wefXiD2h3I3mIRdK+d9yDGMn0qS5fpKDnSGqj' >>/etc/ssh/ssh_known_hosts"
-          sudo sh -c "echo 'ssh://github@hetzarm.vedenemo.dev aarch64-linux /etc/nix/id_builder_key 40 1 nixos-test,benchmark,big-parallel,kvm - -' >/etc/nix/machines"
-          sudo sh -c "echo 'ssh://github@build4.vedenemo.dev x86_64-linux,i686-linux /etc/nix/id_builder_key 32 1 kvm,benchmark,big-parallel,nixos-test - -' >>/etc/nix/machines"
+          sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >builder_key"
 
-      - name: Run ghaf-infra CI tests
-        run: nix develop --command inv pre-push
+      - name: Build ${{ matrix.arch }}
+        run: |
+          if [ "${{ matrix.arch }}" == "x86_64-linux" ]; then
+            BUILDER='${{ vars.BUILDER_X86 }}'
+            TARGET='x86'
+          elif [ "${{ matrix.arch }}" == "aarch64-linux" ]; then
+            BUILDER='${{ vars.BUILDER_AARCH }}'
+            TARGET='aarch'
+          else
+            echo "::error::Unknown architecture: '${{ matrix.arch }}'"
+            exit 1
+          fi
+          OPTS="--remote $BUILDER --remote-ssh-option IdentityFile builder_key"
+          nix develop --command bash -c "./scripts/nix-fast-build.sh -t $TARGET -o '$OPTS'"

--- a/flake.lock
+++ b/flake.lock
@@ -229,6 +229,32 @@
         "type": "github"
       }
     },
+    "nix-fast-build": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730278911,
+        "narHash": "sha256-CrbqsC+lEA3w6gLfpqfDMDEKoEta2sl4sbQK6Z/gXak=",
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "rev": "8e7c9d76979381441facb8888f21408312cf177a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "type": "github"
+      }
+    },
     "nix-serve-ng": {
       "inputs": {
         "flake-compat": "flake-compat_3",
@@ -334,6 +360,7 @@
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
+        "nix-fast-build": "nix-fast-build",
         "nix-serve-ng": "nix-serve-ng",
         "nixpkgs": "nixpkgs_2",
         "robot-framework": "robot-framework",

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,14 @@
       url = "github:tiiuae/ci-yubi";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-fast-build = {
+      url = "github:Mic92/nix-fast-build";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
   };
 
   outputs =

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,19 +1,20 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-_: {
+{ self, ... }:
+{
   perSystem =
     { pkgs, ... }:
     {
       checks = {
         reuse = pkgs.runCommandLocal "reuse-lint" { buildInputs = [ pkgs.reuse ]; } ''
-          cd ${../.}
+          cd ${self.outPath}
           reuse lint
           touch $out
         '';
         pycodestyle =
           pkgs.runCommandLocal "pycodestyle" { nativeBuildInputs = [ pkgs.python3.pkgs.pycodestyle ]; }
             ''
-              cd ${../.}
+              cd ${self.outPath}
               pycodestyle --max-line-length 90 $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
               touch $out
             '';
@@ -29,18 +30,18 @@ _: {
               ];
             }
             ''
-              cd ${../.}
+              cd ${self.outPath}
               export HOME=/tmp
               pylint --enable=useless-suppression -rn $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
               touch $out
             '';
         black = pkgs.runCommandLocal "black" { nativeBuildInputs = [ pkgs.python3.pkgs.black ]; } ''
-          cd ${../.}
+          cd ${self.outPath}
           black -q $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
           touch $out
         '';
         terraform-fmt = pkgs.runCommandLocal "terraform-fmt" { nativeBuildInputs = [ pkgs.terraform ]; } ''
-          cd ${../.}
+          cd ${self.outPath}
           terraform fmt -check -recursive
           touch $out
         '';

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -34,6 +34,11 @@ _: {
               pylint --enable=useless-suppression -rn $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
               touch $out
             '';
+        black = pkgs.runCommandLocal "black" { nativeBuildInputs = [ pkgs.python3.pkgs.black ]; } ''
+          cd ${../.}
+          black -q $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
+          touch $out
+        '';
       };
     };
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -10,6 +10,30 @@ _: {
           reuse lint
           touch $out
         '';
+        pycodestyle =
+          pkgs.runCommandLocal "pycodestyle" { nativeBuildInputs = [ pkgs.python3.pkgs.pycodestyle ]; }
+            ''
+              cd ${../.}
+              pycodestyle --max-line-length 90 $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
+              touch $out
+            '';
+        pylint =
+          pkgs.runCommandLocal "pylint"
+            {
+              nativeBuildInputs = with pkgs.python3.pkgs; [
+                pylint
+                colorlog
+                deploykit
+                invoke
+                tabulate
+              ];
+            }
+            ''
+              cd ${../.}
+              export HOME=/tmp
+              pylint --enable=useless-suppression -rn $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
+              touch $out
+            '';
       };
     };
 }

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -39,6 +39,11 @@ _: {
           black -q $(find . -type f -name "*.py" ! -path "*result*" ! -path "*eggs*")
           touch $out
         '';
+        terraform-fmt = pkgs.runCommandLocal "terraform-fmt" { nativeBuildInputs = [ pkgs.terraform ]; } ''
+          cd ${../.}
+          terraform fmt -check -recursive
+          touch $out
+        '';
       };
     };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -10,8 +10,13 @@
           git
           jq
           nix
+          nix-fast-build
           nixfmt-rfc-style
           nixos-rebuild
+          # parallel_env requires 'compgen' function, which is available
+          # in bashInteractive, but not bash
+          bashInteractive
+          parallel
           python3.pkgs.black
           python3.pkgs.colorlog
           python3.pkgs.deploykit

--- a/scripts/nix-fast-build.sh
+++ b/scripts/nix-fast-build.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+################################################################################
+
+# This script is a helper to run nix-fast-build for ghaf-infra.
+
+# https://www.gnu.org/software/parallel/env_parallel.html
+# shellcheck source=/dev/null
+source env_parallel.bash
+env_parallel --session
+
+set -e # exit immediately if a command fails
+set -u # treat unset variables as an error and exit
+set -o pipefail # exit if any pipeline command fails
+
+MYNAME=$(basename "$0")
+RED='' NONE=''
+DEF_BUILDER="builder.vedenemo.dev"
+
+################################################################################
+
+usage () {
+    echo ""
+    echo "Usage: $MYNAME [-h] [-v] [-o OPTS] [-t TARGET]"
+    echo ""
+    echo "Helper to run nix-fast-build for ghaf-infra"
+    echo ""
+    echo "Options:"
+    echo " -t    Build selector - supported values are 'x86' and 'aarch' (default='x86')"
+    echo " -o    Options passed directly to nix-fast-build. See available options at:"
+    echo "       https://github.com/Mic92/nix-fast-build#reference"
+    echo " -v    Set the script verbosity to DEBUG"
+    echo " -h    Print this help message"
+    echo ""
+    echo "Examples:"
+    echo ""
+    echo "  Following command builds all ghaf-infra 'x86' targets on the default"
+    echo "  remote builder ($DEF_BUILDER) authenticating as current user:"
+    echo ""
+    echo "  $ $MYNAME -t x86"
+    echo ""
+    echo ""
+    echo "  Following command builds all 'aarch' targets on the specified"
+    echo "  remote builder 'my_builder' authenticating as user 'foo' with"
+    echo "  ssh key '~/.ssh/my_key':"
+    echo ""
+    echo "  $ $MYNAME -t aarch -o '--remote foo@my_builder --remote-ssh-option IdentityFile ~/.ssh/my_key'"
+    echo ""
+}
+
+################################################################################
+
+print_err () {
+    printf "${RED}Error:${NONE} %b\n" "$1" >&2
+}
+
+argparse () {
+    # Colorize output if stdout is to a terminal (and not to pipe or file)
+    if [ -t 1 ]; then RED='\033[1;31m'; NONE='\033[0m'; fi
+    # Parse arguments
+    DEBUG="false"; OPTS="--remote $DEF_BUILDER"; TARGET="x86";
+    OPTIND=1
+    while getopts "hvo:t:" copt; do
+        case "${copt}" in
+            h)
+                usage; exit 0 ;;
+            v)
+                DEBUG="true" ;;
+            o)
+                OPTS="$OPTARG" ;;
+            t)
+                TARGET="$OPTARG" ;;
+            *)
+                print_err "unrecognized option"; usage; exit 1 ;;
+        esac
+    done
+    shift $((OPTIND-1))
+    if [ -n "$*" ]; then
+        print_err "unsupported positional argument(s): '$*'"; exit 1
+    fi
+}
+
+exit_unless_command_exists () {
+    if ! command -v "$1" &>/dev/null; then
+        print_err "command '$1' is not installed (Hint: are you inside a nix-shell?)"
+        exit 1
+    fi
+}
+
+################################################################################
+
+nix_fast_build () {
+    target="$1"
+    tfmt="%H:%M:%S"
+    [ "$DEBUG" = "true" ] && set -x
+    echo ""
+    echo "[+] $(date +"$tfmt") Start: nix-fast-build '$target'"
+    # shellcheck disable=SC2086 # intented word splitting of $OPTS
+    nix-fast-build \
+      --flake "$target" \
+      --eval-workers 4 \
+      --option verbose 1 \
+      --option accept-flake-config true \
+      --remote-ssh-option StrictHostKeyChecking no \
+      --remote-ssh-option UserKnownHostsFile /dev/null \
+      --remote-ssh-option ConnectTimeout 10 \
+      --no-download --skip-cached \
+      --no-nom \
+      $OPTS \
+      2>&1
+    ret="$?"
+    echo "[+] $(date +"$tfmt") Done: nix-fast-build '$target' (exit code: $ret)"
+    # 'nix_fast_build' is run in its own process. Below, we set the
+    # process exit status
+    exit $ret
+}
+
+################################################################################
+
+main () {
+    argparse "$@"
+    exit_unless_command_exists nix-fast-build
+    exit_unless_command_exists parallel
+    [ "$DEBUG" = "true" ] && set -x
+    targets_x86=(
+        ".#checks"
+        ".#nixosConfigurations.az-binary-cache.config.system.build.toplevel"
+        ".#nixosConfigurations.az-builder.config.system.build.toplevel"
+        ".#nixosConfigurations.az-jenkins-controller.config.system.build.toplevel"
+        ".#nixosConfigurations.build3.config.system.build.toplevel"
+        ".#nixosConfigurations.build4.config.system.build.toplevel"
+        ".#nixosConfigurations.ghaf-coverity.config.system.build.toplevel"
+        ".#nixosConfigurations.ghaf-log.config.system.build.toplevel"
+        ".#nixosConfigurations.ghaf-proxy.config.system.build.toplevel"
+        ".#nixosConfigurations.ghaf-webserver.config.system.build.toplevel"
+        ".#nixosConfigurations.himalia.config.system.build.toplevel"
+        ".#nixosConfigurations.monitoring.config.system.build.toplevel"
+        ".#nixosConfigurations.testagent-dev.config.system.build.toplevel"
+        ".#nixosConfigurations.testagent-prod.config.system.build.toplevel"
+        ".#nixosConfigurations.testagent-release.config.system.build.toplevel"
+    )
+    targets_aarch=(
+        ".#checks"
+        ".#nixosConfigurations.hetzarm.config.system.build.toplevel"
+    )
+    case "$TARGET" in
+        "x86") targets=( "${targets_x86[@]}" ) ;;
+        "aarch") targets=( "${targets_aarch[@]}" ) ;;
+        *) print_err "TARGET '$TARGET' is not supported" ;;
+    esac
+    echo "[+] OPTS='$OPTS' TARGET='$TARGET'"
+    echo "[+] Running builds, this will take a while..."
+    # Don't print out the full 'env_parallel' environment even if DEBUG=true
+    set +x
+    # Run the function 'nix_fast_build' for each flake target in targets[]
+    # array. Each instance of nix_fast_build will run in its own process.
+    # We limit the maximum number of concurrent processes to 3 (-j3) and
+    # terminate the execution of all jobs immediately if one job fails
+    # (--halt-on-error 2).
+    env_parallel -j3 --halt-on-error 2 nix_fast_build ::: "${targets[@]}"
+}
+
+main "$@"
+
+################################################################################

--- a/tasks.py
+++ b/tasks.py
@@ -511,17 +511,12 @@ def reboot(_c: Any, alias: str) -> None:
 @task
 def pre_push(c: Any) -> None:
     """
-    Run 'pre-push' checks: reuse lint, nix fmt.
+    Run 'pre-push' checks.
     Also, build all nixosConfiguration targets in this flake.
 
     Example usage:
     inv pre-push
     """
-    cmd = "terraform fmt -check -recursive"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        LOG.warning("Run `terraform fmt -recursive` locally to fix formatting")
-        sys.exit(1)
     cmd = "nix flake check -v"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:

--- a/tasks.py
+++ b/tasks.py
@@ -517,19 +517,10 @@ def pre_push(c: Any) -> None:
     Example usage:
     inv pre-push
     """
-    cmd = "reuse lint"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        sys.exit(1)
     cmd = "terraform fmt -check -recursive"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         LOG.warning("Run `terraform fmt -recursive` locally to fix formatting")
-        sys.exit(1)
-    cmd = "nix fmt -- --fail-on-change"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        LOG.warning("Run `nix fmt` locally to fix formatting")
         sys.exit(1)
     cmd = "nix flake check -v"
     ret = exec_cmd(cmd, raise_on_error=False)

--- a/tasks.py
+++ b/tasks.py
@@ -511,20 +511,12 @@ def reboot(_c: Any, alias: str) -> None:
 @task
 def pre_push(c: Any) -> None:
     """
-    Run 'pre-push' checks: black, reuse lint, nix fmt.
+    Run 'pre-push' checks: reuse lint, nix fmt.
     Also, build all nixosConfiguration targets in this flake.
 
     Example usage:
     inv pre-push
     """
-    cmd = "find . -type f -name *.py ! -path *result* ! -path *eggs*"
-    ret = exec_cmd(cmd)
-    assert ret is not None
-    pyfiles = ret.stdout.replace("\n", " ")
-    cmd = f"black -q {pyfiles}"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        sys.exit(1)
     cmd = "reuse lint"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:

--- a/tasks.py
+++ b/tasks.py
@@ -9,10 +9,6 @@
 
 ################################################################################
 
-# pylint: disable=invalid-name
-
-################################################################################
-
 # Basic usage:
 #
 # List tasks:
@@ -515,7 +511,7 @@ def reboot(_c: Any, alias: str) -> None:
 @task
 def pre_push(c: Any) -> None:
     """
-    Run 'pre-push' checks: black, pylint, pycodestyle, reuse lint, nix fmt.
+    Run 'pre-push' checks: black, reuse lint, nix fmt.
     Also, build all nixosConfiguration targets in this flake.
 
     Example usage:
@@ -526,14 +522,6 @@ def pre_push(c: Any) -> None:
     assert ret is not None
     pyfiles = ret.stdout.replace("\n", " ")
     cmd = f"black -q {pyfiles}"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        sys.exit(1)
-    cmd = f"pylint --disable duplicate-code -rn {pyfiles}"
-    ret = exec_cmd(cmd, raise_on_error=False)
-    if not ret:
-        sys.exit(1)
-    cmd = f"pycodestyle --max-line-length=90 {pyfiles}"
     ret = exec_cmd(cmd, raise_on_error=False)
     if not ret:
         sys.exit(1)


### PR DESCRIPTION
- Move pycodestyle, pylint, black, and format checks from `task.py` to ghaf-infra flake `.#checks`
- Remove all redundant checks from `task.py`
- Introduce `nix-fast-build.sh` helper to run relevant flake builds with [nix-fast-build](https://github.com/Mic92/nix-fast-build) to execute all evaluation/build operations completely on the remote builder. Add relevant dependencies to nix `devshell`.
- Start using `nix-fast-build.sh` from github action workflow `test-ghaf-infra.yml`: run all checks and build relevant x86 and aarch targets on remote. This adds some new checks too: the workflow now also builds all azure nixosConfigurations, as well as runs the `.#checks` on aarch64.

Note: after this change, cachix cache on the `test-ghaf-infra.yml` workflow  is used only to cache the ghaf-infra `devshell` dependencies. This is to make the `test-ghaf-infra.yml` faster by not having to download the build closure to the github-hosted runner. Rationale is that local builds of all the ghaf-infra nixosConfigurations are likely rare, and when required, `nix-fast-build.sh` can be used locally too (in which case the remote builder's local nix store would be used as a 'shared cache').

Example run of `test-ghaf-infra.yml` workflow with the changes from this PR: https://github.com/henrirosten/ghaf-infra/actions/runs/11854339487