### PR TITLE
Prevent workspace name conflict

### DIFF
--- a/terraform/terraform-init.sh
+++ b/terraform/terraform-init.sh
@@ -203,6 +203,10 @@ init_persistent_resources () {
 init_workspace_persistent () {
     echo "[+] Initializing workspace-specific persistent"
     pushd "$MYDIR/persistent/workspace-specific" >"$OUT"
+    if [[ "$WORKSPACE" =~ ^(release|prod|priv)"$SHORTLOC"$ ]]; then
+        print_err "workspace name '$WORKSPACE' is taken by persistent resource group"
+        exit 1
+    fi
     run_terraform_init
     terraform workspace select -or-create "$WORKSPACE" >"$OUT"
     terraform apply -var="persistent_resource_group=$PERSISTENT_RG" -auto-approve >"$OUT"


### PR DESCRIPTION
On initializing 'workspace persistent' data, we need to check the user-defined WORKSPACE name does not overlap with one of the [hardcoded (and thus reserved)](https://github.com/tiiuae/ghaf-infra/blob/2bb4bc6b3ceb3991eccc9df12593312b6e636b77/terraform/terraform-init.sh#L196) persistent workspace names.

This change adds a check that aborts `terraform-init.sh` in case user-defined WORKSPACE overlaps.