### PR TITLE
Improve nix-fast-build.sh

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -58,17 +58,32 @@ jobs:
             fetch-depth: 0
       - name: Install nix
         uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
+      - name: Add builders to ssh_known_hosts
+        shell: bash
+        run: |
+          sudo sh -c "echo '${BUILDER_SSH_KNOWN_HOST}' >>/etc/ssh/ssh_known_hosts"
+        env:
+          BUILDER_SSH_KNOWN_HOST: '${{ vars.BUILDER_SSH_KNOWN_HOST }}'
       - name: Build ${{ matrix.arch }}
+        shell: bash
         run: |
           if [ "${{ matrix.arch }}" == "x86_64-linux" ]; then
-            BUILDER='${{ vars.BUILDER_X86 }}'
-            TARGET='x86'
+            BUILDER="${BUILDER_X86}"
+            # x86 targets: all nixosConfigurations except hetzarm, also build x86 devShell
+            FILTER='(^nixosConfigurations\.((?!hetzarm).)*$|^devShells.x86_64-linux.*$)'
           elif [ "${{ matrix.arch }}" == "aarch64-linux" ]; then
-            BUILDER='${{ vars.BUILDER_AARCH }}'
-            TARGET='aarch'
+            BUILDER="${BUILDER_AARCH}"
+            # aarch64 targets: hetzarm nixosConfiguration
+            FILTER='^nixosConfigurations.*hetzarm.*'
           else
             echo "::error::Unknown architecture: '${{ matrix.arch }}'"
             exit 1
           fi
-          OPTS="--remote $BUILDER"
-          nix develop --accept-flake-config --command bash -c "./scripts/nix-fast-build.sh -t $TARGET -o '$OPTS'"
+          OPTS="--remote $BUILDER --no-download --skip-cached --option accept-flake-config true"
+          # Build 'checks' on both x86 and aarch
+          ./scripts/nix-fast-build.sh -t "checks" -o "$OPTS"
+          # Build arch-specific targets based on FILTER
+          ./scripts/nix-fast-build.sh -f "$FILTER" -o "$OPTS"
+        env:
+          BUILDER_X86: ${{ vars.BUILDER_X86 }}
+          BUILDER_AARCH: ${{ vars.BUILDER_AARCH }}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -24,10 +24,6 @@
             nixfmt-rfc-style
             nixos-rebuild
             nixos-anywhere
-            # parallel_env requires 'compgen' function, which is available
-            # in bashInteractive, but not bash
-            bashInteractive
-            parallel
             python3.pkgs.black
             python3.pkgs.colorlog
             python3.pkgs.deploykit

--- a/scripts/nix-fast-build.sh
+++ b/scripts/nix-fast-build.sh
@@ -1,53 +1,94 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
 ################################################################################
 
-# This script is a helper to run nix-fast-build for ghaf-infra.
+# This script is a helper to run nix-fast-build for specified flake targets.
+# The main benefit this script provides over using nix-fast-build directly,
+# is the target selector filter ('-f').
 
-# https://www.gnu.org/software/parallel/env_parallel.html
-# shellcheck source=/dev/null
-source env_parallel.bash
-env_parallel --session
+# TODO: we should file a PR to implement the '--filter' option directly in
+# nix-fast-build. Also, '-s' in this wrapper is a workaround to an issue
+# that should be fixed in nix-fast-build: see more details in function
+# 'symlink_results' in this file.
 
+################################################################################
+
+# Set shell options after env_parallel as it would otherwise fail
 set -e # exit immediately if a command fails
+set -E # exit immediately if a command fails (subshells)
 set -u # treat unset variables as an error and exit
 set -o pipefail # exit if any pipeline command fails
 
+TMPDIR="$(mktemp -d --suffix .tmpbuild)"
 MYNAME=$(basename "$0")
