### PR TITLE
Add prometheus pushgateway to accept metrics from testagents

### DIFF
--- a/hosts/monitoring/secrets.yaml
+++ b/hosts/monitoring/secrets.yaml
@@ -1,6 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:3syc79zImKOJ85pvTNTFN1HWC4cX2aguP8OtlbxiElZWVC6nanJ6boAhjaO/sdIh9tppmrUdBID6QJsLnFABwtEwUj2O0oGYUddtZxerXnyEeP4EncSubJQDtmJxdVWMT7lnu0nseZT54CozbhQ+7EdX6kEOGwLR2Hm0nbaGNnHQLZKaxN37gKycG2csLs1Z2pI03dutFk4E7z1bD0QMnp2V6fzl1Gig4F4eip47nuWC76YDcVDLn8lrOsn5Hsbdbf63OfGqfw4HzEZrXrtf2TWkUgsek6zGJGZeAOMvEZHOFrzj9ojYpKuBtTcG6Dw2XgKIdld96ujwhiHzm8sWjBSp0XQs2lU0W7LndNypOA5PwZwVrQguh1fVTJlcCLJPqSi0DlIbdjpUaZAdAWwxsHkB2Mj1z9sh3K9CA/Ia045VbVixXZUobxERIkvqkhCmoF5WubaMwZFLBE2pF2VaRwm9pHXg9bbDh9PPoACsTgyFYBtmOJKgPk5uik7uj3+KyxeNhp09Lc34XzrATx6z,iv:M9WhCLuUDyo4w44R1AQovxNRSYaAQWtlYQK2EHkRubY=,tag:GyceOfzblQnH6WPCXlsgQg==,type:str]
 sshified_private_key: ENC[AES256_GCM,data:Z2u1AruKYtHTjoXrYJNqwWQjnISGkm3+C2CMYcXF7s+h2Zw9uREqJaYUcxOUtSh4D3u5uiKrPyBObkEPQT+mHPG3W2m1kl5SezTowlW9Pno5ABK4FKtT//45oFt5UcN+eH1cnslkNlA0xRuvpCMVDGamfKt6NWmkKWH4aDJHas0KVGGbwVcttHW0LJtFvmu/jbt6W37X0yvg/XrkAEWFH1x5INox0ksI/EQhbKl3GxHGlHz2JoyuoviIPF6I+wMQ1AzQ50mqYEnnPYhaUa/phEVCH4S39/77vN/AlIT7JYchBalls5XnPJJq5zAJoiSEbLZw/Zyz2YO9R3vBEo8OzRkSz767flNhNndlIVHRCO4gux+vUb/26lGdFeDx5OsGTB4dPhP3GD9myvbD3cfBSixfkKNLuxrR6yRH3Tc4eizwxKP3nxAEPl1oEPDSf2pCbYGQ0UIyw1cABVn+kbpr5p+8tA+aj7o7R/GchZo5TnF22WfiXwiZgWZX6E15JHEEoCHoCtleb6h82MXesp7j,iv:6bUMuH0y+Jw7EN+dwnbYgXFzPtXCWLIM2uXW3ROkLEc=,tag:pRO8rtR3gNnkF5u9U1XxRg==,type:str]
-loki_basic_auth: ENC[AES256_GCM,data:STjTyfmYhUzwigMIoorvMbKeZa9/m6bT1fcKO3tWM8aHYt8+cW6zSE4OBV4=,iv:LMmvBPXzGu0I65GbfTNUHP18NqCUNiM29sQHgllugKk=,tag:ta5Acv9bxaiV0w2QZzJ6vQ==,type:str]
+metrics_basic_auth: ENC[AES256_GCM,data:hLTgkpnxv02YaXCUp61KmunsngvUojaVweU9piXvga6jmWCAXlK5iQxwKzc=,iv:yWNr+/4HVesIakYYOfZPF6ZsF+2EZxppQAYv7eIi8Xs=,tag:Tppkjq1SdQQS3FDUJbhUoA==,type:str]
 github_client_secret: ENC[AES256_GCM,data:VOj/3LS6aW999ZrWENEfoUQD7k1q72aQFk60ZeHOv9lCPcXEvuyojg==,iv:lClGyJUPNoRcghvAHFGxJmVhFgg33gk/K2KGwNlsyIs=,tag:xH+oiy92W4Tp89z+tq8XUw==,type:str]
 github_client_id: ENC[AES256_GCM,data:Zt4DOWQNH9A1T9weX4Rm4BfaNGw=,iv:eEaA8eZjU5xLdakGRiOgq+RgEeErPcuC0cif4X0iwYg=,tag:c0HAn1KT7c6Q0zOaLE5lGg==,type:str]
 sops:
@@ -36,8 +36,8 @@ sops:
             U2JpR0RvbWljZEJPSSs2VlBxWmJYc0EKnWS6LUeP+1DqIpBEv8TfDal0UTBKCnvB
             Ba/pLKtOAjZqiBif84llbLyjKqXBPwmLhsYp/IxSBaSp345neSVhKQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-02-07T12:23:10Z"
-    mac: ENC[AES256_GCM,data:MKzYWVfb80VB8ByB3Mlpocw9bZyqejR8oqAoyU1c6gHG0zKYOGRMUtRVZSSC2WyZ4E+I+xxiYKUJFnUo9bwg+L3skfncF6sajCmdRy2oedk77N5iC7dDlPQDFOXRcaHBblFpV7vjjX7NLaplRms2IVzQBkLiNtakxRDhnrmT8H8=,iv:bRvBkYuDd20RxKL5uqXg7BhBP5C5FXR205pGgyN6DIU=,tag:PUSIwaLhkHUihbT6oVhvCw==,type:str]
+    lastmodified: "2025-05-21T10:28:34Z"
+    mac: ENC[AES256_GCM,data:30NvTCAfnUejhymOMpTraYv/hblRlMWFYNb7RPo66fp2iV4cZQzaUWXz80iQeaWU4sGzfULJX2Hcedpg5lDVArVx3vk3xJdcVX0UJRiKqfPjKe1oMVf9DHd2CKehsy4UpeL7ClFBPmtmWm8DxUNFkXes55JZzzaBYRj7/8Ir3UA=,iv:LWKmG+j3lBGgU15/xmLBebMX2CFL/TweKX5rH/PZ38Y=,tag:CvZkwEHi8QK1tX3FpjZGTw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.2
+    version: 3.9.4

--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -17,7 +17,11 @@
       user-flokli
     ]);
 
