### PR TITLE
Allow fayad access to builder secrets

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -71,24 +71,28 @@ creation_rules:
       - *build1
       - *hrosten
       - *jrautiola
+      - *fayad
   - path_regex: hosts/builders/build2/secrets.yaml$
     key_groups:
     - age:
       - *build2
       - *hrosten
       - *jrautiola
+      - *fayad
   - path_regex: hosts/builders/build3/secrets.yaml$
     key_groups:
     - age:
       - *build3
       - *jrautiola
       - *hrosten
+      - *fayad
   - path_regex: hosts/builders/build4/secrets.yaml$
     key_groups:
     - age:
       - *build4
       - *jrautiola
       - *hrosten
+      - *fayad
   - path_regex: hosts/builders/hetzarm/secrets.yaml$
     key_groups:
     - age:

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -20,6 +20,7 @@ keys:
   - &build1 age15xx3qgw69hsmjyw64zmh9q0akyl3mh73dtvmdvhgezplqwaprstqffth7g
   - &build2 age123c6y9ws4za8xzc5wtm20gfsv2exfp69tvfmzcsu7l377u7s89tq8ymhc3
   - &build3 age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
+  - &build4 age146j4dfg9974kxe8hegjrdq5ywaldxw5j3fnkghxc6jkrrf0tndpsjjs0x3
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
   - &hetztest age1av993eefvndhv2apa4x7tpc7ezyhuj3jz9866vtulnrdwmjqe5hqrjc2z8
   - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
@@ -80,6 +81,12 @@ creation_rules:
     key_groups:
     - age:
       - *build3
+      - *jrautiola
+      - *hrosten
+  - path_regex: hosts/builders/build4/secrets.yaml$
+    key_groups:
+    - age:
+      - *build4
       - *jrautiola
       - *hrosten
   - path_regex: hosts/builders/hetzarm/secrets.yaml$

