### PR TITLE
 Fix typo ctsopokis in binary-cache

### DIFF
--- a/terraform/binary-cache.tf
+++ b/terraform/binary-cache.tf
@@ -31,7 +31,7 @@ module "binary_cache_vm" {
 
   virtual_machine_custom_data = join("\n", ["#cloud-config", yamlencode({
     users = [
-      for user in toset(["bmg", "flokli", "hrosten", "jrautiola", "vjuntunen", "karim", "cazfi", "fayad", "kanyfantakis", "ctsopkis"]) : {
+      for user in toset(["bmg", "flokli", "hrosten", "jrautiola", "vjuntunen", "karim", "cazfi", "fayad", "kanyfantakis", "ctsopokis"]) : {
         name                = user
         sudo                = "ALL=(ALL) NOPASSWD:ALL"
         ssh_authorized_keys = local.ssh_keys[user]


### PR DESCRIPTION
Marko getting the
```
Error: Invalid index
│
│   on binary-cache.tf line 37, in module "binary_cache_vm":
│   37:         ssh_authorized_keys = local.ssh_keys[user]
│     ├────────────────
│     │ local.ssh_keys is object with 12 attributes
```