### PR TITLE
Add cachix-watch-store to build1 and hetzarm

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -17,6 +17,8 @@ keys:
   - &testagent-prod age12nrv5a9rk9vqvx2tqvghn4kt9ps6gdszmmynhjegl2ewefkh03fsexuy9y
   - &testagent-dev age1qjhxuh80tg2vq32kmwu2ne4vqvd8q2up7css30x0yefkrhq9jd0sxju3fa
   - &testagent-release age1pkd7crz3c0axuy4nnesjjzmklmqptx9fq5v8ndjevfgr5lqg8cgskhfyt7
+  - &build1 age15xx3qgw69hsmjyw64zmh9q0akyl3mh73dtvmdvhgezplqwaprstqffth7g
+  - &build2 age123c6y9ws4za8xzc5wtm20gfsv2exfp69tvfmzcsu7l377u7s89tq8ymhc3
   - &build3 age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
   - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
@@ -61,6 +63,18 @@ creation_rules:
       - *jrautiola
       - *vjuntunen
       - *hrosten
+  - path_regex: hosts/builders/build1/secrets.yaml$
+    key_groups:
+    - age:
+      - *build1
+      - *hrosten
+      - *jrautiola
+  - path_regex: hosts/builders/build2/secrets.yaml$
+    key_groups:
+    - age:
+      - *build2
+      - *hrosten
+      - *jrautiola
   - path_regex: hosts/builders/build3/secrets.yaml$
     key_groups:
     - age:

