### PR TITLE
Update release agent's usb_sd_mux_port

### DIFF
--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -116,7 +116,7 @@
           socket_ip_address = "172.18.16.41";
           plug_type = "TAPOP100v2";
           switch_bot = "NONE";
-          usb_sd_mux_port = "/dev/usb-sd-mux/id-000000001267";
+          usb_sd_mux_port = "/dev/usb-sd-mux/id-00048.00197";
           ext_drive_by-id = "usb-LinuxAut_sdmux_HS-SD_MMC_000000001267-0:0";
           threads = 4;
         };


### PR DESCRIPTION
Update release testagent's usb_sd_mux_port value
after mux changed to newer version.