--- a/hosts/builders/build1/secrets.yaml
+++ b/hosts/builders/build1/secrets.yaml
@@ -9,29 +9,38 @@ sops:
         - recipient: age15xx3qgw69hsmjyw64zmh9q0akyl3mh73dtvmdvhgezplqwaprstqffth7g
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibTBaaUtVZGc5NERiYkpz
-            THRhWlNiRCtObDRjRi8rNXVPV002YTl3SWdvCkZ0RTRteEFPY2NVN0hBZlJ1TEs3
-            Y2hPZ0pybHVMOFdjRk9BWlF4TkN2UlEKLS0tIGRsZUgxN3hFYTQxWFpDV1ZzdWVL
-            Z2hwaDRLbGkyOTFSby9HVTA5WC81Q2MK2u2MGwCTTgM+NVC6OCg6aKN0MhEu90R4
-            iYRrEfvvuc3N+RZ5Kq/i51R9VlcEmD5qoLRCSSpQSVokvOJhIYMbZQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwVitEK0w3YWtLUElzbjE0
+            MXpLK2JiMDQ4OHBoODlha2FSYTQ0b1dmSnlFCnlZbHNkeWt0T3JobzVPZFViUDZR
+            QXMwM29VYnZNT00yMGZlWGNVNm16NHMKLS0tIEE0ZkhaRlFLY2NBTHdZYkFxMzVW
+            M3ZaS2ZBNDU4a2JQN21GUGVNUVFxb1UKZb9Ldk9Jka5UEXYV+E+qbg8IslmrRMxJ
+            Z96yqFkoJPtW81hE/ye1PryJVB4kQaSNuBIdRYxP4hcIRscWdv0M6A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUXBGQk1WQ1lyNDRhQm9j
-            eFc5TUd0Q1N4eDFmbDFycjdYam82T0xkdjJRCjBzVDRuK1J4M0tTaWw5elE0Znhv
-            bEZPTnFYUzA4WWl5OUd5enA2eVZyMUUKLS0tIDRYYVQrbFZvR1ROOW1KOHh0WStk
-            SHpzdlQ4MzNqWDl1YmFIZmczRlFJTlkK92fbpQoWK+eRh5sWoE1WCGVXGyAi6OlR
-            d+M3i54PX5Hjff4/Wmf2UQvDowxkC7wSHnHmVXIUbEg1OgR1Z42jbg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUUTRnbVNjZ3dKM0JGRm5O
+            UlQyaXFxSlBHS3YzN2l1Z2IyR05SaWpZQjJvClcyTzVDMkpuaXhtY3BmaTZ0VGk5
+            dGFqVWJwWTBiaWt2SDAveXRJUFlwUUEKLS0tIExES2RWenoxNlh0OGRUTFdZVDY1
+            ZkFZUHlpMXhvZ0xKcWR4MkxLcEEyRUUKuaDzZjVKIqrTGdLMKHCuPhXLGasopo0r
+            b29Mtu93o08VJbVk29LQgyp/pNgqamOxoiIhZCCkZL6hwBHkN3y9lQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHMmEzaGRadGw1eDZiS2lt
-            cHNxdTNCTWRIQWxaSUN6L0lSdWVFdUtFK2w4CllncjEra3czN2FhUG4vNkpDMWNa
-            VS81UXhqREx5S0xGc3hVRUFDczRWOEEKLS0tIEgrV2xQZFRXdlYvd0ljRlgwcDB4
-            YlMrZkc4b3Jtb0JnRUYrRXJ5ekt2ZjQKb0T0o9oKMjQ+2DBQumfQLY5cozbXgKD1
-            khtvNdKUccTmbf8fdt/0J1jDDsR5q9XRmz1hR1iM2hJ8POeijVwitg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWZFVsYU1VaHkvL0pyQ2VM
+            NlhDa2syMGpESEp6dm9DZ1JqYVgxOWFNMVcwCnE2clVNelhEbFJ3azdpOTF4M3Yx
+            aEhxOXZNNHFXYTIyVUQwdWkrU0NjWU0KLS0tIExNZk4zWXkyYXZndTcwcGxJdFlV
+            dXRHY3ArMGV0dlFkQk4vNXl2cWhGMGsKJqJQ2v4kQln3YJt0iOOG3xa8p6fo0wZD
+            Mf53acxSYJ5pdR6D9kBM6D3yVWQ8/EW+e9U3MnFhZRIpQxiY9OcEcw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0cHZudG83WWp2L1VIMzcx
+            eURNS0NyeVgyU2FXRzRwdUlibEx4cVBqZG1NCjVpWTNpUkMxZTNvMnlwekRqTWd5
+            blhLNTQ5YkExUUZpZ2xBMHY4aFR3b1UKLS0tIE1ldTIvb3h4MW83UUJYMS9heUZF
+            Rkd3UGoyWkR5ZFRXMmFmMEdJYUtwRU0KBvnbpiyPbF840FetVmSs6EOO1tSz/nSn
+            QxBt7Bx83A+PVAmRdcfmSJO2bx4bQo2zp6JQ8fSif50+4yNrRsgBuw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-05-15T10:41:57Z"
     mac: ENC[AES256_GCM,data:h28v4SSNhrBOCXVZCsmLs0dLkEGAZvyFqUOlPiBsbNsNRVvIYN0FxXobaFU64Cj2E93Nlsxh/loMTyhk3CEuVhFkajUf0E7Z6ck32WJNbnSI97aMWGQ78MZscp4oAeM+6CnZXWX9OIqjCYm2ZcnSW9FyD5Ctf1r5Oa1+D18vWtM=,iv:YMN285+PJjM1x88zCf/puGNpocXXRXTvlmjCjxV4zFs=,tag:P1eU63gVb/AST2mjG9plRQ==,type:str]

