### PR TITLE
Allow testagents to have different hardware

### DIFF
--- a/hosts/testagent/agent.nix
+++ b/hosts/testagent/agent.nix
@@ -12,12 +12,92 @@ let
   # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
   # https://github.com/NixOS/nixpkgs/pull/313643
   brainstem = pkgs.callPackage ../../pkgs/brainstem { };
+
+  mkAgent =
+    device:
+    let
+      name = "${config.services.testagent.variant}-${device}";
+    in
+    {
+      # bindsTo instead of requires makes the agents stop when the parent service stops
+      bindsTo = [ "start-agents.service" ];
+      wantedBy = [ "start-agents.service" ];
+      after = [ "start-agents.service" ];
+
+      path =
+        [
+          brainstem
+          inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+        ]
+        ++ (with pkgs; [
+          curl
+          wget
+          jdk
+          git
+          bashInteractive
+          coreutils
+          util-linux
+          nix
+          zstd
+          jq
+          csvkit
+          sudo
+          openssh
+          iputils
+          netcat
+          python3
+          usbsdmux
+          grafana-loki
+        ]);
+
+      serviceConfig = {
+        Type = "simple";
+        User = "jenkins";
+        EnvironmentFile = "/var/lib/jenkins/jenkins.env";
+        WorkingDirectory = "/var/lib/jenkins";
+        Restart = "no";
+        SuccessExitStatus = [ 6 ];
+        ExecStart = toString (
+          pkgs.writeShellScript "jenkins-connect.sh" # sh
+            ''
+              set -x
+
+              if [[ -z "$CONTROLLER" ]]; then
+                echo "ERROR: Variable CONTROLLER not configured in $(pwd)/jenkins.env"
+                exit 6
+              fi
+
+              mkdir -p "/var/lib/jenkins/agents/${device}"
+
+              # connects to controller with ssh and parses the secret from the jnlp file
+              JENKINS_SECRET="$(
+                ssh -i ${config.sops.secrets.ssh_host_ed25519_key.path} ${config.networking.hostName}@''${CONTROLLER#*//} \
+                "curl -H 'X-Forwarded-User: ${config.networking.hostName}' -H 'X-Forwarded-Groups: testagents' http://localhost:8081/computer/${name}/jenkins-agent.jnlp | sed 's/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/'"
+              )"
+
+              # opens a websocket connection to the jenkins controller from this agent
+              ${pkgs.jdk}/bin/java \
+                -jar agent.jar \
+                -url "$CONTROLLER" \
+                -name "${name}" \
+                -secret "$JENKINS_SECRET" \
+                -workDir "/var/lib/jenkins/agents/${device}" \
+                -webSocket
+            ''
+        );
+      };
+    };
 in
 {
-  options = {
-    # variant such as dev, prod or release
-    # used in the naming of jenkins slaves
-    services.testagent.variant = lib.mkOption { type = lib.types.str; };
+  options = with lib.types; {
+    services.testagent = {
+      # variant such as dev, prod or release
+      # used in the naming of jenkins slaves
+      variant = lib.mkOption { type = str; };
+
+      # what hardware devices to create nodes for
+      hardware = lib.mkOption { type = listOf str; };
+    };
   };
 
   config = {
@@ -33,83 +113,11 @@ in
     ];
 
     systemd.services =
-      let
-        mkAgent =
-          device:
-          let
-            name = "${config.services.testagent.variant}-${device}";
-          in
-          {
-            # bindsTo instead of requires makes the agents stop when the parent service stops
-            bindsTo = [ "start-agents.service" ];
-            wantedBy = [ "start-agents.service" ];
-            after = [ "start-agents.service" ];
-
-            path =
-              [
-                brainstem
-                inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
-              ]
-              ++ (with pkgs; [
-                curl
-                wget
-                jdk
-                git
-                bashInteractive
-                coreutils
-                util-linux
-                nix
-                zstd
-                jq
-                csvkit
-                sudo
-                openssh
-                iputils
-                netcat
-                python3
-                usbsdmux
-                grafana-loki
-              ]);
-
-            serviceConfig = {
-              Type = "simple";
-              User = "jenkins";
-              EnvironmentFile = "/var/lib/jenkins/jenkins.env";
-              WorkingDirectory = "/var/lib/jenkins";
-              Restart = "no";
-              SuccessExitStatus = [ 6 ];
-              ExecStart = toString (
-                pkgs.writeShellScript "jenkins-connect.sh" # sh
-                  ''
-                    set -x
-
-                    if [[ -z "$CONTROLLER" ]]; then
-                      echo "ERROR: Variable CONTROLLER not configured in $(pwd)/jenkins.env"
-                      exit 6
-                    fi
-
-                    mkdir -p "/var/lib/jenkins/agents/${device}"
-
-                    # connects to controller with ssh and parses the secret from the jnlp file
-                    JENKINS_SECRET="$(
-                      ssh -i ${config.sops.secrets.ssh_host_ed25519_key.path} ${config.networking.hostName}@''${CONTROLLER#*//} \
-                      "curl -H 'X-Forwarded-User: ${config.networking.hostName}' -H 'X-Forwarded-Groups: testagents' http://localhost:8081/computer/${name}/jenkins-agent.jnlp | sed 's/.*<application-desc><argument>\([a-z0-9]*\).*/\1\n/'"
-                    )"
-
-                    # opens a websocket connection to the jenkins controller from this agent
-                    ${pkgs.jdk}/bin/java \
-                      -jar agent.jar \
-                      -url "$CONTROLLER" \
-                      -name "${name}" \
-                      -secret "$JENKINS_SECRET" \
-                      -workDir "/var/lib/jenkins/agents/${device}" \
-                      -webSocket
-                  ''
-              );
-            };
-          };
-      in
-      {
+      # map hardware to services
+      builtins.listToAttrs (
+        map (hw: lib.nameValuePair "agent-${hw}" (mkAgent hw)) config.services.testagent.hardware
+      )
+      // {
         start-agents = {
           path = with pkgs; [ wget ];
           serviceConfig = {
@@ -128,13 +136,6 @@ in
             );
           };
         };
-
-        # one agent per unique hardware device to act as a lock
-        agent-orin-agx = mkAgent "orin-agx";
-        agent-orin-nx = mkAgent "orin-nx";
-        agent-dell-7330 = mkAgent "dell-7330";
-        agent-nuc = mkAgent "nuc";
-        agent-lenovo-x1 = mkAgent "lenovo-x1";
       };
   };
 }

