### PR TITLE
GitHub actions security analysis

### DIFF
--- a/.github/workflows/actions-security-analysis.yml
+++ b/.github/workflows/actions-security-analysis.yml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04
+
+      - name: Run zizmor
+        run: uvx zizmor --format=sarif . > results.sarif 
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
[zizmor](https://woodruffw.github.io/zizmor/) is a static analysis tool for GitHub Actions to find common security issues.

Adds a workflow to run zizmor on push and pull request. The findings will be available in the repository security tab, similarly to the currently used scorecard workflow.

Note: https://woodruffw.github.io/zizmor/usage/#use-in-github-actions
> zizmor will always exit with code 0 even if findings are present, unless an internal error occurs during the audit.

> workflow itself will always succeed, resulting in a green checkmark in GitHub Actions. This should not be confused with a lack of findings.