--- a/hosts/builders/build1/secrets.yaml
+++ b/hosts/builders/build1/secrets.yaml
@@ -1,4 +1,4 @@
-ssh_host_ed25519_key: ENC[AES256_GCM,data:Lmv+e1MqX2fSJJp09OQx2M2vfhCMwBYch3jmPLfg5W7Jng3GobWvr+dFXpgXUnlDevIgXQGK7hCiL+VU6ulAknIF600pkdXDN2kwO+PYs+EVgYihVYVQH03ipWD7WuJZOOBCAZU1uEXUZp9xST5IUDr/japoq0pf1trzb5nc2EQJpd5ByW86onmSDgbiWHI4VgPtnCfbLCVsl5FV8Rv+Cd+jRujc0AxrmhMq31lTMPZKfjdJZkMgWqfsYYaK7QQpl7g0iSYsa2JcIeSZ7CdN0reuzjwFYWcmI2NeftDOnyB/U/yn4io5+uxLfY9pvWOjGf1ONAVsTPplfexxPYu3/Lf1eBQCZ5uxqGwAcVNWvyLwEx0v5IKWxyPA4v891+lsU9qq10Jf9C/9buf0o+32ghSpkDXijuHRDR+RRli9BIqR85rHWTqoUZxP6EB0bWAJ733aiQoJr4fDOtKGx50L8U2tEuhTMSY0zoVB/sAWYG22G7ul0Y9mBBKz9c1AVUrG0DDtXXl7ArnReF2l/pg=,iv:Nb8pP0nNPJhoW5lRBFuP1yts6PYxm2JK8NW2v3m796s=,tag:Q1k2fANtTyRsybluhf9Eog==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:YD/A55P4UfJs1rJaQvFCJszier1L2tQ5I3uCg/kTAyRKQZiS/9fXyPzTqjqecOF2k75siapsghKzDAMBUjxktztHDQWG8CLkHMdDUb/EYFZYeC03U4V47Hzdp+tFlALRv6sFznF6CoNTMq2fBRfsJptLBHhtHf1LN3rvAkib7mcVY4LYsXWPLpENdn0jUTan2SWFG28+es3Xs/QLMz7pdepKLk8pJiuCE6rdUODIf0FusMNsIpYdsUS3ybw8bNA24K0i/geAJU+WbfLxbsHI/cQfpUgCXzvBywJ3GpBT8bKIjHntmgfQEip4oBRFtmN5bi8aiRUjYCfbE9f2MRjGawIOAW/Qoak0FlAS0G7TORlOb7HUG+q8hEkSW+7TMH9sglv0AQDZT3Cj4gq78iWlLua51XDVwk8pW+G+F0iU11845a9w3SMJJhZkJSfYZo7tmbClc/Rw2dMYenNz+IZTrpY8kkk3ewe6VXJR/MTGNyVlEqfZaclNDOthXJmvcn/m8fI3vnsrZar1649oc4vo,iv:bMNqUzoAtfrExHBSNiug9DQr29wMX9lSx+M9fOiqcVY=,tag:NMv3Sb/PEDydohZCSClZsA==,type:str]
 cachix-auth-token: ENC[AES256_GCM,data:qxE+xVs4C3URp1OL7K41i+xWLqzUr9757HTGcpWUIi1WOWfA/HUH+SthsFNesVcu7yohfwFkubf8NWpUOfsoTX/O97hOIpilVPVjABsrPr95ASmpw5/ozX8B2KJ6F66DakKsci/rFjdZJ+IsD9diRLusMgiStLPD9PQOGDcHH30yaknMFhvCeif99eFmScsswI64154J,iv:RNJ5wr5dKoJEI9PhOt02kJE2uXrewyuJyE1IoRyX4NE=,tag:DOfbR/GiFA/lGVorIRJqzA==,type:str]
 sops:
     kms: []
@@ -33,8 +33,8 @@ sops:
             YlMrZkc4b3Jtb0JnRUYrRXJ5ekt2ZjQKb0T0o9oKMjQ+2DBQumfQLY5cozbXgKD1
             khtvNdKUccTmbf8fdt/0J1jDDsR5q9XRmz1hR1iM2hJ8POeijVwitg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-21T08:22:19Z"
-    mac: ENC[AES256_GCM,data:2cjycL+To3BkZzGetvUO/WrhrT8oIzorseFF9h3sywJai1WYLF9HOlaZLuCf1W7/Gnuep3itec1g/8dBIKLAp0DwwcLP7PVXha1SXn1ol1OAQkmn1o4Ks5+z+3haMKHGrYi6rA5Eu+eD4lbnE7HnjK8eujW8k7XHTImt4hrEFDk=,iv:7AAB0Uqcg1tl530brieaupPrIZ9M7LVpsE5WeKdiyn4=,tag:6Kx/OPnTd8neB+MOXitv2w==,type:str]
+    lastmodified: "2025-05-15T10:41:57Z"
+    mac: ENC[AES256_GCM,data:h28v4SSNhrBOCXVZCsmLs0dLkEGAZvyFqUOlPiBsbNsNRVvIYN0FxXobaFU64Cj2E93Nlsxh/loMTyhk3CEuVhFkajUf0E7Z6ck32WJNbnSI97aMWGQ78MZscp4oAeM+6CnZXWX9OIqjCYm2ZcnSW9FyD5Ctf1r5Oa1+D18vWtM=,iv:YMN285+PJjM1x88zCf/puGNpocXXRXTvlmjCjxV4zFs=,tag:P1eU63gVb/AST2mjG9plRQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.4

--- a/hosts/builders/build2/configuration.nix
+++ b/hosts/builders/build2/configuration.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
+  inputs,
   ...
 }:
 {
@@ -10,6 +11,7 @@
       ../ficolo.nix
       ../cross-compilation.nix
       ../builders-common.nix
+      inputs.sops-nix.nixosModules.sops
     ]
     ++ (with self.nixosModules; [
       service-openssh
@@ -19,6 +21,8 @@
     ]);
 
   # build2 specific configuration
