### PR TITLE
terraform: Fix random VM image deployment errors

### DIFF
--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -16,6 +16,7 @@ module "binary_cache_image" {
   location               = azurerm_resource_group.infra.location
   storage_account_name   = azurerm_storage_account.vm_images.name
   storage_container_name = azurerm_storage_container.vm_images.name
+  depends_on             = [azurerm_storage_container.vm_images]
 }
 
 module "binary_cache_vm" {

--- a/terraform/builder.tf
+++ b/terraform/builder.tf
@@ -17,6 +17,7 @@ module "builder_image" {
   location               = azurerm_resource_group.infra.location
   storage_account_name   = azurerm_storage_account.vm_images.name
   storage_container_name = azurerm_storage_container.vm_images.name
+  depends_on             = [azurerm_storage_container.vm_images]
 }
 
 locals {

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -17,6 +17,7 @@ module "jenkins_controller_image" {
   location               = azurerm_resource_group.infra.location
   storage_account_name   = azurerm_storage_account.vm_images.name
   storage_container_name = azurerm_storage_container.vm_images.name
+  depends_on             = [azurerm_storage_container.vm_images]
 }
 
 # Create a machine using this image

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -216,9 +216,16 @@ resource "azurerm_subnet" "builders" {
   address_prefixes     = ["10.0.4.0/28"]
 }
 
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/15609
+resource "random_string" "id" {
+  length  = 8
+  upper   = false
+  special = false
+}
+
 # Storage account and storage container used to store VM images
 resource "azurerm_storage_account" "vm_images" {
-  name                            = "img${local.ws}${local.shortloc}"
+  name                            = "img${random_string.id.result}"
   resource_group_name             = azurerm_resource_group.infra.name
   location                        = azurerm_resource_group.infra.location
   account_tier                    = "Standard"

--- a/terraform/modules/azurerm-nix-vm-image/main.tf
+++ b/terraform/modules/azurerm-nix-vm-image/main.tf
@@ -38,6 +38,10 @@ resource "azurerm_image" "default" {
     os_state = "Generalized"
     os_type  = "Linux"
   }
+  depends_on = [
+    azurerm_storage_blob.default,
+    data.external.nix_build
+  ]
 }
 
 output "image_id" {


### PR DESCRIPTION
This is an attempt to fix the occasional errors that occur on clean deployments. An example terraform error from a deployment before the changes from this PR below:

```
│ Error: creating Blob "binary-cache.vhd" (Container "ghaf-infra-vm-images" / Account "imgreleaseeun"): creating storage blob
on Azure: while uploading source file "/nix/store/dvg2fqgxzd116zjhw9c5bbps96bzsfqi-azure-image/disk.vhd": writing page at 
offset 4455006208 for file "/nix/store/dvg2fqgxzd116zjhw9c5bbps96bzsfqi-azure-image/disk.vhd": 
blobs.Client#PutPageUpdate: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned 
an error. Status=403 Code="AuthenticationFailed" Message="Server failed to authenticate the request. Make sure the value of 
Authorization header is formed correctly including the signature.\n
RequestId:faafbdc5-e01e-0024-79b8-40a5e6000000\nTime:2024-11-27T10:37:11.7371065Z"
│
│   with module.binary_cache_image.azurerm_storage_blob.default,
│   on modules/azurerm-nix-vm-image/main.tf line 4, in resource "azurerm_storage_blob" "default":
│    4: resource "azurerm_storage_blob" "default" 
```

This change adds explicit dependencies, and also applies the workaround suggested in: https://github.com/hashicorp/terraform-provider-azurerm/issues/15609.

With these changes, I was not able to reproduce the failure. Although, given the randomness of the error occurance, it's still possible this doesn't completely fix it.