### PR TITLE
Allow using more than one testagent per controller

### DIFF
--- a/hosts/azure/jenkins-controller/jenkins-casc.yaml
+++ b/hosts/azure/jenkins-controller/jenkins-casc.yaml
@@ -15,34 +15,114 @@ jenkins:
       disableSyntaxHighlighting: false
 
   nodes:
+    # release testagent
   - permanent:
+      name: "release-lenovo-x1"
+      labelString: "lenovo-x1"
       launcher: "inbound"
       mode: EXCLUSIVE
-      name: "lenovo-x1"
       remoteFS: "/var/lib/jenkins/agents/lenovo-x1"
       retentionStrategy: "always"
   - permanent:
+      name: "release-nuc"
+      labelString: "nuc"
       launcher: "inbound"
       mode: EXCLUSIVE
-      name: "nuc"
       remoteFS: "/var/lib/jenkins/agents/nuc"
       retentionStrategy: "always"
   - permanent:
+      name: "release-orin-agx"
+      labelString: "orin-agx"
       launcher: "inbound"
       mode: EXCLUSIVE
-      name: "orin-agx"
       remoteFS: "/var/lib/jenkins/agents/orin-agx"
       retentionStrategy: "always"
   - permanent:
+      name: "release-orin-nx"
+      labelString: "orin-nx"
       launcher: "inbound"
       mode: EXCLUSIVE
-      name: "orin-nx"
       remoteFS: "/var/lib/jenkins/agents/orin-nx"
       retentionStrategy: "always"
   - permanent:
+      name: "release-dell-7330"
+      labelString: "dell-7330"
       launcher: "inbound"
       mode: EXCLUSIVE
-      name: "dell-7330"
+      remoteFS: "/var/lib/jenkins/agents/dell-7330"
+      retentionStrategy: "always"
+
+    # prod testagent
+  - permanent:
+      name: "prod-lenovo-x1"
+      labelString: "lenovo-x1"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/lenovo-x1"
+      retentionStrategy: "always"
+  - permanent:
+      name: "prod-nuc"
+      labelString: "nuc"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/nuc"
+      retentionStrategy: "always"
+  - permanent:
+      name: "prod-orin-agx"
+      labelString: "orin-agx"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/orin-agx"
+      retentionStrategy: "always"
+  - permanent:
+      name: "prod-orin-nx"
+      labelString: "orin-nx"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/orin-nx"
+      retentionStrategy: "always"
+  - permanent:
+      name: "prod-dell-7330"
+      labelString: "dell-7330"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/dell-7330"
+      retentionStrategy: "always"
+  
+    # dev testagent
+  - permanent:
+      name: "dev-lenovo-x1"
+      labelString: "lenovo-x1"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/lenovo-x1"
+      retentionStrategy: "always"
+  - permanent:
+      name: "dev-nuc"
+      labelString: "nuc"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/nuc"
+      retentionStrategy: "always"
+  - permanent:
+      name: "dev-orin-agx"
+      labelString: "orin-agx"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/orin-agx"
+      retentionStrategy: "always"
+  - permanent:
+      name: "dev-orin-nx"
+      labelString: "orin-nx"
+      launcher: "inbound"
+      mode: EXCLUSIVE
+      remoteFS: "/var/lib/jenkins/agents/orin-nx"
+      retentionStrategy: "always"
+  - permanent:
+      name: "dev-dell-7330"
+      labelString: "dell-7330"
+      launcher: "inbound"
+      mode: EXCLUSIVE
       remoteFS: "/var/lib/jenkins/agents/dell-7330"
       retentionStrategy: "always"
 

