### PR TITLE
Populate task targets from deploy-rs node data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ This document assumes you have [`nix`](https://nixos.org/download.html) package 
 Experimental feature "nix-command" must be enabled.
 
 Clone this repository:
+
 ```bash
 ❯ git clone https://github.com/tiiuae/ghaf-infra.git
 ❯ cd ghaf-infra
 ```
 
 Bootstrap ghaf-infra development environment, loading the required development dependencies:
+
 ```bash
 # Start a nix-shell with required dependencies:
 ❯ nix-shell
@@ -27,6 +29,7 @@ Bootstrap ghaf-infra development environment, loading the required development d
 All commands referenced in the documentation are executed inside the nix-shell.
 
 ## Directory Structure
+
 ```bash
 ghaf-infra
 ├── hosts # NixOS host configurations
@@ -63,7 +66,8 @@ ghaf-infra
 
 Ghaf-infra repository includes configuration files for Ghaf CI/CD infrastructure.
 The configuration in this repository is split in two parts:
-- `terraform/` directory contains the terraform configuration describing the image-based CI setup in Azure infra. An example instance is the 'prod' instance, which provides the Jenkins interface at: https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/ as well as the Ghaf nix binary cache at: https://prod-cache.vedenemo.dev. The host configuration files in `hosts/azure` describe the NixOS configuration for the `binary-cache`, `builder`, and `jenkins-controller` hosts as outlined in [README-azure.md](https://github.com/tiiuae/ghaf-infra/blob/main/terraform/README-azure.md#image-based-builds).
+
+- `terraform/` directory contains the terraform configuration describing the image-based CI setup in Azure infra. An example instance is the 'prod' instance, which provides the Jenkins interface at: <https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/> as well as the Ghaf nix binary cache at: <https://prod-cache.vedenemo.dev>. The host configuration files in `hosts/azure` describe the NixOS configuration for the `binary-cache`, `builder`, and `jenkins-controller` hosts as outlined in [README-azure.md](https://github.com/tiiuae/ghaf-infra/blob/main/terraform/README-azure.md#image-based-builds).
 - In addition to the terraform Azure infra, this repository contains NixOS configurations for various other stand-alone hosts in Ghaf CI/CD infra.
   Following are examples of some of the stand-alone configurations and their current usage in the CI/CD infrastructure:
   - `hosts/builders/hetzarm` defines the configuration for shared aarch64 builder, which currently runs in Hetzner cloud (hetzarm.vedenemo.dev). Developers can use `hetzarm.vedenemo.dev` as a remote builder for Ghaf aarch builds. Additionally, `hetzarm` is used both from Ghaf github actions and non-release Jenkins builds as a remote builder.
@@ -75,10 +79,12 @@ Usage and deployment of the Azure infra is described in [`terraform/README.md`](
 Following sections describe the intended usage and deployment of the stand-alone NixOS configurations.
 
 ## Usage
+
 **Important**:
 The configuration files in this repository declaratively define the system configuration for all hosts in the Ghaf CI/CD infrastructure. That is, all system configurations - including the secrets - are stored and version controlled in this repository. Indeed, all the hosts in the infrastructure might be reinstalled without further notice, so do not assume that anything outside the configurations defined in this repository would be available in the hosts. This includes the administrator's home directories: do not keep any important data in your home, since the contents of `/home` might be deleted without further notice.
 
 ### Secrets
+
 For deployment secrets (such as the binary cache signing key), this project uses [sops-nix](https://github.com/Mic92/sops-nix).
 
 The general idea is: each host have `secrets.yaml` file that contains the encrypted secrets required by that host. As an example, the `secrets.yaml` file for the host ghaf-proxy defines a secret [`loki_password`](https://github.com/tiiuae/ghaf-infra/blob/6be2cb637af86ddb1abd8bfb60160f81ce6581ca/hosts/ghaf-proxy/secrets.yaml#L2) which is used by the host ghaf-proxy in [its](https://github.com/tiiuae/ghaf-infra/blob/6be2cb637af86ddb1abd8bfb60160f81ce6581ca/hosts/ghaf-proxy/configuration.nix#L51) monitoring service configuration to push logs to Grafana Loki. All secrets in `secrets.yaml` can be decrypted with each host's ssh key - sops automatically decrypts the host secrets when the system activates (i.e. on boot or whenever nixos-rebuild switch occurs) and places the decrypted secrets in the configured file paths. An [admin user](https://github.com/tiiuae/ghaf-infra/blob/6be2cb637af86ddb1abd8bfb60160f81ce6581ca/.sops.yaml#L6-L12) manages the secrets by using the `sops` command line tool.
@@ -90,29 +96,33 @@ Each host's private ssh key is stored as sops secret and automatically deployed 
 The secrets configuration and the usage of `sops` is adopted from [nix-community infra](https://github.com/nix-community/infra) project.
 
 ### Onboarding new remote builder users
+
 Onboarding new users to remote builders require the following manual steps:
+
 - Add their user and ssh key to [developers](./hosts/builders/developers.nix).
 - [Deploy](./docs/deploy-rs.md) the new configuration to changed hosts.
 
 ### Onboarding new admins
+
 Onboarding new admins require the following manual steps:
+
 - Add their user and ssh key to [users](./users/) and import the user on the hosts they need access to.
 - If they need to manage sops secrets, add their [age key](./docs/adapting-to-new-environments.md#add-your-admin-sops-key) to [.sops.yaml](.sops.yaml), update the `creation_rules`, and run the [`update-sops-files`](./docs/tasks.md#update-sops-files) task.
 - [Deploy](./docs/deploy-rs.md) the new configuration to changed hosts (build3, hetzarm).
 
-### Deploy using deploy-rs
-Follow the instructions at https://github.com/tiiuae/ghaf-infra/blob/main/docs/deploy-rs.md
+### Deploy changes using deploy-rs
 
-### Deploy using tasks.py
-Follow the instructions at https://github.com/tiiuae/ghaf-infra/blob/main/docs/tasks.md
+Follow the instructions at <https://github.com/tiiuae/ghaf-infra/blob/main/docs/deploy-rs.md>
 
 ### Git commit hook
+
 This project uses git hooks to ensure the git commit message aligns with [Ghaf commit message guidelines](https://github.com/tiiuae/ghaf/blob/main/CONTRIBUTING.md#commit-message-guidelines)
 
 To install the commit hook, run `./githooks/install-git-hooks.sh`. Commit message check [script](./githooks/check-commit.sh) will then run for all ghaf-infra git commits.
 To remove the hook, run ``rm -f .git/hooks/commit-msg`` in the repository main directory.
 
 ## License
+
 This repository uses the following licenses:
 
 | License Full Name | SPDX Short Identifier | Description

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,20 +5,19 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Tasks
 
-Originally inspired by [nix-community infra](https://github.com/nix-community/infra) this project makes use of [pyinvoke](https://www.pyinvoke.org/) to help with deployment [tasks](../tasks.py).
+Originally inspired by [nix-community infra](https://github.com/nix-community/infra) this project makes use of [pyinvoke](https://www.pyinvoke.org/) to help with installing new hosts [tasks](../tasks.py).
 
 Run the following command to list the available tasks:
+
 ```bash
 ❯ invoke --list
 Available tasks:
 
   alias-list          List available targets (i.e. configurations and alias names)
   build-local         Build NixOS configuration `alias` locally.
-  deploy              Deploy the configuration for `alias`.
   install             Install `alias` configuration using nixos-anywhere, deploying host private key.
   pre-push            Run 'pre-push' checks.
   print-keys          Decrypt host private key, print ssh and age public keys for `alias` config.
-  reboot              Reboot host identified as `alias`.
   update-sops-files   Update all sops yaml and json files according to .sops.yaml rules.
 
 ```
@@ -26,6 +25,7 @@ Available tasks:
 In the following sections, we will explain the intended usage of the most common of the above deployment tasks.
 
 ## alias-list
+
 The `alias-list` task lists the alias names for ghaf-infra targets. Alias is simply a name given for the combination of nixosConfig and hostname. All ghaf-infra tasks that need to identify a target, accept an alias name as an argument.
 
 ```bash
@@ -68,6 +68,7 @@ Host 65.21.20.242
 Since `task.py` internally uses ssh when accessing hosts, the above example configuration would be applied when accessing the `hetzarm` alias.
 
 ## build-local
+
 The `build-local` task builds the given alias configuration locally. If the alias name is not specified `build-local` builds all alias configurations:
 
 ```bash
@@ -81,6 +82,7 @@ building '/nix/store/wks2pw9692flrfaqdpv1m0pwfyn17ggj-nixos-system-ghaf-log-24.0
 ```
 
 ## install
+
 The `install` task installs the given alias configuration on the target host with [nixos-anywhere](https://github.com/nix-community/nixos-anywhere). It will automatically partition and re-format the host hard drive, meaning all data on the target will be completely overwritten with no option to rollback. During installation, it will also decrypt and deploy the host private key from the sops secrets. The intended use of the `install` task is to install NixOS configuration on a non-NixOS host, or to repurpose an existing server.
 
 Note: `ìnstall` task assumes the given NixOS configuration is compatible with the specified host. In the existing Ghaf CI/CD infrastructure you can safely assume this holds true. However, if you plan to apply the NixOS configurations from this repository on a new infrastructure or onboard new hosts, please read the documentation in [adapting-to-new-environments.md](./adapting-to-new-environments.md).
@@ -101,21 +103,10 @@ Install configuration 'ghaf-webserver' on host '37.27.204.82'? [y/N] y
 ...
 ```
 
-## deploy
-Note: it's strongly recommended to use the [deploy-rs](https://github.com/tiiuae/ghaf-infra/blob/main/docs/deploy-rs.md) instead of the `deploy` task.
-
-The `deploy` task deploys the given alias configuration to the target host with [nixos-rebuild](https://nixos.wiki/wiki/Nixos-rebuild) `switch` subcommand. This task assumes the target host is already running NixOS, and fails if it's not.
-
-Note: unlike the changes made with `install` task, `deploy` changes can be [reverted](https://zero-to-nix.com/concepts/nixos#rollbacks) with `nixos-rebuild switch --rollback` or similar.
-
-```bash
-❯ invoke deploy --alias ghaf-webserver
-...
-```
-
 ## update-sops-files
+
 The `update-sops-files` task updates all sops yaml and json files according to the rules in [`.sops.yaml`](../.sops.yaml). The intended use is to update the secrets after adding new hosts, admins, or secrets:
 
 ```bash
-$ invoke update-sops-files
+invoke update-sops-files
 ```

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -30,6 +30,8 @@
       user-mikkos
     ]);
 
+  sops.defaultSopsFile = ./secrets.yaml;
+
   networking = {
     hostName = "testagent-prod";
     useNetworkd = true;

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -13,6 +13,7 @@
             nix
             nixfmt-rfc-style
             nixos-rebuild
+            nixos-anywhere
             # parallel_env requires 'compgen' function, which is available
             # in bashInteractive, but not bash
             bashInteractive


### PR DESCRIPTION
- Deploy function is removed from `tasks.py`, as deploy-rs is supposed to be used.
- `tasks.py` now evaluates a nix expression that gets all target data from `nix/deployments.nix`, avoiding the need to keep two separate lists in sync.
- Updated docs to remove mentions of `tasks.py` deploy.
- Use nixos-anywhere from devshell instead of hardcoded sha.