-  sops.defaultSopsFile = ./secrets.yaml;
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets.metrics_password.owner = "root";
+  };
+
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-dev";
   services.testagent = {

--- a/hosts/testagent/dev/secrets.yaml
+++ b/hosts/testagent/dev/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:kexwr5dcadNAfx0Al5vZp2vyT3rtKiYbxS2FgvKJb+N6lBAR9oc2Puk9xzxGHvxjagjsPmgNGPFtBnqhRd0pMemhOXVqCEBHLVo/8xM0T/DQaTJ7aWX8cvhxiRihd9goKrjZPaIISf6HJ3o+tYV1gH2OjFgMk4/+mde2IbsOlIM/6WVTAt9SqPZIXKMIeGuHE30toiLuSQkBEcQDevGC5KBpub0+Dwoog2MymtOPpDWWV3bPi++h3GLGa375FYmzlpuKQUphKq/64/maDyMxNxfyaUQ++DmyorWUPZIJ5ZrnuG+31X2Nd2gnCCH4Gv17ms/Vw/zCB4wNmbg1QRQD5FBV6uFYCdhffaMznACAGp/PpritAuP9jkZNm0DfsSwiQzMJHPfi3oT77jIUUFI6E/HLOJXx5GwkAoLNtsOH8vMyNgRaVfDDkWguG3+4ungaY8aVYh1PIRME0Vfg5RIlKylUO3vg5lq7CubDX+oQ1eEymjhpKKMODyhrNSTVGRwH8mRKaU5fd+ZaMk95S75T,iv:mDBrCeAV+ID+tS2KtfEyASHNVPstdfDY+5QTP6PpPeU=,tag:0wc+C2+AfPaFiO9TJyAwzQ==,type:str]
+metrics_password: ENC[AES256_GCM,data:SkJMsEA2EZ4VFQ7gl3x2BReFjw==,iv:Ho6sATcwsJvusLsxZCjAL9Kwn2+cFqevoCJ9qCgIGv4=,tag:vpuC4M1BCvjXltpzTiNO+w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -41,8 +42,8 @@ sops:
             bWRGcDMxdm1WTkNRRVNlZU40V3hxMHcKJf75rQgbIySsP/Uqpin3gSlA67L+hI50
             mgKRtC8LbZX/u7G0S2jqYWYCe3UmJmY4P59E3CCb9IRq90oFrgMzwg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-08-30T07:50:15Z"
-    mac: ENC[AES256_GCM,data:0EX+NCSgd+tSkhxoLxe0oV46XH2bmWHc1GgcU52aU9Qvqjy6VzbH6eNRoJi1b9UeZJQQ49JKcvYSiokywiGSB5XKe7RD3nTdVMgOZI7hFoBu6FVV5ZyJ52em1wXeyLV/97KEBTc6DIMjmWRqrMSN69+Amgsgv8BpKhhERxReayw=,iv:SREkpT+Bjo1Z7AfX6KdgU8vExQcm8bAvIaBGqty32Y8=,tag:Bh86EWngLVGUP12zGOOZwg==,type:str]
+    lastmodified: "2025-05-21T09:35:21Z"
+    mac: ENC[AES256_GCM,data:ALOmFQ7muOfBsULWaNSO6hkhvWtBp5UFJD1OxjOPt/WtbOtZSnJ2NserzI5h3umM4FlCAkR9G+6TtG6aF0WEA1mRapGpdv3h60ELzPXsbFua9mM/HAWQoSZMLqlt7S/+uIHnSUmC8nzSSP+XmzXprMQQh5RR6PfhfZfd3LiXqmA=,iv:wEpd5DJTzeEry+dibzTiUqqgc2sigjuc5qJmUW+A52c=,tag:MWZ30xrTgbxf5p1d7zdMwA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.4

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -18,7 +18,11 @@
       user-flokli
     ]);
 