+
+  sops.defaultSopsFile = ./secrets.yaml;
 
   networking.hostName = "build2";
 

--- a/hosts/builders/build2/secrets.yaml
+++ b/hosts/builders/build2/secrets.yaml
@@ -8,29 +8,38 @@ sops:
         - recipient: age123c6y9ws4za8xzc5wtm20gfsv2exfp69tvfmzcsu7l377u7s89tq8ymhc3
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkNms1amZQM2pwY0hDMzI0
-            L1BUam9OdmM0V2tSTTJmQWhnblhlZ0NpUVVRCjJySkw5QXUvNkhyNnlXMFE3Q1gr
-            N0VoeWZSTUJZRHVsR3AwanVQbUhzRjAKLS0tIG5GOUVUQnlpZUczcHhUOG5qYWFs
-            elBsci9zUzAya2FGTnMxMkFJRVVRZU0Kqvfg9h/VdUNbFmo+wnyxF/fDhDVb7klg
-            DTZxierqYDXyh9OV8esyumIBgAty508RNQ8G8Vl8OOe0kIoH5Scxww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFSVFqS0hoSFJaRDY1L3Zu
+            STNRUWxxM3d5M2Ivb2h6N2MrVUJVTU92RXdrCkRBZjg0a2U1ZjN5WWVkY0tDVkpI
+            QVdQYXRhdjJwMDdIalZKQXlRV3lNdjQKLS0tIG1xZEU1c2FjVm1NMnI3QkRHdlZa
+            T1hMOHR0Vjg2ZVNES1E1TnMxNWlxLzAKs1yVIuLplPiSnotbL7ZnsBcSOqDHOKsG
+            zRT8Tn1c7Zk0FhQTfqsivfYvgkRPKgkcKJFQk9fpbHeGfQBg9clgvQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCWTIwVWwzc2YyN1M3NmMx
-            MDZUTXNLZklOUkRSUzk5NG1XOTJFRVIrTEZzCmVQYnFod0dPTGVrVlk1OThBeEpp
-            NG9pUitHdE5uUDFjTkhveEM4OFpkeGsKLS0tIHh3MTRmcWJRYTZibmEwNkZlSzlz
-            cUxvM0VrQjVsdk15bXVVWUZxb2JYVUkKD9AccJJvi3mIm21BnmenH4iaCAw8Azuy
-            w0onWHkxO0dn/NeQ0DgDrwQluxJGeawJLbwvwlNmQwW0zMDzsR1egg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4SXAya0Fwc1E1RmJGY0dr
+            RFVIR0dlUzVHUkZKdVZuZ0UveTl5dnZSekNZCkkyMVJ4MmExMVk2YlgreVdUb0Rw
+            SVRIZTM4c3NNOURteFRLM01vREtadFUKLS0tIHZmYTNSSUhOaGZZSzBBSmhBT3Ax
+            VEVENFVpRUJEWEV0ZlJESUdzZ1dONTgK+PDnSzl1HmC7y4t5amcYowVItGSWWSRi
+            HmnjbVasYIo3be5XkBqeYAVf/S6YvOMkaYSNQ08ay4nta3yT+o4rag==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5WlFJWDNKWXNpZTY4YVJR
-            UkRqUVR4MG8zQUE5VUs4Ri9hZDU0NGZDanpNCnNXVU8wMlZQWXZ1dzF1TDJHR1N2
-            OTdGVS9lODFRc0xLM3BBdXNUZXhCeWsKLS0tIDhDZlpFTmtuY0pEM2R4dkNrV3lU
-            TStwZS9SclpWWWNSTDJ3VUtQRVFDeEUKrkIOFqbjOX3A9B5+6ogEkBFINsSMpxvU
-            ZSj0si3wFNJnxF5sc+71Sr24PxuhEHzg1aPYjglR3ZoA+Aun5k7idQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuWWNtbGw2N256S1p4UWNO
+            R09hSmVMd2hJRUFMbzNhK0o5UU9kM0UrYlRFCnVXa2p3NVJyREtzR2NNY3lOUWFl
+            TXBmbmJ5cllxalhyakVlTjdlblhxQ0EKLS0tIEJoTE1NaGY4YUtVVlQ0bFNqMmJp
+            azZMMGV0cGpmNGwxUjlmdE9BcVA0bXMKHMQSDrB1l/0410QRO7vwGcyBW7x8JKh0
+            JGILbmntcbV3UH0aTeDW9y7qq3X6IYxa0mEb04RWlQo6MPzG4rHe2w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEWmpQcmhZakJVZUdPeFhr
+            QkM2bDNHUGVmMnhWT1dOcVJYaTQrWDlsMkRRClhWQnFCTEVsckRUWDkvN1JQeHEz
+            TGQ1WUhuc2lqOVVoTlhnTnVzbk8vNjgKLS0tIFRvM281RlE3c1kzZ1F6Zy9vUWdP
+            ZFlZQklDdlhsd0t5eU5WTzJNY2xVbVUKjedneEhHa8Km2fVJiW6n1QoCta3ugl0m
+            E2aG6TXq6A8VSnDV7VUP36mJczcyeoyp32rLTaRgZ1dJt3nhH/C+2g==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-04-22T08:28:00Z"
     mac: ENC[AES256_GCM,data:UJIqR6S/peSVKBDlBZPwx/RPOjT6wHOeZb2/vfDzGrxM9IIEEq0quWKaQmtg0AjbMVln+1/SM83I4dicAjubFoi8Q/eys5IERSfiXOso5JOLsIkD46at5h8V0Oozm+0HkI4vcpb/T+QPJgRQ1VpfFp/3iafbqw44Jsd3fyj5hNY=,iv:IzGOeVxBJk12zt9TjZ0Rk4UaRm3gBlxOoD5AdLQDoPQ=,tag:WhY20pUJNQJ+kWaF9prqAQ==,type:str]

