### PR TITLE
Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -103,9 +103,9 @@ jobs:
             fetch-depth: 0
 
       - name: Install nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
 
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v16
         with:
           name: ghaf-dev
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cachix/cachix-action](https://github.com/cachix/cachix-action)** published a new release **[v16](https://github.com/cachix/cachix-action/releases/tag/v16)** on 2025-03-10T18:55:40Z
* **[cachix/install-nix-action](https://github.com/cachix/install-nix-action)** published a new release **[v31](https://github.com/cachix/install-nix-action/releases/tag/v31)** on 2025-03-10T14:03:18Z