--- a/hosts/testagent/agent.nix
+++ b/hosts/testagent/agent.nix
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  pkgs,
+  inputs,
+  lib,
+  config,
+  ...
+}:
+let
+  # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
+  # https://github.com/NixOS/nixpkgs/pull/313643
+  brainstem = pkgs.callPackage ../../pkgs/brainstem { };
+in
+{
+  options = {
+    # variant such as dev, prod or release
+    # used in the naming of jenkins slaves
+    services.testagent.variant = lib.mkOption { type = lib.types.str; };
+  };
+
+  config = {
+    # The Jenkins slave service is very barebones
+    # it only installs java and sets up jenkins user
+    services.jenkinsSlave.enable = true;
+
+    # Jenkins needs sudo and serial rights to perform the HW tests
+    users.users.jenkins.extraGroups = [
+      "wheel"
+      "dialout"
+      "tty"
+    ];
+
+    systemd.services =
+      let
+        # verifies that the environment file is properly configured
+        # and downloads agent.jar from the controller
+        jenkins-setup-script = pkgs.writeShellScript "jenkins-setup.sh" ''
+          if [[ ! -f jenkins.env ]]; then
+            install -m 600 /dev/null jenkins.env
+            echo "CONTROLLER=" > jenkins.env
+            echo "ADMIN_PASSWORD=" >> jenkins.env
+            echo "Please add jenkins controller details to $(pwd)/jenkins.env"
+            exit 1
+          fi
+
+          source jenkins.env
+
+          if [[ -z "$CONTROLLER" ]]; then
+            echo "Variable CONTROLLER not set in $(pwd)/jenkins.env"
+            exit 1
+          fi
+
+          if [[ -z "$ADMIN_PASSWORD" ]]; then
+            echo "Variable ADMIN_PASSWORD not set in $(pwd)/jenkins.env"
+            exit 1
+          fi
+
+          curl -O "$CONTROLLER/jnlpJars/agent.jar"
+        '';
+
+        # Helper function to create agent services for each hardware device
+        mkAgent =
+          device:
+          let
+            # name of the agent e.g. lenovo-x1_release
+            name = "${config.services.testagent.variant}-${device}";
+
+            # opens a websocket connection to the jenkins controller from this agent
+            jenkins-connect-script = pkgs.writeShellScript "jenkins-connect.sh" ''
+              JENKINS_SECRET="$(
+                curl --proto =https -u admin:$ADMIN_PASSWORD \
+                $CONTROLLER/computer/${name}/jenkins-agent.jnlp |
+                sed "s/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/"
+              )"
+
+              mkdir -p "/var/lib/jenkins/agents/${device}"
+
+              ${pkgs.jdk}/bin/java \
+                -jar agent.jar \
+                -url "$CONTROLLER" \
+                -name "${name}" \
+                -secret "$JENKINS_SECRET" \
+                -workDir "/var/lib/jenkins/agents/${device}" \
+                -webSocket
+            '';
+          in
+          {
+            # agents require the setup service to run without errors before starting
+            requires = [ "setup-agents.service" ];
+            wantedBy = [ "setup-agents.service" ];
+            after = [ "setup-agents.service" ];
+
+            path =
+              [
+                brainstem
+                inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+              ]
+              ++ (with pkgs; [
+                curl
+                wget
+                jdk
+                git
+                bashInteractive
+                coreutils
+                util-linux
+                nix
+                zstd
+                jq
+                csvkit
+                sudo
+                openssh
+                iputils
+                netcat
+                python3
+                usbsdmux
+                grafana-loki
+              ]);
+
+            serviceConfig = {
+              Type = "simple";
+              User = "jenkins";
+              EnvironmentFile = "/var/lib/jenkins/jenkins.env";
+              WorkingDirectory = "/var/lib/jenkins";
+              ExecStart = "${jenkins-connect-script}";
+            };
+          };
+      in
+      {
+        # the setup service does not start automatically or it would fail activation
+        # of the system since jenkins.env is empty before manually set up
+        setup-agents = {
+          path = with pkgs; [ curl ];
+          serviceConfig = {
+            Type = "oneshot";
+            User = "jenkins";
+            RemainAfterExit = "yes";
+            WorkingDirectory = "/var/lib/jenkins";
+            ExecStart = "${jenkins-setup-script}";
+          };
+        };
+
+        # one agent per unique hardware device to act as a lock
+        agent-orin-agx = mkAgent "orin-agx";
+        agent-orin-nx = mkAgent "orin-nx";
+        agent-dell-7330 = mkAgent "dell-7330";
+        agent-nuc = mkAgent "nuc";
+        agent-lenovo-x1 = mkAgent "lenovo-x1";
+      };
+  };
+}