--- a/hosts/builders/build3/secrets.yaml
+++ b/hosts/builders/build3/secrets.yaml
@@ -9,29 +9,38 @@ sops:
         - recipient: age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbmNqZ011MXV5YkVvT05w
-            VVRHK2pXcTF1T044MjlXVFh6dTJ1RWk2OFh3Cms0VkpzNTcxcEgxWEJmK21JMFk2
-            UEhISkxNK2JMYnBKdlhlQnlxTmpwc3cKLS0tIGpmOGlCK3RYZ2l3T25FVkVVOHE3
-            Y2JuYXZJTlhuSGpDL291QnRPUmFBYkkK9zDeaPXwErY0P2BotsaVaHCmibpCjbC2
-            PSIG1UL9JxuPZASx/Iy9duycoMs+FRBj96SKULqDBde6G19eOvSbyw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTbGNLbnNiemJqaHorUjk2
+            VmtFc0xWb291ZFJQNmprL1A5Um9ra1ZOYkJRClJQYWE3WU5PUHBNZGhOMGg3Uk9u
+            UURMbCswTmJFMXZxUG5Ja3NCU1hjSmsKLS0tIEJ5QitRUnQyZ2pDaVp4Zk9UZGdT
+            Q3RSUDMvZkQ3OE9jZUZyWG14N2UxZDgKzCUnredJwccnlq7h/DRLJ7WWBUfcvwyv
+            PQV2Lq+m0sjgg2dR0Sj260rwfhsup9ppa2V+e2SQMcZEiMdK1gbBhQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsSUhRSVhvSjNNb05TN2Zt
-            RmtIZWI2R3hKZ3hCdzdqbEdkbXRsZ2JZV1E4CnNEazNMOFU0QTYycERLeWhRWmFL
-            cG1Jajd0L29iVGoyM0N5ZjMzeFUxQTgKLS0tIFpMdDVVTUNqUjViQVFNanMyT3pm
-            ZitaL3orbXgxMzQvbTlFTStlSHdVNzQKMm5PPkGLHW5i1f/2YBGU/T71DZL6t5QC
-            sTcFvZx472y4fY80xbN1IWJ87lnkKxRYdG6ln/KpxFFhIgdJnRA16w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhcEs4Ymc3TGJudjBoK3p3
+            RVNGK1FlU0NraEhsMXNod2tJWkpiYWFMNlZBCkxTZ2Y1djdyemYyUUZxemZFbUFW
+            MEMzRUJuQWVKOGVmMjQ0S3BUdWxlWWMKLS0tIHh0M2dXeGJhM3g4RnQxK2ZlNXU5
+            TWtKbHJocWxObTkxcGRFZmllRDdJbFUKGM26NjX3Trr9W5s5D0CTIp+SbT6Ac0nc
+            hb3sv3iyTs0c/hacAnG8lW3pJSAeFQh7b3BoNzXmWk+RWtbuEMLdHw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCZlByYnp4T1NmK2VGNDE0
-            TXZDQnVNbXhqdjZFbVg4b3IwMXFGNXY1RWhjCmdDMHJrWFdSRGsvcERZL2lkTDQx
-            QmNlelhTMG5nb3RlejF0aXcwU0duQW8KLS0tIHByK0FmTG5Jc3NLN1d4UXhyMnNN
-            TDQwQS9LTitYOG1pZ1NKanFkSXFkekUKzUFD9zz3SvmDFPdmHts9yiNBTJiW3q1c
-            63SEF/+Bv+NzixsVXgLj4GmdzL+dfaCmEfonOt06eEe8CVQxcge6mQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBobE55RStGaHRhOXlCMU83
+            MWVWS2Y2WjJFa1JpU3RUTklKMlBtZGQ1dlQwCjcvNFl6cjBIUmlmcnJsRVVsYzZN
+            M2xvbTYvMnNlMmNlSU10SEU2STZqTXMKLS0tIFp6L0Evclp0Zmprak9ETm0wbllm
+            aTJyNTFHN015RlNvZndyaWYxRGFVSWsKMzXEUUyaT+QZ7o4g14kErsRXwfdBNOGX
+            Tj2lPunU3/6WHdHG4bmKsGIB1t4rc4D7UEPZ6Jozp+XOANg4U7qC7g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWUEZCbzZCMWVNSmFhdmc3
+            WHRxSXh0Yms3UzViV044Y1E1OVpKdUZYWng0CkR3cmVQME9nYTlIc0tZVXp6UlZX
+            MGRLbUlqNlBJdFVCUzVoK21aTStLdlUKLS0tICtYN3QzeXJDeDZvYkphSWw0UXdI
+            bVdGYkYzc1BXZVo5Z0cvL1VaTWU1cEkK+hgs9mMhFyQz2D8o0K8wN4hPjZaZmcEY
+            jxIdx9xuATy5+dRgSxU0fP9LELoXmHhNVFW994A3hrU+BAkuDeioBg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-05-24T05:48:00Z"
     mac: ENC[AES256_GCM,data:ZISriCWwstvq6nSp+cXvfhLlTc4wrfHnx0I06Ezkwyd2Hr3WNbMDQl8hA/Iq5UOlkULNg/w8j2zJEn7WKzSyzpC5cSiLCwwr0YJJUtLvyodK/cq/JfRoYEzZlMVZaMwH4UCdj5a4v5+sThdxCFUJaMF8i0c/IpzD0tCPfYEUSEc=,iv:ElxzzfvVS/4Gco7AQDlReywdmJdE+IoFh/aMSldZAQI=,tag:IZGkov+bFDbE+yA57lfKSA==,type:str]

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -1,12 +1,17 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ self, ... }:
+{
+  self,
+  inputs,
+  ...
+}:
 {
   imports =
     [
       ../ficolo.nix
       ../cross-compilation.nix
       ../builders-common.nix
+      inputs.sops-nix.nixosModules.sops
     ]
     ++ (with self.nixosModules; [
       service-openssh
@@ -16,6 +21,8 @@
     ]);
 
   # build4 specific configuration
+
+  sops.defaultSopsFile = ./secrets.yaml;
 
   networking.hostName = "build4";
 

--- a/hosts/builders/build4/secrets.yaml
+++ b/hosts/builders/build4/secrets.yaml
@@ -8,29 +8,38 @@ sops:
         - recipient: age146j4dfg9974kxe8hegjrdq5ywaldxw5j3fnkghxc6jkrrf0tndpsjjs0x3
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyRis5U2tyQ3l6eHFpMTFz
-            VE9sS0Jva0VlRmh5bGZUTjc1dVY3UnhQYUFVClE5SnNhSmNNOTl3cWlrdXp3ZERw
-            NHM5ZzVZUVB4NnJmM0FLU2MwellVemcKLS0tIExFbFo0NnR4RS9kY3RVY1c3YU0w
-            WndkTVM4cmFaTGdIajZGdWFKeVVrRUkK+1hsQAmAvsRbb/SxHHxx6oMM7WfbERJF
-            sFtWhpDggqTBgse1Vo960wnBIGbds9V7t2Wtk8ap5NTIyxmJQM+oXQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXVWVxM05RbndlTm9aVDE5
+            Q3ZJR3RPbkJNbHkzelFoR3Q0enAvL2VEZUJRCjUwRnVnK1lXK2hDY0NkaGtwMTFX
+            M3dadkhBbmlLOEJWY0RLNUNnNHJBZlEKLS0tIFJwc1ZuRktLSzZlelBqK0ErRlZO
+            TERzSER4QjdENU8yelRLYTlQU3diWUkKj9ZOBO1qcg+dKFnRBaOXXCNgllsdgSkj
+            r6oDK/XkWCcyZHV9QVbiedkbH5nrewrUFPJdCfwJUeGASnlceUKtgw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBS2FTMXJ0cVB5ZVdlL28r
-            Z0ZjYUtSTUZBZlZySDVtQzRNVWZENUR2Tkc0CkZIb3R3bkh0WHJNTlFxc2c5Rmcx
-            VWZFMEFaQTJOVkRERTVQV1RzRm5kZTQKLS0tIFd1dDlWbVlndzJ1TkRsczFTWjFI
-            dHNiZWlBRFh2V3I0UXJRcEl5WEhPZU0K+CsliAY6gJv1d44X+Tb7zWkb/u/fJemn
-            QRbIX/2JQtRSgA3rt+jE/mqWo+Q3uZNJelqfV5r8h5SmBTO0KLglqA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqSjM1T3c4cVMvNnZiYldt
+            TmhrMUlBVWRjcGpqSWRWcEczQmNRdXcrVVZBCnFDVHlNeUIvbWQ3ekV4MUdGZTZw
+            ZW8rSTZiTk5jb3VGQm8zYWtiSi9aR00KLS0tIFZDKzBKeGxBQS83aW5TOXZCNEdY
+            LzhxQXRqR2hNTVVaOWplZFkvbndDdFkKVMmqByu73HMySomsuA5CCDO1rWte5Sze
+            jV4o0IMZ77IQ0HWcMWCAdn9BwBdDpjnXPLBY6CoyU0S7xFimXqFzPg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2YW1MWEVOdWt1Y1dXeHdw
-            TkIvdGFQY2VMSmtaeEhzcW0xeGl4SGRacG5FCmFxRE93YkVlSDlqaVpTNzQ4QnM3
-            b0YvYzdlQ2tuczdWZEZDbWl0clUzRGsKLS0tIEJyNnRsWFVMc3pCaFV5bDg2NGl6
-            dnJleXQvLzh0TVNjMWFoLzlGRkN3Z1UKglmbWBiyiQNfcpl3JwiQrkccGJ/FhVgT
-            fnKNGUItGQtMdi7GSxmdWlIOcX1pockfXDRW5MxQe3ekhzdSWO1nkg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYnJKQit4T0NkWWt3UG9S
+            SGk4VHI0TWlKVEo0YXppOFlmR1RmUmlLVUFBClFtVGZ4UWtzRW96NEZTNEF2bSs1
+            eGNRbTRSTjNrbjVnekpnQU5MNmVyOEUKLS0tIFYrYVZmK3BSelhjb0t1UjNsYVNk
+            eDVISWdXSC82c040d0Vha2hLck1XaG8KYcSG5et3Zohckg7ynG6JL/Sr0uRavS9a
+            bE+uGJBtZVzUHH48JtCCVhuUNOmC3bFlh6kU7p/sl9teN7vFPC3afQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsYnRnaFdtbnI3WGZuVkVy
+            OXdGZlcvWVc0em4yd0tOVk80SkpZSHc5bDBFCk1aQmNXZWRib2w5TS9JbTJnNU1S
+            WlBYdTBlU0lCcTd4L2h4S0p6VVNoQWcKLS0tIEN2aXFoTXhlUjFVbm9LQ2lCWG5W
+            NC9VcU4wSWZlajc3WllqR3Y2TFN4M28KZkul+TAj96zcT2jI3i479U5BntfWLp4f
+            cVN2Yvb9l8qAtoPudYtxHwnkAiYBCIjVHcRt65ftIf+RWzYOt/WbWQ==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-05-15T10:34:04Z"
     mac: ENC[AES256_GCM,data:aQLWexHZOqRNS79sSSgQLwHRziLPwYSZK85FXGauoN07/Oi7f2Kkm9EC1bgvRthhcoZ83MorHly61ld6pgI/o6e7WO/SUKGytd9OFExd6jWCp7qPahVUXS/VEx4GHZkLARgGvk0ajMFp39C2+vtpK8aUT7iOkyuvfMlMz+asN/U=,iv:rZUPM/CLJXiSMpXW+ag9P8hMxf3v2e/zuYr7BvYZElo=,tag:rK9WlWTUYhXxaIx7HGN7yQ==,type:str]

--- a/hosts/builders/build4/secrets.yaml
+++ b/hosts/builders/build4/secrets.yaml
@@ -1,0 +1,39 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:3bs2niWe3uMkENCW7NU9ZnC1piamVALAW0xlVqok2eKJnJ45jQpAFTZ0yyTqZfs+BJf+8nXiOFVuz9avyTslA9wc15BnB5PoTFhUeiaLhWfuo9rH7fsVfQ1I5r8xyOg6OjbpmungQoUOodFKl+ohuWfDFhfoD3df5Kd4CaGdklBTxj84qOciYvjZ/QX3yprhdLhky/pDA7w5drx3wkop+Vtgt+XDo3pojywX63yzEeXHhzYb6e6mrkEWymFMxTSv5lTS+3sjEv8InxSbXwjOvj2jUqNCyFhvG8psOjmcxOsJCWxMVO535MyinNHLsS3SQ5x/gIfmGmA2y0HnDQ/Jr6munaIlag67GqIH301x0IYGKWHY5tBPTI63ZO7IWwz1WGTnkqznPdche8FLUqimOs2jeuDfbdG1+n1oMwAaJquji7h5YbWxYnNnikPG+G1DGK3iB2QmfTu/1w1Voh/c1X6AHXBV9zNhju7XHguKMlQm0mq+Dzp7KB+TfiI+BlnSevg+99dMMAN4AF8ZixiG,iv:IA+WqJy4tw56OMFya/tMnpxjyPAVL5eOw89tIEmHtus=,tag:IO8BnKKiJCpgupXD8uqbCA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age146j4dfg9974kxe8hegjrdq5ywaldxw5j3fnkghxc6jkrrf0tndpsjjs0x3
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyRis5U2tyQ3l6eHFpMTFz
+            VE9sS0Jva0VlRmh5bGZUTjc1dVY3UnhQYUFVClE5SnNhSmNNOTl3cWlrdXp3ZERw
+            NHM5ZzVZUVB4NnJmM0FLU2MwellVemcKLS0tIExFbFo0NnR4RS9kY3RVY1c3YU0w
+            WndkTVM4cmFaTGdIajZGdWFKeVVrRUkK+1hsQAmAvsRbb/SxHHxx6oMM7WfbERJF
+            sFtWhpDggqTBgse1Vo960wnBIGbds9V7t2Wtk8ap5NTIyxmJQM+oXQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBS2FTMXJ0cVB5ZVdlL28r
+            Z0ZjYUtSTUZBZlZySDVtQzRNVWZENUR2Tkc0CkZIb3R3bkh0WHJNTlFxc2c5Rmcx
+            VWZFMEFaQTJOVkRERTVQV1RzRm5kZTQKLS0tIFd1dDlWbVlndzJ1TkRsczFTWjFI
+            dHNiZWlBRFh2V3I0UXJRcEl5WEhPZU0K+CsliAY6gJv1d44X+Tb7zWkb/u/fJemn
+            QRbIX/2JQtRSgA3rt+jE/mqWo+Q3uZNJelqfV5r8h5SmBTO0KLglqA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2YW1MWEVOdWt1Y1dXeHdw
+            TkIvdGFQY2VMSmtaeEhzcW0xeGl4SGRacG5FCmFxRE93YkVlSDlqaVpTNzQ4QnM3
+            b0YvYzdlQ2tuczdWZEZDbWl0clUzRGsKLS0tIEJyNnRsWFVMc3pCaFV5bDg2NGl6
+            dnJleXQvLzh0TVNjMWFoLzlGRkN3Z1UKglmbWBiyiQNfcpl3JwiQrkccGJ/FhVgT
+            fnKNGUItGQtMdi7GSxmdWlIOcX1pockfXDRW5MxQe3ekhzdSWO1nkg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-05-15T10:34:04Z"
+    mac: ENC[AES256_GCM,data:aQLWexHZOqRNS79sSSgQLwHRziLPwYSZK85FXGauoN07/Oi7f2Kkm9EC1bgvRthhcoZ83MorHly61ld6pgI/o6e7WO/SUKGytd9OFExd6jWCp7qPahVUXS/VEx4GHZkLARgGvk0ajMFp39C2+vtpK8aUT7iOkyuvfMlMz+asN/U=,iv:rZUPM/CLJXiSMpXW+ag9P8hMxf3v2e/zuYr7BvYZElo=,tag:rK9WlWTUYhXxaIx7HGN7yQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4


### PR DESCRIPTION
This PR adds fayad to the list of users who can decrypt builder secrets, and also fixes some issues with missing secret definitions on build4 and build2