### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733168902,
-        "narHash": "sha256-8dupm9GfK+BowGdQd7EHK5V61nneLfr9xR6sc5vtDi0=",
+        "lastModified": 1737038063,
+        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "785c1e02c7e465375df971949b8dcbde9ec362e5",
+        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733069686,
-        "narHash": "sha256-lThMnu0otRxDTso07OU72+RZrUNokXwLKTjzTWGrxUo=",
+        "lastModified": 1736592044,
+        "narHash": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "95f5dc09a725a1916fd064f01eb3be9a5f487095",
+        "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733261153,
-        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
+        "lastModified": 1737885640,
+        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
+        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
         "type": "github"
       },
       "original": {
@@ -208,11 +208,11 @@
     },
     "nixpkgs-24-05": {
       "locked": {
-        "lastModified": 1733220138,
-        "narHash": "sha256-Yh5XZ9yVurrcYdNTSWxYgW4+EJ0pcOqgM1043z9JaRc=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcb68885668cccec12276bbb379f8f2557aa06ce",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
@@ -224,14 +224,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "robot-framework": {
@@ -242,11 +242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733301664,
-        "narHash": "sha256-xJpAWU2X1xx9nt/i76/HiiLUxGutMciHFMdnxLTOS4c=",
+        "lastModified": 1737971710,
+        "narHash": "sha256-wYllm02f+Py92Y607ESwJ1QieEgSr9z+pwnfu+N/NLc=",
         "owner": "tiiuae",
         "repo": "ci-test-automation",
-        "rev": "0e9150e6708a0d6954008554b29228682d3a2363",
+        "rev": "1852757448e2b44c52cb478bcae19a9583034dc4",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733401583,
-        "narHash": "sha256-hbhVNtw3pqSPhmSM5P2oH3J1EicE3L9oTWqYPyl4jk4=",
+        "lastModified": 1736944108,
+        "narHash": "sha256-YRX6KMqBmKtHHVIbWrLQPPHyO97g/z8osTLM1qnnfGU=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "bb75766bc4a839edca36e350956d19d8c83c2405",
+        "rev": "79f5f02cdfe251ee2c3b3f213fcf8c954bb4674a",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733128155,
-        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
+        "lastModified": 1737411508,
+        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
+        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
         "type": "github"
       },
       "original": {
@@ -376,11 +376,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733222881,
-        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
         "type": "github"
       },
       "original": {

--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -70,7 +70,7 @@ let
         print(s.value)
       '';
 
-  # nixos 24.05 pkgs is used for rclone and jenkins-job-builder
+  # nixos 24.05 pkgs is used for rclone
   old-pkgs = import inputs.nixpkgs-24-05 { inherit (pkgs) system; };
 
   # rclone 1.68.2 breaks our pipelines, keep using the old 1.66 version
@@ -106,15 +106,6 @@ in
       "x-systemd.growfs"
     ];
   };
-
-  # https://github.com/NixOS/nixpkgs/issues/362054
-  # Use jenkins-job-builder from nixos-24.05, as it's broken in 24.11.
-  # Needs to be an overlay so that it propagates to service.jenkins.jobBuilder
-  nixpkgs.overlays = [
-    (_: _: {
-      inherit (old-pkgs) jenkins-job-builder;
-    })
-  ];
 
   services.jenkins = {
     enable = true;

--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -60,6 +60,7 @@
   };
 
   programs.ssh.knownHosts = {
-    "hetzarm.vedenemo.dev".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    "hetzarm.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
   };
 }

--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -50,9 +50,12 @@ in
   users.users."sshified".isNormalUser = true;
 
   services.openssh.knownHosts = {
-    "65.21.20.242".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
-    "95.217.177.197".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
-    "95.216.200.85".publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
+    "65.21.20.242".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    "95.217.177.197".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
+    "95.216.200.85".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
   };
 
   # runs a tiny webserver on port 8888 that tunnels requests through ssh connection

--- a/pkgs/coverity/default.nix
+++ b/pkgs/coverity/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://archive.ssrcdevops.tii.ae/ghaf/cov-analysis.tar.gz";
-    hash = "sha256-Y6DvakNzl+FVZjPq+X/R0RQ9SMzyztZlA/yD0slPG7M=";
+    hash = "sha256-Jafs8hegK3fWcy9/YGhy4mnRVCdFj0BYKZoipkph7fc=";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];


### PR DESCRIPTION
- Jenkins is updated to fix a CVE https://github.com/NixOS/nixpkgs/pull/360869 and also for better plugin compability
- jenkins-job-builder is now fixed so we don't have to use the 24.05 version.
- Coverity had a hash mismatch -> updated hash.
- Most recent nix formatter behaves slightly differently so had to do a reformat.