--- a/hosts/testagent/agents-common.nix
+++ b/hosts/testagent/agents-common.nix
@@ -5,6 +5,7 @@
   pkgs,
   inputs,
   lib,
+  self,
   ...
 }:
 let
@@ -13,6 +14,17 @@ let
   brainstem = pkgs.callPackage ../../pkgs/brainstem { };
 in
 {
+  imports =
+    [
+      ./agent.nix
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
+      common
+      service-openssh
+    ]);
+
   sops.secrets =
     let
       credential = {
@@ -32,15 +44,28 @@ in
       pi-pass = credential;
     };
 
+  networking.useDHCP = true;
+
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
+  hardware = {
+    enableRedistributableFirmware = true;
+    cpu.intel.updateMicrocode = true;
+  };
+
   services.udev.packages = [
     brainstem
     pkgs.usbsdmux
   ];
 
+  # packages available in all user sessions
   environment.systemPackages =
     [
-      inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
       brainstem
+      inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
     ]
     ++ (with pkgs; [
       minicom
@@ -49,132 +74,7 @@ in
       (python3.withPackages (ps: with ps; [ pyserial ]))
     ]);
 
-  # The Jenkins slave service is very barebones
-  # it only installs java and sets up jenkins user
-  services.jenkinsSlave.enable = true;
-
-  # Jenkins needs sudo and serial rights to perform the HW tests
-  users.users.jenkins.extraGroups = [
-    "wheel"
-    "dialout"
-    "tty"
-  ];
-
   # This server is only exposed to the internal network
   # fail2ban only causes issues here
   services.fail2ban.enable = lib.mkForce false;
