### PR TITLE
sbomnix: Use nixpkgs from sbomnix upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -246,6 +246,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "robot-framework": {
       "inputs": {
         "flake-utils": [
@@ -299,9 +315,7 @@
         "flake-root": [
           "flake-root"
         ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_3",
         "treefmt-nix": [
           "treefmt-nix"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,6 @@
     sbomnix = {
       url = "github:tiiuae/sbomnix";
       inputs = {
-        nixpkgs.follows = "nixpkgs";
         flake-parts.follows = "flake-parts";
         flake-compat.follows = "flake-compat";
         flake-root.follows = "flake-root";


### PR DESCRIPTION
This change fixes an issue with vulnix scans, an example error is here: https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/ghaf-nightly-pipeline/62/execution/node/385/log/.

That same issue was fixed in vulnix upstream: https://github.com/nix-community/vulnix/pull/101. The vulnix fix in nixpkgs [has not been backported to 24.11](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/vu/vulnix/package.nix), which is the nixpkgs version ghaf-infra flake [currently follows](https://github.com/tiiuae/ghaf-infra/blob/bfef20ce4a387ef67c40bc00326ad45ba0feab76/flake.nix#L8). Therefore, if we enforce sbomnix to follow the 24.11 nixpkgs, it will use vulnix version `vulnix-1.10.1-unstable-2024-04-02` which does not include the fix.

To include the fix in ghaf-infra, we need to let sbomnix use a version of nixpkgs from nixos-unstable that includes vulnix version 1.10.2 with the [fix](https://github.com/nix-community/vulnix/pull/101) included.
