### PR TITLE
task.py: Fix inv install

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -389,7 +389,7 @@ def install(c: Any, alias) -> None:
     with TemporaryDirectory() as tmpdir:
         decrypt_host_key(target, tmpdir)
         command = f"nixos-anywhere {h.host} --extra-files {tmpdir} "
-        command += "--flake .#{target.nixosconfig} --option accept-flake-config true"
+        command += f"--flake .#{target.nixosconfig} --option accept-flake-config true"
         LOG.warning(command)
         c.run(command)
 


### PR DESCRIPTION
Fix the `install` task which, before this PR, failed after kexec switch as follows:

```
error: flake 'git+file:///.../ghaf-infra' does not provide attribute 'packages.x86_64-linux.nixosConfigurations."
{target.nixosconfig}".config.system.build.diskoScript', 'legacyPackages.x86_64-linux.nixosConfigurations.
"{target.nixosconfig}".config.system.build.diskoScript' or 'nixosConfigurations."{target.nixosconfig}".config.system.build.diskoScript'

```