### PR TITLE
get-artifacts.sh: Fix resume download

### DIFF
--- a/scripts/get-artifacts.sh
+++ b/scripts/get-artifacts.sh
@@ -97,6 +97,8 @@ get_recursively () {
         --no-parent \
         --level=inf \
         --timestamping \
+        --no-if-modified-since \
+        --continue \
         --execute robots=off \
         --reject 'index.html?*' \
         --user-agent=Mozilla/5.0 \


### PR DESCRIPTION
- Use wget `--continue` option to resume downloading a partially downloaded remote directory. 
- We also need to use `--no-if-modified-since`, because otherwise wget would consider a partially downloaded file a complete due to `--timestamping`

After these changes, one can abort `get-artifacts.sh` (e.g. with ctrl-c) and continue the download later - the script will resume the download as long as the output directory from the earlier attempt is not removed.