### PR TITLE
Define pipeline jobs using JCasC and Job DSL

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -230,10 +230,15 @@ in
       ''
         # Install plugins
         jenkins-cli ${jenkins-auth} install-plugin \
-          "workflow-aggregator" "github" "timestamper" "pipeline-stage-view" "blueocean" \
-          "pipeline-graph-view" "github-pullrequest" "antisamy-markup-formatter" \
-          "configuration-as-code" "slack" "pipeline-utility-steps" "pipeline-build-step" \
-          "robot" "copyartifact"
+          "configuration-as-code" "job-dsl" \
+          "workflow-aggregator" "pipeline-utility-steps" "pipeline-build-step" \
+          "github" "github-pullrequest" \
+          "blueocean" "pipeline-stage-view" "pipeline-graph-view" \
+          "timestamper" \
+          "antisamy-markup-formatter" \
+          "slack" \
+          "robot" \
+          "copyartifact"
 
         # Disable initial install
         jenkins-cli ${jenkins-auth} groovy = < ${jenkins-groovy}

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -137,45 +137,6 @@ in
       # Increase the number of rows shown in Stage View (default is 10)
       "-Dcom.cloudbees.workflow.rest.external.JobExt.maxRunsPerJob=32"
     ];
-
-    # Configure jenkins job(s):
-    # https://jenkins-job-builder.readthedocs.io/en/latest/project_pipeline.html
-    # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/continuous-integration/jenkins/job-builder.nix
-    jobBuilder = {
-      enable = true;
-      nixJobs =
-        lib.mapAttrsToList
-          (display-name: script: {
-            job = {
-              inherit display-name;
-              name = script;
-              project-type = "pipeline";
-              concurrent = true;
-              pipeline-scm = {
-                script-path = "${script}.groovy";
-                lightweight-checkout = true;
-                scm = [
-                  {
-                    git = {
-                      url = "https://github.com/tiiuae/ghaf-jenkins-pipeline.git";
-                      clean = true;
-                      branches = [ "*/main" ];
-                    };
-                  }
-                ];
-              };
-            };
-          })
-          {
-            "Ghaf main pipeline" = "ghaf-main-pipeline";
-            "Ghaf pre-merge pipeline" = "ghaf-pre-merge-pipeline";
-            "Ghaf nightly pipeline" = "ghaf-nightly-pipeline";
-            "Ghaf release pipeline" = "ghaf-release-pipeline";
-            "Ghaf HW test" = "ghaf-hw-test";
-            "Ghaf parallel HW test" = "ghaf-parallel-hw-test";
-            "FMO OS main pipeline" = "fmo-os-main-pipeline";
-          };
-    };
   };
 
   systemd.services.jenkins.serviceConfig = {

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -307,3 +307,13 @@ jobs:
           }
         }
       }
+  - script: >
+      queue('Ghaf main pipeline')
+  - script: >
+      queue('Ghaf pre-merge pipeline')
+  - script: >
+      queue('Ghaf nightly pipeline')
+  - script: >
+      queue('Ghaf release pipeline')
+  - script: >
+      queue('FMO OS main_pipeline')

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -168,7 +168,8 @@ tool:
 # https://jenkinsci.github.io/job-dsl-plugin
 jobs:
   - script: >
-      pipelineJob('Ghaf main pipeline') {
+      pipelineJob('ghaf-main-pipeline') {
+        displayName('Ghaf main pipeline')
         definition {
           cpsScm {
             scm {
@@ -181,14 +182,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-main-pipeline.groovy")
+              scriptPath('ghaf-main-pipeline.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('Ghaf pre-merge pipeline') {
+      pipelineJob('ghaf-pre-merge-pipeline') {
+        displayName('Ghaf pre-merge pipeline')
         definition {
           cpsScm {
             scm {
@@ -201,14 +203,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-pre-merge-pipeline.groovy")
+              scriptPath('ghaf-pre-merge-pipeline.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('Ghaf nightly pipeline') {
+      pipelineJob('ghaf-nightly-pipeline') {
+        displayName('Ghaf nightly pipeline')
         definition {
           cpsScm {
             scm {
@@ -221,14 +224,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-nightly-pipeline.groovy")
+              scriptPath('ghaf-nightly-pipeline.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('Ghaf release pipeline') {
+      pipelineJob('ghaf-release-pipeline') {
+        displayName('Ghaf release pipeline')
         definition {
           cpsScm {
             scm {
@@ -241,14 +245,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-release-pipeline.groovy")
+              scriptPath('ghaf-release-pipeline.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('Ghaf HW test') {
+      pipelineJob('ghaf-hw-test') {
+        displayName('Ghaf HW test')
         definition {
           cpsScm {
             scm {
@@ -261,14 +266,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-hw-test.groovy")
+              scriptPath('ghaf-hw-test.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('Ghaf parallel HW test') {
+      pipelineJob('ghaf-parallel-hw-test') {
+        displayName('Ghaf parallel HW test')
         definition {
           cpsScm {
             scm {
@@ -281,14 +287,15 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("ghaf-parallel-hw-test.groovy")
+              scriptPath('ghaf-parallel-hw-test.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      pipelineJob('FMO OS main_pipeline') {
+      pipelineJob('fmo-os-main-pipeline') {
+        displayName('FMO OS main_pipeline')
         definition {
           cpsScm {
             scm {
@@ -301,19 +308,19 @@ jobs:
                   cleanBeforeCheckout()
                 }
               }
-              scriptPath("fmo-os-main-pipeline.groovy")
+              scriptPath('fmo-os-main-pipeline.groovy')
             }
             lightweight()
           }
         }
       }
   - script: >
-      queue('Ghaf main pipeline')
+      queue('ghaf-main-pipeline')
   - script: >
-      queue('Ghaf pre-merge pipeline')
+      queue('ghaf-pre-merge-pipeline')
   - script: >
-      queue('Ghaf nightly pipeline')
+      queue('ghaf-nightly-pipeline')
   - script: >
-      queue('Ghaf release pipeline')
+      queue('ghaf-release-pipeline')
   - script: >
-      queue('FMO OS main_pipeline')
+      queue('fmo-os-main-pipeline')

--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -164,3 +164,146 @@ tool:
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"
+# https://github.com/jenkinsci/job-dsl-plugin
+# https://jenkinsci.github.io/job-dsl-plugin
+jobs:
+  - script: >
+      pipelineJob('Ghaf main pipeline') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-main-pipeline.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('Ghaf pre-merge pipeline') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-pre-merge-pipeline.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('Ghaf nightly pipeline') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-nightly-pipeline.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('Ghaf release pipeline') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-release-pipeline.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('Ghaf HW test') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-hw-test.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('Ghaf parallel HW test') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("ghaf-parallel-hw-test.groovy")
+            }
+            lightweight()
+          }
+        }
+      }
+  - script: >
+      pipelineJob('FMO OS main_pipeline') {
+        definition {
+          cpsScm {
+            scm {
+              git {
+                remote {
+                  url('https://github.com/tiiuae/ghaf-jenkins-pipeline.git')
+                }
+                branch('*/main')
+                extensions {
+                  cleanBeforeCheckout()
+                }
+              }
+              scriptPath("fmo-os-main-pipeline.groovy")
+            }
+            lightweight()
+          }
+        }
+      }


### PR DESCRIPTION
Install Jenkins Job DSL plugin.
Define pipelines jobs using JCasC.
Scheduling builds for pipeline jobs when JCasC configuration is loaded.

Related PR changes pipeline jobs so that only their configuration is loaded when JCasC is loaded:
https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/110