--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -27,7 +27,16 @@
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-dev";
-  services.testagent.variant = "dev";
+  services.testagent = {
+    variant = "dev";
+    hardware = [
+      "orin-agx"
+      "orin-nx"
+      "nuc"
+      "lenovo-x1"
+      "dell-7330"
+    ];
+  };
 
   boot.initrd.availableKernelModules = [
     "vmd"

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -27,7 +27,16 @@
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-prod";
-  services.testagent.variant = "prod";
+  services.testagent = {
+    variant = "prod";
+    hardware = [
+      "orin-agx"
+      "orin-nx"
+      "nuc"
+      "lenovo-x1"
+      "dell-7330"
+    ];
+  };
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -29,7 +29,15 @@
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-release";
-  services.testagent.variant = "release";
+  services.testagent = {
+    variant = "release";
+    hardware = [
+      "orin-agx"
+      "orin-nx"
+      "nuc"
+      "lenovo-x1"
+    ];
+  };
 
   boot.initrd.availableKernelModules = [
     "vmd"

--- a/hosts/testagent/uae-dev/configuration.nix
+++ b/hosts/testagent/uae-dev/configuration.nix
@@ -24,7 +24,16 @@
   sops.defaultSopsFile = ./secrets.yaml;
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-uae-dev";
-  services.testagent.variant = "dev";
+  services.testagent = {
+    variant = "dev";
+    hardware = [
+      "orin-agx"
+      "orin-nx"
+      "nuc"
+      "lenovo-x1"
+      "dell-7330"
+    ];
+  };
 
   boot.initrd.availableKernelModules = [
     "xhci_pci"


### PR DESCRIPTION
Release set doesn't have dell-7330 at the moment. Add config option to set the hardware for different testagents.