-  sops.defaultSopsFile = ./secrets.yaml;
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets.metrics_password.owner = "root";
+  };
+
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-prod";
   services.testagent = {

--- a/hosts/testagent/prod/secrets.yaml
+++ b/hosts/testagent/prod/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:ePgwl20W9jDz+xWAV/GqqvSe/4uQ+9VrZODhe9ClwRzE8b0UxOpkmxFBqUWn34CpQvZsIo7Zraf1amDit+jbxEYr3iVTAwz6boPqzf8JDNO+FQ1q43ql4Wz42CmsiYVFV6JsQ3eDPCZKqCOrhYWia4smJm+NwlGrpL8XQgbpRXXMsWa1iRf/KRaQ/u0dK16QI4CoJh3oWouXvNjIuLQ5lzRDsyRNWHHKZ/mfQoU7gsYWb/nHknudeikYymQ90JR5U++LuOdVpXArQfrEpgdkMeLHv5VYsnfNzwCtHXibXLXXTfxSPrBnwrtazOOviBTYMpCr5+KsrzmFnzlO4Gx5GeN3H5tDd4g5OcRPaAkV3hMRxCuA8bak6vNH0X+jNa8X0QyNsQe8GdPAtCRtkUB5CJqkNsFrVfv+3WhUXODaskHQyRL1FjRTvJyVBI0dw0l6/zlMCvNd8+GrNhgBn8Wd9nvCeWqauWYpTTMHJAs5ggbfb04UzN3FhM+PGfR0atA4B3yLbz6DvGAAGmLypvDB,iv:MKD4LDca+XNKxmstxBQg9UBLuk6TO/ZEa6tdBNNB+vY=,tag:xRFRLg48WTvvyGgfUzDGQg==,type:str]
+metrics_password: ENC[AES256_GCM,data:cB6s2ux7pXRrZ58BHJddh3aNCw==,iv:rgzFujTp9IOsW7ZVDemkSawq//4dYexSDcT2yv7h9OY=,tag:fZAcKM/UHv9wUNQ5kh4Y2g==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -50,8 +51,8 @@ sops:
             Zll1ZGM4RW1CQnk5clVxZzdYQ2tSajQK2N9hCSWgklRNPGOveGIu1rdRyD6fGsKl
             pr9OY8PSIGQYVjYMA7ApcGW9q7lxOny89IVfHLRpbnAZ78WNLAq4aw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-04-10T09:43:52Z"
-    mac: ENC[AES256_GCM,data:u8bkyGtC15Yf2x34tCnS/hR3uDI14AW/yXARSBkCZO7/G6mQXvacmKQ8itqdEENXyPi+UQXvYwo4Wyt2lQSivXAXOYyRtgWd+VUHuoBHJNX7/Ei3G0Ww4uAMuZgySf2n6yPK0mGgyIegu9VGMdw0kSh002xy2eVQWFp7xOxD4pk=,iv:k9Ms4eYUYxZG1GU3KUykTw0rpCtPMOFIyKs9cCpLRg4=,tag:2+/uWSYYpa+E+fS6LOqB7g==,type:str]
+    lastmodified: "2025-05-21T10:21:36Z"
+    mac: ENC[AES256_GCM,data:jf9UTu5y1t8YHevBuW62u+Lly2oxIW7faEj61/+eikpfaPwr3RsIa+jxjUXvtslcCnIkAU/ElD2FPpuWF+EG9oofe8RBxIClglAVIvem98bGSSgmPGm+bBc9MxSQssYpwgpDDyLHyQ24qabtzFsps/Rh/Z/I24AJq3FMcim4uT8=,iv:TW12GkjECnpmNELXvCk6+3qFjR2z+xvVSlPzHA5oVMQ=,tag:L1fIdo6w/wKLCQQlOp4eiQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.4

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -17,7 +17,11 @@
       user-flokli
     ]);
 
