### PR TITLE
Align pre-merge workflow with Ghaf

### DIFF
--- a/.github/workflows/authorize.yml
+++ b/.github/workflows/authorize.yml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 TII (SSRC) and the Ghaf contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: authorize
+
+permissions: {}
+
+on:
+  workflow_call:
+    secrets:
+      read-org-members:
+        description: "Github token with read access to organization members"
+        required: true
+    inputs:
+      github-org:
+        description: "Github organization name"
+        required: true
+        type: string
+    outputs:
+      result:
+        value: ${{ jobs.authorize.outputs.result }}
+
+jobs:
+  is-org-member:
+    runs-on: ubuntu-latest
+    outputs:
+      is_org_member: ${{ steps.check-is-org-member.outputs.is_org_member }}
+    environment: "internal"
+    steps:
+      - name: Check identity
+        id: check-is-org-member
+        shell: bash
+        # More details: https://docs.github.com/en/rest/orgs/members
+        run: |
+          is_org_member='False'
+          actor_enc=$(printf '%s' '${{ github.actor }}' | jq -sRr '@uri')
+          response=$(curl -L -o /dev/null -w "%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.read-org-members }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/${{ inputs.github-org }}/members/$actor_enc")
+          if [ "$response" == "204" ]; then
+            is_org_member='True'
+          fi
+          echo "is_org_member=$is_org_member"
+          echo "is_org_member=$is_org_member" >>"$GITHUB_OUTPUT"
+  authorize:
+    outputs:
+      result: ${{ steps.set-output.outputs.result }}
+    needs: [is-org-member]
+    # Authorization passes without approval if:
+    # - The event is not a pull request (e.g. push to main) or
+    # - Pull request comes from another branch in the same repo or
+    # - Github actor is a member of 'github-org' organization
+    # Otherwise, the workflow requires manual approval from a maintainer
+    # as configured in the 'external' github environment
+    environment: ${{
+      ( github.event_name != 'pull_request_target' ||
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        needs.is-org-member.outputs.is_org_member == 'True' )
+      && 'internal' || 'external' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set output
+        id: set-output
+        run: |
+          echo "Auth OK"
+          echo "result=authorized" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-name: Run pre-push checks
+name: Build and test
 
 on:
   push:
@@ -15,91 +15,21 @@ permissions:
   contents: read
 
 jobs:
-  # Checks if the author of pull request is in our predefined list of authorized users
-  check-identity:
-    runs-on: ubuntu-latest
-    outputs:
-      authorized_user: ${{ steps.check-authorized-user.outputs.authorized_user}}
-    environment: 'internal'
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-
-      - name: Check identity
-        id: check-authorized-user
-        shell: bash
-        run: |
-          # AUTHORIZED_USERS is a newline separated list of usernames
-          if echo "${{ vars.AUTHORIZED_USERS }}" | tr -s '[:space:]' '\n' | grep -Fxq "${{ github.actor }}"; then
-            echo "User is authorized"
-            echo "authorized_user=True" >> "$GITHUB_OUTPUT"
-          else
-            echo "User not authorized"
-            echo "authorized_user=False" >> "$GITHUB_OUTPUT"
-          fi
-
-  # Authorization passes without approval if
-  # - the event is not a pull request (eg. push to main)
-  # - pull request comes from another branch in the same repo
-  # - author is in our predefined list of authorized users
-  # If none of these conditions are met, the workflow requires
-  # manual approval from a maintainer with write permissions to continue
   authorize:
-    needs: [check-identity]
-    environment: ${{
-      ( github.event_name != 'pull_request_target' ||
-        github.event.pull_request.head.repo.full_name == github.repository ||
-        needs.check-identity.outputs.authorized_user == 'True' )
-      && 'internal' || 'external' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-
-      - run: echo "Auth OK"
-
-  # Send a warning and fail this job if the workflow file was changed.
-  # Rest of the workflow continues as normal but the job failure will grab author's attention.
-  no-workflow-changes:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' }}
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          fetch-depth: 0
-
-      - name: Check if workflow is modified
-        id: workflow-changed
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
-        with:
-          files: .github/workflows/test-ghaf-infra.yml
-
-      - name: Send warning
-        run: |
-          if [ "${{ steps.workflow-changed.outputs.any_changed }}" == "true" ]; then
-            echo "::error::"\
-                 "This change edits workflow file '.github/workflows/test-ghaf-infra.yml'."\
-                 "Raising this error to notify that the workflow change will only take impact after merge."\
-                 "Therefore, you need to manually test the change (perhaps in a forked repo) "\
-                 "before merging to make sure the change does not break anything."
-
-            exit 1
-          fi
-
+    # Important: 'authorize' must run before checkout to ensure 'authorize.yml'
+    # runs the base version, not the untrusted version from the PR.
+    uses: ./.github/workflows/authorize.yml
+    # Skip running in forked repositories, since the workflow run would fail
+    # due to missing repository secret(s):
+    if: ${{ github.repository == 'tiiuae/ghaf-infra' }}
+    with:
+      github-org: tiiuae
+    secrets:
+      read-org-members: ${{ secrets.READ_ORG_MEMBERS }}
   build_matrix:
     name: "build"
-    # Don't run unless authorization was successful
     needs: [authorize]
+    if: needs.authorize.outputs.result == 'authorized'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
@@ -107,7 +37,6 @@ jobs:
         include:
           - arch: x86_64-linux
           - arch: aarch64-linux
-    if: ${{ always() && needs.authorize.result == 'success' }}
     concurrency:
       # Cancel any in-progress workflow runs from the same PR or branch,
       # allowing matrix jobs to run concurrently:
@@ -118,25 +47,17 @@ jobs:
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
-
+      - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        with:
+          ssh-private-key: |
+            ${{ secrets.BUILDER_SSH_KEY }}
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
             fetch-depth: 0
-
       - name: Install nix
         uses: cachix/install-nix-action@754537aaedb35f72ab11a60cc162c49ef3016495 # v31
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        with:
-          name: ghaf-dev
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Prepare build
-        run: |
-          sh -c "umask 377; echo '${{ secrets.BUILDER_SSH_KEY }}' >builder_key"
-
       - name: Build ${{ matrix.arch }}
         run: |
           if [ "${{ matrix.arch }}" == "x86_64-linux" ]; then
@@ -149,5 +70,5 @@ jobs:
             echo "::error::Unknown architecture: '${{ matrix.arch }}'"
             exit 1
           fi
-          OPTS="--remote $BUILDER --remote-ssh-option IdentityFile builder_key"
+          OPTS="--remote $BUILDER"
           nix develop --command bash -c "./scripts/nix-fast-build.sh -t $TARGET -o '$OPTS'"

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -71,4 +71,4 @@ jobs:
             exit 1
           fi
           OPTS="--remote $BUILDER"
-          nix develop --command bash -c "./scripts/nix-fast-build.sh -t $TARGET -o '$OPTS'"
+          nix develop --accept-flake-config --command bash -c "./scripts/nix-fast-build.sh -t $TARGET -o '$OPTS'"

--- a/.github/workflows/warn-on-workflow-changes.yml
+++ b/.github/workflows/warn-on-workflow-changes.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025 TII (SSRC) and the Ghaf contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: warn
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  warn-on-workflow-changes:
+    # Send a warning and fail this job if any of the listed workflow files are changed.
+    # Other workflows continue as normal but the failure will grab author's attention.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Check if workflow is modified
+        id: workflow-changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: |
+            .github/workflows/authorize.yml
+            .github/workflows/test-ghaf-infra.yml
+      - name: Send warning
+        run: |
+          if [ "${{ steps.workflow-changed.outputs.any_changed }}" == "true" ]; then
+            echo "::error::"\
+                 "This change edits a workflow file that triggers on 'pull_request_target'. "\
+                 "Raising this error to notify that the workflow change will only take "\
+                 "impact after merge. "\
+                 "Therefore, you need to manually test the change (perhaps in a forked repo) "\
+                 "before merging to make sure the change does not break anything." \
+                 "Workflow run results, as reported in the github PR actions for this change, "\
+                 "will be misleading."
+            exit 1
+          fi

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,21 @@
 {
   description = "NixOS configurations for Ghaf Infra";
 
+  nixConfig = {
+    substituters = [
+      "https://ghaf-dev.cachix.org"
+      "https://cache.nixos.org/"
+    ];
+    extra-trusted-substituters = [
+      "https://ghaf-dev.cachix.org"
+      "https://cache.nixos.org/"
+    ];
+    extra-trusted-public-keys = [
+      "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    ];
+  };
+
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";

--- a/scripts/nix-fast-build.sh
+++ b/scripts/nix-fast-build.sh
@@ -136,6 +136,7 @@ main () {
     [ "$DEBUG" = "true" ] && set -x
     targets_x86=(
         ".#checks"
+        ".#devShells.x86_64-linux.default"
         ".#nixosConfigurations.az-binary-cache.config.system.build.toplevel"
         ".#nixosConfigurations.az-builder.config.system.build.toplevel"
         ".#nixosConfigurations.az-jenkins-controller.config.system.build.toplevel"


### PR DESCRIPTION
- Authorize pre-merge workflow runs based on author's membership in tiiuae organization, separating the `authorization.yml` to its own workflow
- Move the workflow changed warning to `warn-on-workflow-changes.yml` which can trigger on `pull_request` rather than `pull_request_target`
- Builds are now run on `build1` and `hetzarm`, both of which push to cachix cache
- Add nix substituters configuration to `flake.nix` - trust our own cachix cache 
- Start using ssh-agent for the builder ssh key in the pre-merge action
- Start building x86 devShell in the pre-merge action to have the devshell dependencies also available in the cachix cache

These changes have been tested in fork at https://github.com/henrirosten/ghaf-infra/actions/runs/14620192422