### PR TITLE
Use disk/by-id/ instead of labels in disko configuration

### DIFF
--- a/hosts/builders/build1/configuration.nix
+++ b/hosts/builders/build1/configuration.nix
@@ -23,6 +23,13 @@
 
   # build1 specific configuration
 
+  disko.devices.disk = {
+    sda.device = "/dev/disk/by-id/ata-DELLBOSS_VD_74c47b68af530010";
+    sdb.device = "/dev/disk/by-id/scsi-362cea7f07374e7002785cfaa0d8881ae";
+    root.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801250";
+    home.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801255";
+  };
+
   sops = {
     defaultSopsFile = ./secrets.yaml;
     secrets.cachix-auth-token.owner = "root";

--- a/hosts/builders/build2/configuration.nix
+++ b/hosts/builders/build2/configuration.nix
@@ -22,6 +22,13 @@
 
   # build2 specific configuration
 
+  disko.devices.disk = {
+    sda.device = "/dev/disk/by-id/scsi-362cea7f0737489002786fe0bbde781c4";
+    sdb.device = "/dev/disk/by-id/ata-DELLBOSS_VD_9c8a18dee7d80010";
+    root.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801254";
+    home.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801252";
+  };
+
   sops.defaultSopsFile = ./secrets.yaml;
 
   networking.hostName = "build2";

--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -24,6 +24,13 @@
       user-remote-build # Remove when all jenkins builds moved to build4
     ]);
 
+  disko.devices.disk = {
+    sda.device = "/dev/disk/by-id/ata-DELLBOSS_VD_22781d60fbbe0010";
+    sdb.device = "/dev/disk/by-id/scsi-362cea7f07374850027870046da90a1b0";
+    root.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801247";
+    home.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801257";
+  };
+
   sops = {
     defaultSopsFile = ./secrets.yaml;
     secrets.ssh_private_key.owner = "root";

--- a/hosts/builders/build4/configuration.nix
+++ b/hosts/builders/build4/configuration.nix
@@ -22,6 +22,13 @@
 
   # build4 specific configuration
 
+  disko.devices.disk = {
+    sda.device = "/dev/disk/by-id/ata-DELLBOSS_VD_0c174cf02ac90010";
+    sdb.device = "/dev/disk/by-id/scsi-362cea7f07374e80027870010d6eab515";
+    root.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801253";
+    home.device = "/dev/disk/by-id/nvme-Dell_Ent_NVMe_AGN_MU_U.2_1.6TB_S61ENE0N801251";
+  };
+
   sops.defaultSopsFile = ./secrets.yaml;
 
   networking.hostName = "build4";

--- a/hosts/builders/ficolo-disk-config.nix
+++ b/hosts/builders/ficolo-disk-config.nix
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+{ lib, ... }:
 {
   disko.devices = {
     disk = {
       sda = {
-        device = "/dev/sda";
+        device = lib.mkDefault "/dev/sda";
         type = "disk";
         content = {
           type = "gpt";
@@ -34,7 +35,7 @@
         };
       };
       sdb = {
-        device = "/dev/sdb";
+        device = lib.mkDefault "/dev/sdb";
         type = "disk";
         content = {
           type = "gpt";
@@ -51,7 +52,7 @@
         };
       };
       root = {
-        device = "/dev/nvme0n1";
+        device = lib.mkDefault "/dev/nvme0n1";
         type = "disk";
         content = {
           type = "gpt";
@@ -68,7 +69,7 @@
         };
       };
       home = {
-        device = "/dev/nvme1n1";
+        device = lib.mkDefault "/dev/nvme1n1";
         type = "disk";
         content = {
           type = "gpt";

--- a/hosts/builders/hetzarm/disk-config.nix
+++ b/hosts/builders/hetzarm/disk-config.nix
@@ -3,7 +3,7 @@
 {
   disko.devices.disk = {
     nvme0 = {
-      device = "/dev/nvme0n1";
+      device = "/dev/disk/by-id/nvme-INTEL_SSDPF2KX038TZ_PHAC212302XD3P8AGN";
       type = "disk";
       content = {
         type = "gpt";
@@ -34,7 +34,7 @@
     };
 
     nvme1 = {
-      device = "/dev/nvme1n1";
+      device = "/dev/disk/by-id/nvme-INTEL_SSDPF2KX038TZ_PHAC21220A8J3P8AGN";
       type = "disk";
       content = {
         type = "gpt";

--- a/hosts/generic-disk-config.nix
+++ b/hosts/generic-disk-config.nix
@@ -4,6 +4,7 @@
 {
   disko.devices = {
     disk.disk1 = {
+      # replace this with disk/by-id
       device = lib.mkDefault "/dev/sda";
       type = "disk";
       content = {

--- a/hosts/ghaf-log/disk-config.nix
+++ b/hosts/ghaf-log/disk-config.nix
@@ -3,7 +3,7 @@
 {
   disko.devices.disk = {
     os = {
-      device = "/dev/disk/by-path/pci-0000:06:00.0-scsi-0:0:0:0";
+      device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_48387827";
       type = "disk";
       content = {
         type = "gpt";

--- a/hosts/monitoring/disk-config.nix
+++ b/hosts/monitoring/disk-config.nix
@@ -5,7 +5,8 @@
   disko.devices = {
     disk = {
       vda = {
-        device = "/dev/vda";
+        # there is no id for this virtual disk
+        device = "/dev/disk/by-path/pci-0000:03:00.0";
         type = "disk";
         content = {
           type = "gpt";

--- a/hosts/testagent/dev/disk-config.nix
+++ b/hosts/testagent/dev/disk-config.nix
@@ -4,7 +4,7 @@
   disko.devices = {
     disk = {
       vda = {
-        device = "/dev/nvme0n1";
+        device = "/dev/disk/by-id/nvme-PC801_NVMe_SK_hynix_1TB__SSB9N617311709K3P";
         type = "disk";
         content = {
           type = "gpt";

--- a/hosts/testagent/release/disk-config.nix
+++ b/hosts/testagent/release/disk-config.nix
@@ -4,7 +4,7 @@
   disko.devices = {
     disk = {
       vda = {
-        device = "/dev/nvme0n1";
+        device = "/dev/disk/by-id/nvme-PC801_NVMe_SK_hynix_1TB__SDB4N76791030544L";
         type = "disk";
         content = {
           type = "gpt";


### PR DESCRIPTION
Updated most disk configurations with the correct disk ids instead of using labels like /dev/sda which can change on reboot. Left out himalia and binarycache since they aren't online.