### PR TITLE
Fix GitHub security warnings

### DIFF
--- a/.github/workflows/actions-security-analysis.yml
+++ b/.github/workflows/actions-security-analysis.yml
@@ -25,9 +25,9 @@ jobs:
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb
 
       - name: Run zizmor
-        run: uvx zizmor --format=sarif . > results.sarif 
+        run: uvx zizmor --format=sarif . > results.sarif
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18

--- a/.github/workflows/authorize.yml
+++ b/.github/workflows/authorize.yml
@@ -34,17 +34,21 @@ jobs:
         # More details: https://docs.github.com/en/rest/orgs/members
         run: |
           is_org_member='False'
-          actor_enc=$(printf '%s' '${{ github.actor }}' | jq -sRr '@uri')
+          actor_enc=$(printf '%s' "${GITHUB_ACTOR}" | jq -sRr '@uri')
+          org_enc=$(printf '%s' "${GITHUB_ORG}" | jq -sRr '@uri')
           response=$(curl -L -o /dev/null -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.read-org-members }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/${{ inputs.github-org }}/members/$actor_enc")
+            "https://api.github.com/orgs/${org_enc}/members/${actor_enc}")
           if [ "$response" == "204" ]; then
             is_org_member='True'
           fi
           echo "is_org_member=$is_org_member"
           echo "is_org_member=$is_org_member" >>"$GITHUB_OUTPUT"
+        env:
+          GITHUB_ORG: ${{ inputs.github-org }}
+          GITHUB_ACTOR: ${{ github.actor }}
   authorize:
     outputs:
       result: ${{ steps.set-output.outputs.result }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -54,8 +54,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            ref: ${{ github.event.pull_request.head.sha || github.ref }}
-            fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: Install nix
         uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
       - name: Add builders to ssh_known_hosts

--- a/.github/workflows/warn-on-workflow-changes.yml
+++ b/.github/workflows/warn-on-workflow-changes.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check if workflow is modified
         id: workflow-changed
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5

--- a/.github/workflows/warn-on-workflow-changes.yml
+++ b/.github/workflows/warn-on-workflow-changes.yml
@@ -32,8 +32,9 @@ jobs:
             .github/workflows/authorize.yml
             .github/workflows/test-ghaf-infra.yml
       - name: Send warning
+        shell: bash
         run: |
-          if [ "${{ steps.workflow-changed.outputs.any_changed }}" == "true" ]; then
+          if [ "${ANY_WORKFLOWS_CHANGED}" == "true" ]; then
             echo "::error::"\
                  "This change edits a workflow file that triggers on 'pull_request_target'. "\
                  "Raising this error to notify that the workflow change will only take "\
@@ -44,3 +45,5 @@ jobs:
                  "will be misleading."
             exit 1
           fi
+        env:
+          ANY_WORKFLOWS_CHANGED: ${{ steps.workflow-changed.outputs.any_changed }}


### PR DESCRIPTION
Fixes a number of [code-scanning](https://github.com/tiiuae/ghaf-infra/security/code-scanning) warnings:
- ... may expand into attacker-controllable code"
- ... does not set persist-credentials: false"