### PR TITLE
Use Github auth for monitoring server access

### DIFF
--- a/hosts/monitoring/secrets.yaml
+++ b/hosts/monitoring/secrets.yaml
@@ -1,6 +1,8 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:3syc79zImKOJ85pvTNTFN1HWC4cX2aguP8OtlbxiElZWVC6nanJ6boAhjaO/sdIh9tppmrUdBID6QJsLnFABwtEwUj2O0oGYUddtZxerXnyEeP4EncSubJQDtmJxdVWMT7lnu0nseZT54CozbhQ+7EdX6kEOGwLR2Hm0nbaGNnHQLZKaxN37gKycG2csLs1Z2pI03dutFk4E7z1bD0QMnp2V6fzl1Gig4F4eip47nuWC76YDcVDLn8lrOsn5Hsbdbf63OfGqfw4HzEZrXrtf2TWkUgsek6zGJGZeAOMvEZHOFrzj9ojYpKuBtTcG6Dw2XgKIdld96ujwhiHzm8sWjBSp0XQs2lU0W7LndNypOA5PwZwVrQguh1fVTJlcCLJPqSi0DlIbdjpUaZAdAWwxsHkB2Mj1z9sh3K9CA/Ia045VbVixXZUobxERIkvqkhCmoF5WubaMwZFLBE2pF2VaRwm9pHXg9bbDh9PPoACsTgyFYBtmOJKgPk5uik7uj3+KyxeNhp09Lc34XzrATx6z,iv:M9WhCLuUDyo4w44R1AQovxNRSYaAQWtlYQK2EHkRubY=,tag:GyceOfzblQnH6WPCXlsgQg==,type:str]
 sshified_private_key: ENC[AES256_GCM,data:Z2u1AruKYtHTjoXrYJNqwWQjnISGkm3+C2CMYcXF7s+h2Zw9uREqJaYUcxOUtSh4D3u5uiKrPyBObkEPQT+mHPG3W2m1kl5SezTowlW9Pno5ABK4FKtT//45oFt5UcN+eH1cnslkNlA0xRuvpCMVDGamfKt6NWmkKWH4aDJHas0KVGGbwVcttHW0LJtFvmu/jbt6W37X0yvg/XrkAEWFH1x5INox0ksI/EQhbKl3GxHGlHz2JoyuoviIPF6I+wMQ1AzQ50mqYEnnPYhaUa/phEVCH4S39/77vN/AlIT7JYchBalls5XnPJJq5zAJoiSEbLZw/Zyz2YO9R3vBEo8OzRkSz767flNhNndlIVHRCO4gux+vUb/26lGdFeDx5OsGTB4dPhP3GD9myvbD3cfBSixfkKNLuxrR6yRH3Tc4eizwxKP3nxAEPl1oEPDSf2pCbYGQ0UIyw1cABVn+kbpr5p+8tA+aj7o7R/GchZo5TnF22WfiXwiZgWZX6E15JHEEoCHoCtleb6h82MXesp7j,iv:6bUMuH0y+Jw7EN+dwnbYgXFzPtXCWLIM2uXW3ROkLEc=,tag:pRO8rtR3gNnkF5u9U1XxRg==,type:str]
 loki_basic_auth: ENC[AES256_GCM,data:STjTyfmYhUzwigMIoorvMbKeZa9/m6bT1fcKO3tWM8aHYt8+cW6zSE4OBV4=,iv:LMmvBPXzGu0I65GbfTNUHP18NqCUNiM29sQHgllugKk=,tag:ta5Acv9bxaiV0w2QZzJ6vQ==,type:str]
+github_client_secret: ENC[AES256_GCM,data:VOj/3LS6aW999ZrWENEfoUQD7k1q72aQFk60ZeHOv9lCPcXEvuyojg==,iv:lClGyJUPNoRcghvAHFGxJmVhFgg33gk/K2KGwNlsyIs=,tag:xH+oiy92W4Tp89z+tq8XUw==,type:str]
+github_client_id: ENC[AES256_GCM,data:Zt4DOWQNH9A1T9weX4Rm4BfaNGw=,iv:eEaA8eZjU5xLdakGRiOgq+RgEeErPcuC0cif4X0iwYg=,tag:c0HAn1KT7c6Q0zOaLE5lGg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -25,8 +27,8 @@ sops:
             Um56VGNaWmloWDNiWEVKZUhBd1VhdTQKrho7ofe8BhWFcqPDHjC5sdS7C2GR1wbv
             4777q4QGXC3go+rL4AtY4uMHd5NuiuSr5SMI3YIKb/Q/o4j5h266oQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-24T07:06:31Z"
-    mac: ENC[AES256_GCM,data:GgPwGUSiCWrdyu82qD7o6+pR6lFG+D9SpgTyXy+0dp8Nce45oEdIzj7p3eav7lV0eWIN+tX5isQr9+wSS4362OppDDFTNMzh+scFnjvyVG8rhjTZS7/pSGH6VuUzxsNKbzimd2nYZXlGD0W3D29B8lKnddrTuWI9Rf4Bo8yG1Tc=,iv:IGedT2PkbXsTbHgrXcgHcKLRjSMRCljdF8AkD9cTTDI=,tag:t3ifPpi4OyYHBTvq5euMRQ==,type:str]
+    lastmodified: "2025-02-07T12:23:10Z"
+    mac: ENC[AES256_GCM,data:MKzYWVfb80VB8ByB3Mlpocw9bZyqejR8oqAoyU1c6gHG0zKYOGRMUtRVZSSC2WyZ4E+I+xxiYKUJFnUo9bwg+L3skfncF6sajCmdRy2oedk77N5iC7dDlPQDFOXRcaHBblFpV7vjjX7NLaplRms2IVzQBkLiNtakxRDhnrmT8H8=,iv:bRvBkYuDd20RxKL5uqXg7BhBP5C5FXR205pGgyN6DIU=,tag:PUSIwaLhkHUihbT6oVhvCw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.2


### PR DESCRIPTION
Users can now log in to https://monitoring.vedenemo.dev with their Github account if they are in the `tiiuae` org and in the `devenv-fi` team.