--- a/hosts/builders/build1/configuration.nix
+++ b/hosts/builders/build1/configuration.nix
@@ -1,12 +1,18 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ self, ... }:
+{
+  self,
+  inputs,
+  config,
+  ...
+}:
 {
   imports =
     [
       ../ficolo.nix
       ../cross-compilation.nix
       ../builders-common.nix
+      inputs.sops-nix.nixosModules.sops
     ]
     ++ (with self.nixosModules; [
       user-github
@@ -15,10 +21,22 @@
 
   # build1 specific configuration
 
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets.cachix-auth-token.owner = "root";
+  };
+
   networking.hostName = "build1";
 
   services.monitoring = {
     metrics.enable = true;
     logs.enable = true;
+  };
+
+  services.cachix-watch-store = {
+    enable = true;
+    verbose = true;
+    cacheName = "ghaf-dev";
+    cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
 }

--- a/hosts/builders/build1/secrets.yaml
+++ b/hosts/builders/build1/secrets.yaml
@@ -1,0 +1,40 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:Lmv+e1MqX2fSJJp09OQx2M2vfhCMwBYch3jmPLfg5W7Jng3GobWvr+dFXpgXUnlDevIgXQGK7hCiL+VU6ulAknIF600pkdXDN2kwO+PYs+EVgYihVYVQH03ipWD7WuJZOOBCAZU1uEXUZp9xST5IUDr/japoq0pf1trzb5nc2EQJpd5ByW86onmSDgbiWHI4VgPtnCfbLCVsl5FV8Rv+Cd+jRujc0AxrmhMq31lTMPZKfjdJZkMgWqfsYYaK7QQpl7g0iSYsa2JcIeSZ7CdN0reuzjwFYWcmI2NeftDOnyB/U/yn4io5+uxLfY9pvWOjGf1ONAVsTPplfexxPYu3/Lf1eBQCZ5uxqGwAcVNWvyLwEx0v5IKWxyPA4v891+lsU9qq10Jf9C/9buf0o+32ghSpkDXijuHRDR+RRli9BIqR85rHWTqoUZxP6EB0bWAJ733aiQoJr4fDOtKGx50L8U2tEuhTMSY0zoVB/sAWYG22G7ul0Y9mBBKz9c1AVUrG0DDtXXl7ArnReF2l/pg=,iv:Nb8pP0nNPJhoW5lRBFuP1yts6PYxm2JK8NW2v3m796s=,tag:Q1k2fANtTyRsybluhf9Eog==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:qxE+xVs4C3URp1OL7K41i+xWLqzUr9757HTGcpWUIi1WOWfA/HUH+SthsFNesVcu7yohfwFkubf8NWpUOfsoTX/O97hOIpilVPVjABsrPr95ASmpw5/ozX8B2KJ6F66DakKsci/rFjdZJ+IsD9diRLusMgiStLPD9PQOGDcHH30yaknMFhvCeif99eFmScsswI64154J,iv:RNJ5wr5dKoJEI9PhOt02kJE2uXrewyuJyE1IoRyX4NE=,tag:DOfbR/GiFA/lGVorIRJqzA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age15xx3qgw69hsmjyw64zmh9q0akyl3mh73dtvmdvhgezplqwaprstqffth7g
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibTBaaUtVZGc5NERiYkpz
+            THRhWlNiRCtObDRjRi8rNXVPV002YTl3SWdvCkZ0RTRteEFPY2NVN0hBZlJ1TEs3
+            Y2hPZ0pybHVMOFdjRk9BWlF4TkN2UlEKLS0tIGRsZUgxN3hFYTQxWFpDV1ZzdWVL
+            Z2hwaDRLbGkyOTFSby9HVTA5WC81Q2MK2u2MGwCTTgM+NVC6OCg6aKN0MhEu90R4
+            iYRrEfvvuc3N+RZ5Kq/i51R9VlcEmD5qoLRCSSpQSVokvOJhIYMbZQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUXBGQk1WQ1lyNDRhQm9j
+            eFc5TUd0Q1N4eDFmbDFycjdYam82T0xkdjJRCjBzVDRuK1J4M0tTaWw5elE0Znhv
+            bEZPTnFYUzA4WWl5OUd5enA2eVZyMUUKLS0tIDRYYVQrbFZvR1ROOW1KOHh0WStk
+            SHpzdlQ4MzNqWDl1YmFIZmczRlFJTlkK92fbpQoWK+eRh5sWoE1WCGVXGyAi6OlR
+            d+M3i54PX5Hjff4/Wmf2UQvDowxkC7wSHnHmVXIUbEg1OgR1Z42jbg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHMmEzaGRadGw1eDZiS2lt
+            cHNxdTNCTWRIQWxaSUN6L0lSdWVFdUtFK2w4CllncjEra3czN2FhUG4vNkpDMWNa
+            VS81UXhqREx5S0xGc3hVRUFDczRWOEEKLS0tIEgrV2xQZFRXdlYvd0ljRlgwcDB4
+            YlMrZkc4b3Jtb0JnRUYrRXJ5ekt2ZjQKb0T0o9oKMjQ+2DBQumfQLY5cozbXgKD1
+            khtvNdKUccTmbf8fdt/0J1jDDsR5q9XRmz1hR1iM2hJ8POeijVwitg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-04-21T08:22:19Z"
+    mac: ENC[AES256_GCM,data:2cjycL+To3BkZzGetvUO/WrhrT8oIzorseFF9h3sywJai1WYLF9HOlaZLuCf1W7/Gnuep3itec1g/8dBIKLAp0DwwcLP7PVXha1SXn1ol1OAQkmn1o4Ks5+z+3haMKHGrYi6rA5Eu+eD4lbnE7HnjK8eujW8k7XHTImt4hrEFDk=,iv:7AAB0Uqcg1tl530brieaupPrIZ9M7LVpsE5WeKdiyn4=,tag:6Kx/OPnTd8neB+MOXitv2w==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/hosts/builders/build2/configuration.nix
+++ b/hosts/builders/build2/configuration.nix
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ self, ... }:
+{
+  self,
+  ...
+}:
 {
   imports =
     [

--- a/hosts/builders/build2/secrets.yaml
+++ b/hosts/builders/build2/secrets.yaml
@@ -1,0 +1,39 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:/MC7p9iSYNtmViJBxDzcdTiNYMoQJhUQwkq5e4GaSaC/r2Tqc9zARmbQo5qkbPY4z50nR3XLj6nI9n9Qtx7bLPKMxsLuP7Arq4VHMruDbHhnYOzhYOXvy73uZFKZmk1Ejirvb9mDUusmUdm5P/0TsbHXA6ZkC+/+aGBXvfMfPf387plz0GfDGoKCKqRLQKUs9FzIvKwcbXaGpA8T2n8/1z9yScxnClhcTQMNUUXt3gurXTH4aX29rDvrpKuJbSg9NnIh5K/ufhmMEti7GavrJhvySWLiNjfKFUytNeFzt7+jabVrM97nDw/LsRjWpCzkfX9dOd2QIq/zQERA1LV0za/VncG7PS7MMw+OSHEv6VumJ4dSHcG4gU8+N4R3bcjrj1ji+sc5/tRHuarNJ0nAr6iAZkAdvSdL1glEPvoTg3wMsJAj//V+tRmsbid8fb7LBeQLw8ftMS2coxZOMVW9i2SvXg8mQIq8OR0EhyRnASXwZyfUZLXTcYvPl47hlfdyZtsWpslUX2pnKLO4IVej,iv:NIBIHI67jqZdsLJceNP2p/iO8JnQQl2Ms14k1+DRhDY=,tag:XdG7d35+UH81iuN0Z25XjA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age123c6y9ws4za8xzc5wtm20gfsv2exfp69tvfmzcsu7l377u7s89tq8ymhc3
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkNms1amZQM2pwY0hDMzI0
+            L1BUam9OdmM0V2tSTTJmQWhnblhlZ0NpUVVRCjJySkw5QXUvNkhyNnlXMFE3Q1gr
+            N0VoeWZSTUJZRHVsR3AwanVQbUhzRjAKLS0tIG5GOUVUQnlpZUczcHhUOG5qYWFs
+            elBsci9zUzAya2FGTnMxMkFJRVVRZU0Kqvfg9h/VdUNbFmo+wnyxF/fDhDVb7klg
+            DTZxierqYDXyh9OV8esyumIBgAty508RNQ8G8Vl8OOe0kIoH5Scxww==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCWTIwVWwzc2YyN1M3NmMx
+            MDZUTXNLZklOUkRSUzk5NG1XOTJFRVIrTEZzCmVQYnFod0dPTGVrVlk1OThBeEpp
+            NG9pUitHdE5uUDFjTkhveEM4OFpkeGsKLS0tIHh3MTRmcWJRYTZibmEwNkZlSzlz
+            cUxvM0VrQjVsdk15bXVVWUZxb2JYVUkKD9AccJJvi3mIm21BnmenH4iaCAw8Azuy
+            w0onWHkxO0dn/NeQ0DgDrwQluxJGeawJLbwvwlNmQwW0zMDzsR1egg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5WlFJWDNKWXNpZTY4YVJR
+            UkRqUVR4MG8zQUE5VUs4Ri9hZDU0NGZDanpNCnNXVU8wMlZQWXZ1dzF1TDJHR1N2
+            OTdGVS9lODFRc0xLM3BBdXNUZXhCeWsKLS0tIDhDZlpFTmtuY0pEM2R4dkNrV3lU
+            TStwZS9SclpWWWNSTDJ3VUtQRVFDeEUKrkIOFqbjOX3A9B5+6ogEkBFINsSMpxvU
+            ZSj0si3wFNJnxF5sc+71Sr24PxuhEHzg1aPYjglR3ZoA+Aun5k7idQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-04-22T08:28:00Z"
+    mac: ENC[AES256_GCM,data:UJIqR6S/peSVKBDlBZPwx/RPOjT6wHOeZb2/vfDzGrxM9IIEEq0quWKaQmtg0AjbMVln+1/SM83I4dicAjubFoi8Q/eys5IERSfiXOso5JOLsIkD46at5h8V0Oozm+0HkI4vcpb/T+QPJgRQ1VpfFp/3iafbqw44Jsd3fyj5hNY=,iv:IzGOeVxBJk12zt9TjZ0Rk4UaRm3gBlxOoD5AdLQDoPQ=,tag:WhY20pUJNQJ+kWaF9prqAQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -31,6 +31,7 @@
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       loki_password.owner = "promtail";
+      cachix-auth-token.owner = "root";
     };
   };
 
@@ -52,6 +53,13 @@
       lokiAddress = "https://monitoring.vedenemo.dev";
       auth.password_file = config.sops.secrets.loki_password.path;
     };
+  };
+
+  services.cachix-watch-store = {
+    enable = true;
+    verbose = true;
+    cacheName = "ghaf-dev";
+    cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
 
   boot = {

--- a/hosts/builders/hetzarm/secrets.yaml
+++ b/hosts/builders/hetzarm/secrets.yaml
@@ -1,5 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:UTXKJoJTMT1Wk4UIC6wAaUs5vm3c1FWuTNqzOYkU1l1t57rrFLj3I9ZogClvWMdxZ/Y1rWtUX8845IKYoUEyKjenJg1OATjSB2kMJeF0WKVUtEsIuSstpvSIFk2H65+ABLrzNXiPJhqiUaL+3I7DvVDAWXNnt7dLKsmoxnmG7f9psVJVd6tR1Wx4orBeZjJHRO3YPq4uk7xy/CrJg45UzYZAbNnVw/pKPN19oRXwWYVRRJirEWrj+ECjbDNudtgwRfcIBJtrWGuAxdjiPlFxl7HWucHqs3M+5ziJyycTbM/zG+QEIdhv5bAIk+tsP0tcrKbAWlaXBU1JypOe9N2EBCCRI9VaGwsMFmabgtgo6jU8GvT2qxukOgnBDkLclBmBIhNvgBDDmLObZCgmdhA+wgsy3pDuvBJlwmj0sdKCFxyRENPxoowD2jcibxJI79evUoaLMDayLCGRfxkZgiCcbIG+3dPaprT8vs20YijFbAEKQiiTYohs6ZttIx22jBBdHbwOAwh4I4ywZVAmWMtNWYh7+E0LtriZQGnKJYuPnTTaUFiRRsUY98EtzhNmo8Kt,iv:U7tpw+Ce4DuGhnO2RIUjsgpJ6I0j0vmdqI4zk8RoHec=,tag:nyxaLHy20C6uMcxZLVUWiw==,type:str]
 loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:Iu6UTqIGJU5CwowsZaJnNsXzlWB74q+KnyoCvEI/hIV7XFyLxZHaK2IPI+aTV7s70Tumf1GzBWqUd+bjGiofsi7ZJ0jhWQEGmXGBH5xnwK88Grnd8gSvtheJMI1kd0jVUcvVvhC1HJr59uIRfR/9m+YoxpwGHULTgLSDLKH5wq+uumiV4Qvqvk3fNO7m7L7/vvVlVtIx,iv:R4MDAL5dRg0fhtBuZAAggWp5OSuxWQ20KdQo0hLO9t0=,tag:9DYUm0NOi0yXd4FnQkpWYQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -33,8 +34,8 @@ sops:
             cWM5UFBTalJ3Q1gra1NnTUFBYmh5dUEKYLmUJRa+3KqWIWpPgIXeDelJxZXgb29C
             Hf2aMuJx8jba7mWZoR6b/8KybXmgkjRYdcVOZ45gLVRV+6LIcKqSyw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-11-11T09:27:30Z"
-    mac: ENC[AES256_GCM,data:dJ4sixRMFeoZl25M+rykO4VVh2K29eECvDNPWl8otg10JusAen8j+i1uCWOus0ny4+6q4g0FEai+9BT1JSrv8y32AzJsz12dm+PSypQFG7RqVdzLC03LxSn0bseoJ6pLTxDfuxq2MsGybxjmkWQrjriotbpPMtvXy/emy7w7F68=,iv:p6HSeUKo4pdOzClY/fBg/g9CqjDyx5wDqMz/RqXloIY=,tag:luY/k6J9tdRxfbUXSzG1eA==,type:str]
+    lastmodified: "2025-04-22T08:29:56Z"
+    mac: ENC[AES256_GCM,data:1zLwQjBgsPq3S6FGW1S0XlSE69KKenwCyZ0YzKLiLmwinUb6aI07KBt9w9Cnr8RbqhoUlIfI7/u7quaDaW/iaOEVVUqqqSFi568n+4s0IG0vuqyY0RXALuepNCC9a4Gp8jLo863SfrOBcYCqOsJHwDuuqC8hbHW9gAmiOZY3Ev8=,iv:1oFQ3NafOBl/AvZ2KBf9g2EbUMhkNw4DbQtcv26WAdY=,tag:ejcYPSX3TA74UC6+G10stg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.4


### PR DESCRIPTION
Main changes:
- Add host keys to `build1` and `build2`
- Add [cachix-watch-store service](https://search.nixos.org/options?channel=unstable&show=services.cachix-watch-store.enable&from=0&size=50&sort=relevance&type=packages&query=cachix-watch-store) and cachix authentication token for hosts `build1` and `hetzarm` to start populating [ghaf-dev](https://app.cachix.org/organization/tiiuae/cache/ghaf-dev) cachix cache
 
After this PR is deployed, `cachix-watch-store` service on hosts `build1` and `hetzarm` starts pushing all newly built nix store paths to cache https://ghaf-dev.cachix.org. If this turns out to be too much, we might later want to limit the pushes, but I'd propose we start with this.