-RED='' NONE=''
-DEF_BUILDER="builder.vedenemo.dev"
 
 ################################################################################
 
 usage () {
     echo ""
-    echo "Usage: $MYNAME [-h] [-v] [-o OPTS] [-t TARGET]"
+    echo "Usage: $MYNAME [-h] [-v] [-s SYMLINK] [-o OPTS] {-f FILTER | -t 'TARGET1 [TARGET2 ...]'}"
     echo ""
-    echo "Helper to run nix-fast-build for ghaf-infra"
+    echo "Helper script to run nix-fast-build for specified flake targets."
     echo ""
     echo "Options:"
-    echo " -t    Build selector - supported values are 'x86' and 'aarch' (default='x86')"
+    echo " -h    Print this help message."
+    echo " -v    Set the script verbosity to DEBUG."
+    echo " -s    Symlink top-level outputs with the out-link SYMLINK."
     echo " -o    Options passed directly to nix-fast-build. See available options at:"
-    echo "       https://github.com/Mic92/nix-fast-build#reference"
-    echo " -v    Set the script verbosity to DEBUG"
-    echo " -h    Print this help message"
+    echo "       https://github.com/Mic92/nix-fast-build#reference."
+    echo " -f    Target selector filter - regular expression applied over flake outputs"
+    echo "       to determine the build targets. This option is mutually exclusive with"
+    echo "       option -t."
+    echo "       Example: -f '^devShells\.'"
+    echo " -t    Target selector list - space separated list of flake outputs to build. "
+    echo "       This options is mutually exclusive with option -f. "
+    echo "       Example: -t 'devShells.x86_64-linux.default checks.x86_64-linux.treefmt'"
+    echo ""
     echo ""
     echo "Examples:"
     echo ""
-    echo "  Following command builds all ghaf-infra 'x86' targets on the default"
-    echo "  remote builder ($DEF_BUILDER) authenticating as current user:"
+    echo "  --"
     echo ""
-    echo "  $ $MYNAME -t x86"
+    echo "  Following command builds the target 'checks.x86_64-linux.treefmt' locally:"
     echo ""
+    echo "    $MYNAME -t checks.x86_64-linux.treefmt"
     echo ""
-    echo "  Following command builds all 'aarch' targets on the specified"
-    echo "  remote builder 'my_builder' authenticating as user 'foo' with"
-    echo "  ssh key '~/.ssh/my_key':"
+    echo "  --"
     echo ""
-    echo "  $ $MYNAME -t aarch -o '--remote foo@my_builder --remote-ssh-option IdentityFile ~/.ssh/my_key'"
+    echo "  Following command builds the target 'checks.x86_64-linux.treefmt' on the"
+    echo "  remote builder 'my_builder' authenticating as current user, symlinking"
+    echo "  build outputs in current directory with 'result' prefix:"
+    echo ""
+    echo "    $MYNAME -t checks.x86_64-linux.treefmt -o '--remote my-builder' -s result"
+    echo ""
+    echo "  --"
+    echo ""
+    echo "  Following command builds all 'checks.x86_64-linux.*debug' targets on"
+    echo "  the specified remote builder 'my_builder' authenticating as user 'me'"
+    echo "  with ssh key '~/.ssh/my_key', not downloading build results from remote, "
+    echo "  skipping builds that are already in binary cache, and accepting the target "
+    echo "  flake configuration (assuming 'me' is a nix trusted user on remote):"
+    echo ""
+    echo "    $MYNAME \\"
+    echo "      -f '^checks\.x86_64-linux\..*debug$' \\"
+    echo "      -o '--remote me@my_builder \\"
+    echo "          --remote-ssh-option IdentityFile ~/.ssh/my_key \\"
+    echo "          --no-download --skip-cached \\"
+    echo "          --option accept-flake-config true"
+    echo ""
+    echo "  --"
+    echo ""
+    echo "  Following command builds all non-release aarch64 checks targets"
+    echo "  (outputs 'checks.aarch64-linux.' not followed by a word 'release'"
+    echo "  in the output target name) on the specified remote builder 'my_builder'"
+    echo "  authenticating as user 'me':"
+    echo ""
+    echo "    $MYNAME \\"
+    echo "      -f '^checks\.aarch64-linux\.((?!release).)*$' \\"
+    echo "      -o '--remote me@my_builder"
     echo ""
 }
 
@@ -57,22 +98,71 @@ print_err () {
     printf "${RED}Error:${NONE} %b\n" "$1" >&2
 }
 
