### PR TITLE
Add ktu to dev and prod test agents

### DIFF
--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -22,6 +22,7 @@
       user-alextserepov
       user-mikkos
       user-milval
+      user-ktu
     ]);
 
   sops.defaultSopsFile = ./secrets.yaml;

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -22,6 +22,7 @@
       user-hrosten
       user-mikkos
       user-milval
+      user-ktu
     ]);
 
   sops.defaultSopsFile = ./secrets.yaml;


### PR DESCRIPTION
Access to prod and dev agents would allow me to bind test agents back to prod/dev after a release build