### PR TITLE
Reduce dev binary cache vm size to save costs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -115,7 +115,7 @@ locals {
     }
     dev = {
       persistent_id           = "prod"
-      vm_size_binarycache     = "Standard_D4_v3"
+      vm_size_binarycache     = "Standard_D2_v4"
       osdisk_size_binarycache = "250"
       vm_size_builder_x86     = "Standard_D16_v3"
       vm_size_builder_aarch64 = "Standard_D8ps_v5"


### PR DESCRIPTION
Reduce the virtual machine size of the dev binary cache from 4 vCPU to 2 vCPU  to save costs. Also, move from d3 virtual machine family to d4 because d3 is a previous generation series. While older VM sizes are supported until further notice, Azure recommends using newer generations for improved performance and security. 