### PR TITLE
Replace reuse dep5 with REUSE.toml

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,8 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: ghaf
-Upstream-Contact: <https://github.com/tiiuae/ghaf>
-Source: https://github.com/tiiuae/ghaf
-
-Copyright: 2022-2024 Technology Innovation Institute (TII) <https://github.com/tiiuae/ghaf-infra>
-License: Apache-2.0
-Files: *.lock *patch *.png *.svg *.csv *.yaml *.pub */provider.tf */backend.tf

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+SPDX-PackageName = "ghaf-infra"
+SPDX-PackageSupplier = "Technology Innovation Institute <https://tii.ae>"
+SPDX-PackageDownloadLocation = "https://github.com/tiiuae/ghaf-infra"
+
+[[annotations]]
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "2022-2025 TII (SSRC) and the Ghaf contributors"
+precedence = "closest"
+path = [
+  "flake.lock",
+  "**.patch",
+  "**.yaml",
+  "**/provider.tf",
+  "**/backend.tf",
+]


### PR DESCRIPTION
Reuse dep5 is [deprecated](https://reuse.software/spec-3.2/#dep5-deprecated): replace reuse dep5 with [REUSE.toml](https://reuse.software/spec-3.2/#reusetoml)