-
-  systemd.services =
-    let
-      # verifies that the environment file is properly configured
-      # and downloads agent.jar from the controller
-      jenkins-setup-script = pkgs.writeShellScript "jenkins-setup.sh" ''
-        if [[ ! -f jenkins.env ]]; then
-          install -m 600 /dev/null jenkins.env
-          echo "CONTROLLER=" > jenkins.env
-          echo "ADMIN_PASSWORD=" >> jenkins.env
-          echo "Please add jenkins controller details to $(pwd)/jenkins.env"
-          exit 1
-        fi
-
-        source jenkins.env
-
-        if [[ -z "$CONTROLLER" ]]; then
-          echo "Variable CONTROLLER not set in $(pwd)/jenkins.env"
-          exit 1
-        fi
-
-        if [[ -z "$ADMIN_PASSWORD" ]]; then
-          echo "Variable ADMIN_PASSWORD not set in $(pwd)/jenkins.env"
-          exit 1
-        fi
-
-        curl -O "$CONTROLLER/jnlpJars/agent.jar"
-      '';
-
-      # Helper function to create agent services for each hardware device
-      mkAgent =
-        device:
-        let
-          # opens a websocket connection to the jenkins controller from this agent
-          jenkins-connect-script = pkgs.writeShellScript "jenkins-connect.sh" ''
-            JENKINS_SECRET="$(
-              curl --proto =https -u admin:$ADMIN_PASSWORD \
-              $CONTROLLER/computer/${device}/jenkins-agent.jnlp |
-              sed "s/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/"
-            )"
-
-            mkdir -p "/var/lib/jenkins/agents/${device}"
-
-            ${pkgs.jdk}/bin/java \
-              -jar agent.jar \
-              -url "$CONTROLLER" \
-              -name "${device}" \
-              -secret "$JENKINS_SECRET" \
-              -workDir "/var/lib/jenkins/agents/${device}" \
-              -webSocket
-          '';
-        in
-        {
-          # agents require the setup service to run without errors before starting
-          requires = [ "setup-agents.service" ];
-          wantedBy = [ "setup-agents.service" ];
-          after = [ "setup-agents.service" ];
-
-          path =
-            [
-              brainstem
-              inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-            ]
-            ++ (with pkgs; [
-              curl
-              wget
-              jdk
-              git
-              bashInteractive
-              coreutils
-              util-linux
-              nix
-              zstd
-              jq
-              csvkit
-              sudo
-              openssh
-              iputils
-              netcat
-              python3
-              usbsdmux
-              grafana-loki
-            ]);
-
-          serviceConfig = {
-            Type = "simple";
-            User = "jenkins";
-            EnvironmentFile = "/var/lib/jenkins/jenkins.env";
-            WorkingDirectory = "/var/lib/jenkins";
-            ExecStart = "${jenkins-connect-script}";
-          };
-        };
-    in
-    {
-      # the setup service does not start automatically or it would fail activation
-      # of the system since jenkins.env is empty before manually set up
-      setup-agents = {
-        path = with pkgs; [ curl ];
-        serviceConfig = {
-          Type = "oneshot";
-          User = "jenkins";
-          RemainAfterExit = "yes";
-          WorkingDirectory = "/var/lib/jenkins";
-          ExecStart = "${jenkins-setup-script}";
-        };
-      };
-
-      # one agent per unique hardware device to act as a lock
-      agent-orin-agx = mkAgent "orin-agx";
-      agent-orin-nx = mkAgent "orin-nx";
-      agent-dell-7330 = mkAgent "dell-7330";
-      agent-nuc = mkAgent "nuc";
-      agent-lenovo-x1 = mkAgent "lenovo-x1";
-    };
 }