-  sops.defaultSopsFile = ./secrets.yaml;
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets.metrics_password.owner = "root";
+  };
+
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-release";
   services.testagent = {

--- a/hosts/testagent/release/secrets.yaml
+++ b/hosts/testagent/release/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:5zW9fEkB1ZwhyERntlVtULlyHlUbEEXW7QrBxmsxlSroaXKOkvlsCCjChEgYK6NprYSUit4zfizYvc5RtXjVi8UzEbhYc4dPOxWSCxB0rNN6+hRCPjaGtMZ1ceY7ZelhAEGFQTOMp1v49UiTE1SyVHfuwu99jTpgEL4yhPGJAknVbHJf8YbuSW+dLt9q5+H08hoPu93v0DQAVVnMXnZio5BdWiXPABO29sgKp1GGvYSi9DhJAMUMxSSKK8X84ezxQmvrextROBp0qNYI58AeDe6g3VVaAPy+J09/uayEhSqvsFrVfcvoXL4fJEOoaHaIpNPpbY7cfobefC9jGEBBTycX1CBJ6K12fEpT4TWY/FNtbAScx6+Yx9c7XtYJR8WBMhOszDpECJXp1IhfPtQlWyyp/T5SELxz/mq8Mh7zQVe4AMHzWuCToeVvyIaEFEgnBSFDQL40U0XdLwRu/dPt6YdD+QZntjKEdcbKK7u47uCBjgw266ANVW8J11wStUgwCHPYN7omrFhrUmTwfg+S,iv:WyvWWo2fVkL+PSmmy7cB13s1u/syev5Hcz/iSowiAO0=,tag:0GVBJfkhWvKChOpdN/dG0Q==,type:str]
+metrics_password: ENC[AES256_GCM,data:FQMV4VGb84e9y6JJ+6hHF9yxZQ==,iv:IYoW/jUwlLhfcYkihwmZaM5kU3ZI8i8oUR51Z0TNRbw=,tag:jjIMLEUd2fOq9YdDq0ZPhA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -41,8 +42,8 @@ sops:
             KzZEdEx6VENRb1pNb1hESERVVXdWYjgKdvypUF5W8LOtQLww23BlCbTqRWgm5JlK
             wPTRDjR6ErQkShnqY9jiA1SSKhidPG5DbveIaqI2KdX1rus/IKpIrw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-29T12:44:31Z"
-    mac: ENC[AES256_GCM,data:Kq1/Fx1CGKoEBifDEFj2oDIqYWzjc1FbbzAaGGpkR0LpxQkLFuwZzVEYKyz5l2BkVG8QDALMjJqmWuSTs+IT7kU4i+1CHxRw9db1VeQFw74inA4Uzfkz968jqnNhtFk5vNevaz2WbqAgUwZ9fG6T00fVUffENscAbIMF5h068WU=,iv:WH3a/NJPF1Udh+mgEhh4bl+3ZmzgbygRSE8Nxt2+PD8=,tag:RPSP/jBndnDOi6TB9NWJng==,type:str]
+    lastmodified: "2025-05-21T10:21:45Z"
+    mac: ENC[AES256_GCM,data:OZD2mItpDxCZPi8+Q4npyNaZGZcL5hM4D7rSvTV+nVAmTCRnkdAzOViTzaHp9pgluEzrAm66S62I49GCwddCjrIFo3j4kQxIIjzYzxmZrwjbIDDbcgsIdGNYfzt3w2NS69C6r6rlnBQNkgkISfE766YG547OF4YAd2ifiCfEW60=,iv:6Hs3XtQuXFAzioDtnKDsIYPytsoHwOxIL65Xj6nWk5M=,tag:wLsqYggm1tKuJVcKa6CV/A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.9.4


### PR DESCRIPTION
Adds pushgateway to monitoring server under `/push/` with basic auth. This can be used to push metrics from inaccessible servers (testagents).

The actual metrics are to be implemented later, this only adds the capabilities.