+on_exit () {
+    echo "[+] Removing tmpdir: '$TMPDIR'"
+    rm -fr "$TMPDIR"
+}
+
+parallel () {
+    # Gnu parallel in nixos-unstable does not work correctly for our use-case,
+    # therefore, using the version from 24.11. TODO: file a bug in nixpkgs.
+    nix run nixpkgs/nixos-24.11#parallel -- "$@"
+}
+
+nix-fast-build () {
+    # nix-fast-build in nixos-unstable does not work correctly for our use-case,
+    # therefore, using the version from 24.11. TODO: file a bug in nix-fast-build.
+    nix run nixpkgs/nixos-24.11#nix-fast-build -- "$@"
+}
+
+jq () {
+    nix run --inputs-from .# nixpkgs#jq -- "$@"
+}
+
+filter_targets () {
+    filter="$1"
+    typeset -n ref_TARGETS=$2 # argument $2 is passed as reference
+    # Output all flake output names
+    nix flake show --all-systems --json |\
+      jq  '[paths(scalars) as $path | { ($path|join(".")): getpath($path) }] | add' \
+      >"$TMPDIR/all"
+    # Remove leading spaces and quotes, keep only '.name' attributes:
+    sed -n -E "s/^.*\"(\S*).name\".*$/\1/p" "$TMPDIR/all" > "$TMPDIR/out_targets"
+    # Remove leading spaces and quotes, keep only 'nixos-configuration' types:
+    # append '.config.system.build.toplevel' which represents the complete
+    # system closure of the given NixOS configuration as package:
+    sed -n -E \
+      "s/^.*\"(\S*).type\": \"nixos-configuration\".*$/\1.config.system.build.toplevel/p" \
+      "$TMPDIR/all" >> "$TMPDIR/out_targets"
+    # Apply the 'filter' argument
+    if ! grep -P "${filter}" "$TMPDIR/out_targets" | sort | uniq >"$TMPDIR/out_filtered";
+    then
+        print_err "No flake outputs match filter: '$filter'"; exit 1
+    fi
+    # Read lines from $TMPDIR/out_filtered to array 'ref_TARGETS' which
+    # is passed as reference, so this changes the caller's variable
+    # shellcheck disable=SC2034 # ref_TARGETS is not unused
+    readarray -t ref_TARGETS<"$TMPDIR/out_filtered"
+}
+
 argparse () {
-    # Colorize output if stdout is to a terminal (and not to pipe or file)
-    if [ -t 1 ]; then RED='\033[1;31m'; NONE='\033[0m'; fi
     # Parse arguments
-    DEBUG="false"; OPTS="--remote $DEF_BUILDER"; TARGET="x86";
+    OPTS=""; SYMLINK=""; FILTER=""; TARGETS=();
     OPTIND=1
-    while getopts "hvo:t:" copt; do
+    while getopts "hvs:o:f:t:" copt; do
         case "${copt}" in
             h)
                 usage; exit 0 ;;
             v)
-                DEBUG="true" ;;
+                set -x ;;
             o)
                 OPTS="$OPTARG" ;;
+            s)
+                SYMLINK="$OPTARG" ;;
+            f)
+                FILTER="$OPTARG" ;;
             t)
-                TARGET="$OPTARG" ;;
+                TARGETS+=("$OPTARG") ;;
             *)
                 print_err "unrecognized option"; usage; exit 1 ;;
         esac
