### PR TITLE
Set Ficolo builder cores to 24, maxjobs to 16

### DIFF
--- a/hosts/builders/ficolo.nix
+++ b/hosts/builders/ficolo.nix
@@ -46,7 +46,7 @@
   };
 
   nix.settings = {
-    cores = 8;
-    max-jobs = 32;
+    cores = 24;
+    max-jobs = 16;
   };
 }


### PR DESCRIPTION
Ficolo x86 remote builders are working long time with only 8 cores resulting long build times. Trying to improve performance by setting cores to 24 and reducing maxjobs to 16. This combo could still reach peak load of 384.