### PR TITLE
Make policy checker and the trust policy file available on testagents

### DIFF
--- a/hosts/testagent/agent.nix
+++ b/hosts/testagent/agent.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {
+  self,
   pkgs,
   inputs,
   lib,
@@ -28,6 +29,7 @@ let
         [
           brainstem
           inputs.robot-framework.packages.${pkgs.system}.ghaf-robot
+          self.packages.${pkgs.system}.policy-checker
         ]
         ++ (with pkgs; [
           curl

--- a/hosts/testagent/agents-common.nix
+++ b/hosts/testagent/agents-common.nix
@@ -148,4 +148,7 @@ in
       OnUnitActiveSec = "1min";
     };
   };
+
+  environment.etc."jenkins/provenance-trust-policy.json".source =
+    ../../slsa/provenance-trust-policy.json;
 }

--- a/pkgs/policy-checker/main.go
+++ b/pkgs/policy-checker/main.go
@@ -55,7 +55,10 @@ func VerifySignature(provenance_file string, provenance_signature string, policy
 
 func provenanceCheck(provenance_file string, config TrustPolicy) {
 	// Read and unmarshal the provenance file into a map
-	raw, _ := os.ReadFile(provenance_file)
+	raw, err := os.ReadFile(provenance_file)
+	if err != nil {
+		panic(err)
+	}
 	var input map[string]any
 	_ = json.Unmarshal(raw, &input)
 
@@ -144,7 +147,10 @@ func main() {
 			}
 
 			// read the trust policy file
-			raw, _ := os.ReadFile(config_file)
+			raw, err := os.ReadFile(config_file)
+			if err != nil {
+				panic(err)
+			}
 			var config TrustPolicy
 			_ = json.Unmarshal(raw, &config)
 

--- a/slsa/provenance-trust-policy.json
+++ b/slsa/provenance-trust-policy.json
@@ -16,7 +16,7 @@
       "id": "builder-id-azure",
       "description": "Builder ID is dev, prod or release",
       "cel": "predicate.runDetails.builder.id in [ 'https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/', 'https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/', 'https://ghaf-jenkins-controller-release.northeurope.cloudapp.azure.com/' ]",
-      "required": true
+      "required": false
     },
     {
       "id": "built-recently",


### PR DESCRIPTION
- Trust policy file is added to the testagents in `/etc/jenkins/provenance-trust-policy.json`.
- Policy checker is available for agent services.
- Made builder id not a strict requirement for now since it would fail in all priv environments (and make testing changes impossible). Maybe in the future we would need this policy to be more flexible.