### PR TITLE
Move rpi config from dev to prod

### DIFF
--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -132,10 +132,6 @@
           ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0W606188E-0:0";
           threads = 20;
         };
-        measurement_agent = {
-          inherit location;
-          device_ip_address = "172.18.16.10";
-        };
       };
     };
 }

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -108,6 +108,10 @@
           ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0T918984B-0:0";
           threads = 8;
         };
+        measurement_agent = {
+          inherit location;
+          device_ip_address = "172.18.16.10";
+        };
       };
     };
 }


### PR DESCRIPTION
We are connecting power measurement system to lenovo-x1 on prod setup. Already tested it in dev setup. So to make it work only in prod setup need to have that rpi ip config moved to prod.