### PR TITLE
Add UDEV rules for SSD-drives

### DIFF
--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -51,22 +51,37 @@
     "sg"
   ];
 
-  # udev rules for test devices serial connections
+  # udev rules for test devices serial connections and SSD-drives
   services.udev.extraRules = ''
     # Orin nx
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD1BQQS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNS0W606359P", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
 
     # Orin AGX1
     SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{serial}=="TOPOC39C0EE1", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyAGX1", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W202677W", SYMLINK+="ssdORINAGX1", MODE="0666", GROUP="dialout"
 
     # Orin AGX64
     SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{serial}=="TOPOB63758F2", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyAGX64", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W201129V", SYMLINK+="ssdORINAGX64", MODE="0666", GROUP="dialout"
+
+    # Lenovo X1
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNS0W606188E", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
+
+    # Dell 7330
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W500904J", SYMLINK+="ssdDELL7330", MODE="0666", GROUP="dialout"
   '';
 
   # Trigger UDEV rules
   system.activationScripts.udevTrigger = ''
-    echo "==> Triggering udev rules for already plugged devices..."
+    echo "==> Triggering udev rules..."
     /run/current-system/sw/bin/udevadm trigger --subsystem-match=tty
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=block
   '';
 
   # Details of the hardware devices connected to this host
@@ -86,7 +101,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "0x2954223B";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W202677W-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX1";
           threads = 12;
         };
         OrinNX1 = {
@@ -98,7 +113,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "0xEE92E4FD";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0W606359P-0:0";
+          ext_drive_by-id = "/dev/ssdORINNX1";
           threads = 8;
         };
         OrinAGX64 = {
@@ -110,7 +125,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "0x029CEAF3";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W201129V-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX64";
           threads = 12;
         };
         LenovoX1-1 = {
@@ -121,7 +136,7 @@
           plug_type = "NONE";
           switch_bot = "LenovoX1-dev";
           usbhub_serial = "0x99EB9D84";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0W606188E-0:0";
+          ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
         };
         Dell7330 = {
@@ -132,7 +147,7 @@
           plug_type = "NONE";
           switch_bot = "Dell7330-dev";
           usbhub_serial = "5AC2B4AD";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W500904J-0:0";
+          ext_drive_by-id = "/dev/ssdDELL7330";
           threads = 8;
         };
       };

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -40,18 +40,33 @@
   services.udev.extraRules = ''
     # Orin nx
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNS0T918984B", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
 
     # Orin AGX1
     SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{serial}=="TOPO375FF8FA", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyAGX1", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6WXNS0W300153T", SYMLINK+="ssdORINAGX1", MODE="0666", GROUP="dialout"
 
     # Orin AGX64
     SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{serial}=="TOPO47B579E5", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyAGX64", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNJ0TB00828W", SYMLINK+="ssdORINAGX64", MODE="0666", GROUP="dialout"
+
+    # Lenovo X1
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S7MLNS0X532696T", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
+
+    # Dell 7330
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="50026B72836E78E0", SYMLINK+="ssdDELL7330", MODE="0666", GROUP="dialout"
   '';
 
   # Trigger UDEV rules
   system.activationScripts.udevTrigger = ''
-    echo "==> Triggering udev rules for already plugged devices..."
+    echo "==> Triggering udev rules..."
     /run/current-system/sw/bin/udevadm trigger --subsystem-match=tty
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=block
   '';
 
   # Details of the hardware devices connected to this host
@@ -71,7 +86,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "F0A0D6CF";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNJ0TB00828W-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX64";
           threads = 12;
         };
         OrinAGX1 = {
@@ -83,7 +98,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "92D8AEB7";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WXNS0W300153T-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX1";
           threads = 12;
         };
         LenovoX1-1 = {
@@ -94,7 +109,7 @@
           plug_type = "NONE";
           switch_bot = "LenovoX1-prod";
           usbhub_serial = "641B6D74";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S7MLNS0X532696T-0:0";
+          ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
         };
         OrinNX1 = {
@@ -106,7 +121,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "5220564F";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0T918984B-0:0";
+          ext_drive_by-id = "/dev/ssdORINNX1";
           threads = 8;
         };
         Dell7330 = {
@@ -117,7 +132,7 @@
           plug_type = "NONE";
           switch_bot = "Dell7330-prod";
           usbhub_serial = "FF62140D";
-          ext_drive_by-id = "usb-Kingston_XS2000_50026B72836E78E0-0:0";
+          ext_drive_by-id = "/dev/ssdDELL7330";
           threads = 8;
         };
         measurement_agent = {

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -29,7 +29,6 @@
     hardware = [
       "orin-agx"
       "orin-nx"
-      "nuc"
       "lenovo-x1"
     ];
   };
