### PR TITLE
builders: Increase ulimit -n

### DIFF
--- a/hosts/builders/builders-common.nix
+++ b/hosts/builders/builders-common.nix
@@ -7,4 +7,13 @@
   services.openssh.settings = {
     MaxStartups = 100;
   };
+  # Increase the maximum number of open files user limit, see ulimit
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      item = "nofile";
+      type = "-";
+      value = "8192";
+    }
+  ];
 }


### PR DESCRIPTION
Increase the maximum number of open files per user, see `ulimit -n`.

Fixes an issue that we have occasionally started seeing on builders:
```
error: creating pipe: Too many open files
```