### PR TITLE
azure-common: Enable zramSwap in all Azure hosts

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -62,4 +62,18 @@ in
     htop
     tree
   ];
+
+  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 100;
+  };
+  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 180;
+    "vm.watermark_boost_factor" = 0;
+    "vm.watermark_scale_factor" = 125;
+    "vm.page-cluster" = 0;
+  };
 }


### PR DESCRIPTION
Enable [zramSwap](https://search.nixos.org/options?show=zramSwap.enable) on all Azure hosts to try to mitigate the OOM issues we have started seeing recently, especially on jenkins-controller.