### PR TITLE
Support per-environment builder ssh keys

### DIFF
--- a/terraform/persistent/builder-ssh-key/builder-ssh-key.tf
+++ b/terraform/persistent/builder-ssh-key/builder-ssh-key.tf
@@ -36,10 +36,11 @@ resource "tls_private_key" "ed25519_remote_build" {
 
 # Create an Azure key vault
 resource "azurerm_key_vault" "ssh_remote_build" {
-  name                = var.builder_ssh_keyvault_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  sku_name            = "standard"
+  name                     = var.builder_ssh_keyvault_name
+  location                 = var.location
+  resource_group_name      = var.resource_group_name
+  sku_name                 = "standard"
+  purge_protection_enabled = false
   # The Azure Active Directory tenant ID that should be used for authenticating
   # requests to the key vault
   tenant_id = var.tenant_id
@@ -79,6 +80,8 @@ resource "azurerm_key_vault_access_policy" "ssh_remote_build_terraform" {
   secret_permissions = [
     "Get",
     "List",
-    "Set"
+    "Set",
+    "Delete",
+    "Purge"
   ]
 }

--- a/terraform/persistent/resources/main.tf
+++ b/terraform/persistent/resources/main.tf
@@ -72,16 +72,6 @@ resource "secret_resource" "binary_cache_signing_key" {
 resource "secret_resource" "binary_cache_signing_key_pub" {
 }
 
-module "builder_ssh_key" {
-  source = "../builder-ssh-key"
-  # Must be globally unique, max 24 characters
-  builder_ssh_keyvault_name = "sshb-id0${local.ws}"
-  resource_group_name       = data.azurerm_resource_group.persistent.name
-  location                  = data.azurerm_resource_group.persistent.location
-  tenant_id                 = data.azurerm_client_config.current.tenant_id
-  object_id                 = data.azurerm_client_config.current.object_id
-}
-
 module "binary_cache_sigkey" {
   source = "../binary-cache-sigkey"
   # Must be globally unique, max 24 characters


### PR DESCRIPTION
Create and use per-environment builder ssh key unless external builders are used in the given ghaf-infra instance. Builder ssh key used to access the external builder(s) is still stored and accessed from the persistent resource group.

After this change, ghaf-infra configurations that don't use external builders (e.g. 'release') will create and use new builder ssh-keys on every new ghaf-infra deployment.