### PR TITLE
hosts/azure: add users to wheel, make trusted

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -21,6 +21,8 @@ in
       max-free = asGB 200;
       # check the free disk space every 5 seconds
       min-free-check-interval = 5;
+      # Trust users in the wheel group. They can sudo anyways.
+      trusted-users = [ "@wheel" ];
     };
   };
   systemd.services.nix-gc.serviceConfig = {
@@ -49,6 +51,9 @@ in
   # but the way nixpkgs configures cloud-init prevents it from picking up DNS
   # settings from elsewhere.
   # services.resolved.enable = false;
+
+  security.sudo.enable = true;
+  security.sudo.wheelNeedsPassword = false;
 
   # List packages installed in system profile
   environment.systemPackages = with pkgs; [

--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -35,7 +35,7 @@ module "jenkins_controller_vm" {
     users = [
       for user in toset(["bmg", "flokli", "hrosten", "jrautiola", "karim", "cazfi", "vjuntunen", "ktu", "alextserepov", "fayad"]) : {
         name                = user
-        sudo                = "ALL=(ALL) NOPASSWD:ALL"
+        groups              = "wheel"
         ssh_authorized_keys = local.ssh_keys[user]
       }
     ]


### PR DESCRIPTION
Use membership in the "wheel" group to control whether users are allowed to sudo or not, rather than managing it explicitly.

Also configure everyone in the wheel group to be a trusted Nix user. These same users where already able to sudo without password, so this doesn't give them more privileges.

However, it allows them to also use nix-copy-closure to upload loacally-built closures to a system, which is a great way to incrementally test changes without having to recreate a new VM image every time.

A subsequent terraform run would still redeploy a new VM with a new image, but this can dramatically reduce the iteration time during development.