@@ -81,23 +171,27 @@ argparse () {
     if [ -n "$*" ]; then
         print_err "unsupported positional argument(s): '$*'"; exit 1
     fi
-}
-
-exit_unless_command_exists () {
-    if ! command -v "$1" &>/dev/null; then
-        print_err "command '$1' is not installed (Hint: are you inside a nix-shell?)"
-        exit 1
+    if [ -z "$FILTER" ] && (( ${#TARGETS[@]} == 0 )); then
+        print_err "either '-f' or '-t' must be specified"; usage; exit 1;
+    fi
+    if [ -n "$FILTER" ] && (( ${#TARGETS[@]} != 0 )); then
+        print_err "'-f' and '-t' are mutually exclusive"; usage; exit 1;
+    fi
+    echo "[+] OPTS='$OPTS'"
+    if [ -n "$FILTER" ]; then
+        echo "[+] FILTER='$FILTER'"
+        filter_targets "$FILTER" TARGETS
+    fi
+    if (( ${#TARGETS[@]} != 0 )); then
+        echo "[+] TARGETS:"
+        printf '  %s\n' "${TARGETS[@]}"
     fi
 }
 
-################################################################################
-
-nix_fast_build () {
-    target="$1"
-    tfmt="%H:%M:%S"
-    [ "$DEBUG" = "true" ] && set -x
-    echo ""
-    echo "[+] $(date +"$tfmt") Start: nix-fast-build '$target'"
+fast_build () {
+    target=".#$1"
+    timer_begin=$(date +%s)
+    echo "[+] $(date +"%H:%M:%S") Start: nix-fast-build '$target'"
     # Do not use ssh ControlMaster as it might cause issues with
     # nix-fast-build the way we use it. SSH multiplexing needs to be disabled
     # both by exporting `NIX_SSHOPTS` and `--remote-ssh-option` since
@@ -107,73 +201,66 @@ nix_fast_build () {
     # we need to export the relevant option in `NIX_SSHOPTS` to completely
     # disable ssh multiplexing:
     export NIX_SSHOPTS="-o ControlMaster=no"
+    set -o pipefail
     # shellcheck disable=SC2086 # intented word splitting of $OPTS
     nix-fast-build \
       --flake "$target" \
       --eval-workers 4 \
-      --option accept-flake-config true \
       --remote-ssh-option ControlMaster no \
-      --remote-ssh-option StrictHostKeyChecking no \
-      --remote-ssh-option UserKnownHostsFile /dev/null \
       --remote-ssh-option ConnectTimeout 10 \
-      --no-download --skip-cached \
       --no-nom \
       $OPTS \
-      2>&1
+      2>&1 | tee -a "$TMPDIR/nix-fast-build-out.log"
     ret="$?"
-    echo "[+] $(date +"$tfmt") Done: nix-fast-build '$target' (exit code: $ret)"
-    # 'nix_fast_build' is run in its own process. Below, we set the
-    # process exit status
+    lapse=$(( $(date +%s) - timer_begin ))
+    echo "[+] $(date +"%H:%M:%S") Stop: nix-fast-build '$target' (took ${lapse}s; exit $ret)"
+    # This function runs in its own process, this sets the process exit status
     exit $ret
+}
+
+symlink_results () {
+    # nix-fast-build doesn't create out-links locally, when building on remote.
+    # This function is a workaround to create out-links also in such cases.
+    # TODO: this should be fixed in nix-fast-build instead.
+    if [ -z "$SYMLINK" ]; then
+        return
+    fi
+    echo "[+] Symlinking build outputs"
+    grep -E '^/nix/store/[^ ]+$' "$TMPDIR/nix-fast-build-out.log" | while read -r path;
+    do
+        if ! [ -e "$path" ]; then
+            echo "Skipping symlink (not available locally): $path"
+            continue
+        fi
+        link_postfix=$(sed -n -E "s/.*[0-9a-z]{32}(-.+)$/\1/p" <<< "$path")
+        link_name="${SYMLINK}${link_postfix}"
+        echo "[+] Creating symlink: $link_name"
+        ln -sfn "$path" "$link_name"
+    done
 }
 
 ################################################################################
 
 main () {
+    # Colorize output if stdout is to a terminal (and not to pipe or file)
+    RED='' NONE=''
+    if [ -t 1 ]; then RED='\033[1;31m'; NONE='\033[0m'; fi
+    # Parse arguments
     argparse "$@"
-    exit_unless_command_exists nix-fast-build
-    exit_unless_command_exists parallel
-    [ "$DEBUG" = "true" ] && set -x
-    targets_x86=(
-        ".#checks"
-        ".#devShells.x86_64-linux.default"
-        ".#nixosConfigurations.az-binary-cache.config.system.build.toplevel"
-        ".#nixosConfigurations.az-builder.config.system.build.toplevel"
-        ".#nixosConfigurations.az-jenkins-controller.config.system.build.toplevel"
-        ".#nixosConfigurations.binarycache.config.system.build.toplevel"
-        ".#nixosConfigurations.build1.config.system.build.toplevel"
-        ".#nixosConfigurations.build2.config.system.build.toplevel"
-        ".#nixosConfigurations.build3.config.system.build.toplevel"
-        ".#nixosConfigurations.build4.config.system.build.toplevel"
-        ".#nixosConfigurations.ghaf-coverity.config.system.build.toplevel"
-        ".#nixosConfigurations.ghaf-log.config.system.build.toplevel"
-        ".#nixosConfigurations.ghaf-proxy.config.system.build.toplevel"
-        ".#nixosConfigurations.ghaf-webserver.config.system.build.toplevel"
-        ".#nixosConfigurations.himalia.config.system.build.toplevel"
-        ".#nixosConfigurations.monitoring.config.system.build.toplevel"
-        ".#nixosConfigurations.testagent-dev.config.system.build.toplevel"
-        ".#nixosConfigurations.testagent-prod.config.system.build.toplevel"
-        ".#nixosConfigurations.testagent-release.config.system.build.toplevel"
-    )
-    targets_aarch=(
-        ".#checks"
-        ".#nixosConfigurations.hetzarm.config.system.build.toplevel"
-    )
-    case "$TARGET" in
-        "x86") targets=( "${targets_x86[@]}" ) ;;
-        "aarch") targets=( "${targets_aarch[@]}" ) ;;
-        *) print_err "TARGET '$TARGET' is not supported" ;;
-    esac
-    echo "[+] OPTS='$OPTS' TARGET='$TARGET'"
-    echo "[+] Running builds, this will take a while..."
-    # Don't print out the full 'env_parallel' environment even if DEBUG=true
-    set +x
-    # Run the function 'nix_fast_build' for each flake target in targets[]
-    # array. Each instance of nix_fast_build will run in its own process.
-    # We limit the maximum number of concurrent processes to 3 (-j3) and
+    # Remove TMPDIR on exit
+    trap on_exit EXIT
+    echo "[+] Using tmpdir: '$TMPDIR'"
+    # Build TARGETS with nix-fast-build
+    echo "[+] Running builds ..."
+    # Run the function 'fast_build' for each flake target in TARGETS[]
+    # array. Each instance of fast_build will run in its own process.
+    # We limit the maximum number of concurrent processes with -j and
     # terminate the execution of all jobs immediately if one job fails
-    # (--halt-on-error 2).
-    env_parallel -j3 --halt-on-error 2 nix_fast_build ::: "${targets[@]}"
+    # (--halt 2). Keep-order (-k) and line-buffer (--lb) keep the output
+    # logs readable.
+    export -f fast_build nix-fast-build; export OPTS TMPDIR;
+    parallel --will-cite -j 4 --halt 2 -k --lb fast_build ::: "${TARGETS[@]}"
+    symlink_results
 }
 
 main "$@"


### PR DESCRIPTION
Allow specifying `nix-fast-build.sh` build targets with regex filter via option `-f`. This change makes the script more generic, making it possible to use the `nix-fast-build.sh` to build any standard nix flake. As a result, we can remove the [static list](https://github.com/tiiuae/ghaf-infra/blob/e83a89737a402494e2f24917ce780edb1bb18f59/scripts/nix-fast-build.sh#L140-L156) of ghaf-infra specific build targets: from now on, the list of targets we build in the `test-ghaf-infra.yml` workflow automatically updates based on the [target filters](https://github.com/tiiuae/ghaf-infra/blob/c040d281dcec156f6030d2edfebaaf65353c1d95/.github/workflows/test-ghaf-infra.yml#L83-L86) specified in the workflow and nixosConfigurations in the ghaf-infra flake. 

These changes have been tested in a fork at: https://github.com/henrirosten/ghaf-infra/actions/runs/15018950761.

This change slightly improves the `test-ghaf-infra.yml` workflow execution time, since we no longer load the full nix devshell in the github runner before running `nix-fast-build.sh`. It also adds building nixosConfigurations that were not build before due to  earlier [explicit list of target nixosConfigurations](https://github.com/tiiuae/ghaf-infra/blob/e83a89737a402494e2f24917ce780edb1bb18f59/scripts/nix-fast-build.sh#L140-L156) not including all nixosConfigurations currently provided by ghaf-infra flake.

Github action tests will fail for this PR due to workflow changes, but will start passing again as soon as this change is merged to main.