--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -2,21 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
-  inputs,
   config,
   ...
 }:
 {
   imports =
     [
-      ./disk-config.nix
       ../agents-common.nix
-      inputs.sops-nix.nixosModules.sops
-      inputs.disko.nixosModules.disko
+      ./disk-config.nix
     ]
     ++ (with self.nixosModules; [
-      common
-      service-openssh
+      # users who have ssh access to this machine
       user-vjuntunen
       user-flokli
       user-jrautiola
@@ -30,39 +26,24 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "testagent-dev";
+  services.testagent.variant = "dev";
 
-  networking = {
-    hostName = "testagent-dev";
-    useDHCP = true;
-  };
-
-  boot = {
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
-
-    initrd.availableKernelModules = [
-      "vmd"
-      "xhci_pci"
-      "ahci"
-      "nvme"
-      "usbhid"
-      "usb_storage"
-      "sd_mod"
-      "sr_mod"
-      "rtsx_pci_sdmmc"
-    ];
-    kernelModules = [
-      "kvm-intel"
-      "sg"
-    ];
-  };
-
-  hardware = {
-    enableRedistributableFirmware = true;
-    cpu.intel.updateMicrocode = true;
-  };
+  boot.initrd.availableKernelModules = [
+    "vmd"
+    "xhci_pci"
+    "ahci"
+    "nvme"
+    "usbhid"
+    "usb_storage"
+    "sd_mod"
+    "sr_mod"
+    "rtsx_pci_sdmmc"
+  ];
+  boot.kernelModules = [
+    "kvm-intel"
+    "sg"
+  ];
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -3,24 +3,17 @@
 
 {
   self,
-  inputs,
   config,
   ...
 }:
 {
   imports =
     [
-      # Include the results of the hardware scan.
-      ./hardware-configuration.nix
       ../agents-common.nix
+      ./hardware-configuration.nix
     ]
-    ++ (with inputs; [
-      sops-nix.nixosModules.sops
-      disko.nixosModules.disko
-    ])
     ++ (with self.nixosModules; [
-      common
-      service-openssh
+      # users who have ssh access to this machine
       user-vjuntunen
       user-flokli
       user-jrautiola
@@ -32,16 +25,9 @@
     ]);
 
   sops.defaultSopsFile = ./secrets.yaml;
-
-  networking = {
-    hostName = "testagent-prod";
-    useNetworkd = true;
-  };
-
-  boot.loader = {
-    systemd-boot.enable = true;
-    efi.canTouchEfiVariables = true;
-  };
+  nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "testagent-prod";
+  services.testagent.variant = "prod";
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -2,21 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
-  inputs,
   config,
   ...
 }:
 {
   imports =
     [
-      ./disk-config.nix
       ../agents-common.nix
-      inputs.sops-nix.nixosModules.sops
-      inputs.disko.nixosModules.disko
+      ./disk-config.nix
     ]
     ++ (with self.nixosModules; [
-      common
-      service-openssh
+      # users who have ssh access to this machine
       user-vjuntunen
       user-flokli
       user-jrautiola
@@ -32,39 +28,24 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "testagent-release";
+  services.testagent.variant = "release";
 
-  networking = {
-    hostName = "testagent-release";
-    useDHCP = true;
-  };
-
-  boot = {
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
-
-    initrd.availableKernelModules = [
-      "vmd"
-      "xhci_pci"
-      "ahci"
-      "nvme"
-      "usbhid"
-      "usb_storage"
-      "sd_mod"
-      "sr_mod"
-      "rtsx_pci_sdmmc"
-    ];
-    kernelModules = [
-      "kvm-intel"
-      "sg"
-    ];
-  };
-
-  hardware = {
-    enableRedistributableFirmware = true;
-    cpu.intel.updateMicrocode = true;
-  };
+  boot.initrd.availableKernelModules = [
+    "vmd"
+    "xhci_pci"
+    "ahci"
+    "nvme"
+    "usbhid"
+    "usb_storage"
+    "sd_mod"
+    "sr_mod"
+    "rtsx_pci_sdmmc"
+  ];
+  boot.kernelModules = [
+    "kvm-intel"
+    "sg"
+  ];
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''

--- a/hosts/testagent/uae-dev/configuration.nix
+++ b/hosts/testagent/uae-dev/configuration.nix
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
-  inputs,
   config,
   ...
 }:
@@ -11,12 +10,8 @@
     [
       ./disk-config.nix
       ../agents-common.nix
-      inputs.sops-nix.nixosModules.sops
-      inputs.disko.nixosModules.disko
     ]
     ++ (with self.nixosModules; [
-      common
-      service-openssh
       user-vjuntunen
       user-flokli
       user-jrautiola
@@ -28,32 +23,17 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "testagent-uae-dev";
+  services.testagent.variant = "dev";
 
-  networking = {
-    hostName = "testagent-uae-dev";
-    useDHCP = true;
-  };
-
-  boot = {
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
-
-    initrd.availableKernelModules = [
-      "xhci_pci"
-      "nvme"
-      "thunderbolt"
-    ];
-    kernelModules = [
-      "kvm-intel"
-    ];
-  };
-
-  hardware = {
-    enableRedistributableFirmware = true;
-    cpu.intel.updateMicrocode = true;
-  };
+  boot.initrd.availableKernelModules = [
+    "xhci_pci"
+    "nvme"
+    "thunderbolt"
+  ];
+  boot.kernelModules = [
+    "kvm-intel"
+  ];
 
   # udev rules for test devices serial connections
   # placeholder configs from finland. need updation with new uae targets, in progress


### PR DESCRIPTION
Adds all three testsets as nodes to each controller (dev, prod and release). Any combination of these can connect. Builds can use both at the same time with the device label.

Refactored testagents config to be more consistent, and moved the agent connection script to its own module with an option.