@@ -52,9 +51,25 @@
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''
+    # Orin nx
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTCY4MM2", SYMLINK+="ttyORINNX1"
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTCG3MMH", SYMLINK+="ttyNUC1"
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="04A629B8AB8750B711ECB2A4B2B056B", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6WXNS0W300212M", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
+
+    # Orin agx
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6WYNS0W402363J", SYMLINK+="ssdORINAGX1", MODE="0666", GROUP="dialout"
+
+    # Lenovo X1
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W500889K", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
+  '';
+
+  # Trigger UDEV rules
+  system.activationScripts.udevTrigger = ''
+    echo "==> Triggering udev rules..."
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=tty
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=block
   '';
 
   # Details of the hardware devices connected to this host
@@ -65,18 +80,6 @@
     builtins.toJSON {
       addresses = {
         relay_serial_port = "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A10KZMAN-if00-port0";
-        NUC1 = {
-          inherit location;
-          serial_port = "/dev/ttyNUC1";
-          relay_number = 1;
-          device_ip_address = "172.18.16.49";
-          socket_ip_address = "NONE";
-          plug_type = "NONE";
-          switch_bot = "NONE";
-          usbhub_serial = "6B780E17";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S5T4NJ0NB10775R-0:0";
-          threads = 8;
-        };
         OrinAGX1 = {
           inherit location;
           serial_port = "/dev/ttyACM0";
@@ -86,7 +89,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "EBBBCDD4";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WYNS0W402363J-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX1";
           threads = 12;
         };
         LenovoX1-1 = {
@@ -97,7 +100,7 @@
           plug_type = "NONE";
           switch_bot = "LenovoX1-release";
           usbhub_serial = "5F166079";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W500889K-0:0";
+          ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
         };
         OrinNX1 = {
@@ -109,7 +112,7 @@
           plug_type = "NONE";
           switch_bot = "NONE";
           usbhub_serial = "8CC6B0A9";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6WXNS0W300212M-0:0";
+          ext_drive_by-id = "/dev/ssdORINNX1";
           threads = 8;
         };
       };

--- a/hosts/testagent/uae-dev/configuration.nix
+++ b/hosts/testagent/uae-dev/configuration.nix
@@ -27,10 +27,7 @@
     variant = "dev";
     hardware = [
       "orin-agx"
-      "orin-nx"
-      "nuc"
       "lenovo-x1"
-      "dell-7330"
     ];
   };
 
@@ -46,9 +43,20 @@
   # udev rules for test devices serial connections
   # placeholder configs from finland. need updation with new uae targets, in progress
   services.udev.extraRules = ''
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0WF8Y", SYMLINK+="ttyNUC1", MODE="0666", GROUP="dialout"
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", ATTRS{serial}=="04A629B8AB87AB8111ECB2A38815028", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyRISCV1", MODE="0666", GROUP="dialout"
+    # Orin agx
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W202677W", SYMLINK+="ssdORINAGX1", MODE="0666", GROUP="dialout"
+
+    # Lenovo X1
+    # SSD-drive
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNS0W606188E", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
+  '';
+
+  # Trigger UDEV rules
+  system.activationScripts.udevTrigger = ''
+    echo "==> Triggering udev rules..."
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=tty
+    /run/current-system/sw/bin/udevadm trigger --subsystem-match=block
   '';
 
   # Details of the hardware devices connected to this host
@@ -67,7 +75,7 @@
           plug_type = "TAPOP100v2";
           switch_bot = "NONE";
           usbhub_serial = "0x2954223B";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XNNS0W202677W-0:0";
+          ext_drive_by-id = "/dev/ssdORINAGX1";
           threads = 8;
         };
         LenovoX1-1 = {
@@ -78,7 +86,7 @@
           plug_type = "NONE";
           switch_bot = "LenovoX1-uae-dev";
           usbhub_serial = "0x99EB9D84";
-          ext_drive_by-id = "usb-Samsung_PSSD_T7_S6XPNS0W606188E-0:0";
+          ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
         };
       };


### PR DESCRIPTION
Add UDEV rules for SSD-drives that are used
with test devices and add those links to device
configurations.