### PR TITLE
Set correct thread number for Orin AGX

### DIFF
--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -86,7 +86,7 @@
           switch_bot = "NONE";
           usbhub_serial = "0x2954223B";
           ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W202677W-0:0";
-          threads = 8;
+          threads = 12;
         };
         OrinNX1 = {
           inherit location;

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -76,7 +76,7 @@
           switch_bot = "NONE";
           usbhub_serial = "92D8AEB7";
           ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WXNS0W300153T-0:0";
-          threads = 8;
+          threads = 12;
         };
         LenovoX1-1 = {
           inherit location;

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -102,7 +102,7 @@
           switch_bot = "NONE";
           usbhub_serial = "EBBBCDD4";
           ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WYNS0W402363J-0:0";
-          threads = 8;
+          threads = 12;
         };
         LenovoX1-1 = {
           inherit location;


### PR DESCRIPTION
Orin AGX has 12 threads available in all of the 3 setups: dev, prod and release but only 8 was configured for multi- thread performance tests.