### PR TITLE
Stop using build4 remote builder in azure/jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ ghaf-infra
 │   │   ├── builder
 │   │   └── jenkins-controller
 │   ├── builders # Stand-alone builder configurations
+│   │   ├── build1
+│   │   ├── build2
 │   │   ├── build3
 │   │   ├── build4
+│   │   ├── hetz86
 │   │   ├── hetzarm
 │   │   └── developers.nix # Users with access to build3 and hetzarm
 │   ├── ...
@@ -70,9 +73,12 @@ The configuration in this repository is split in two parts:
 - `terraform/` directory contains the terraform configuration describing the image-based CI setup in Azure infra. An example instance is the 'prod' instance, which provides the Jenkins interface at: <https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/> as well as the Ghaf nix binary cache at: <https://prod-cache.vedenemo.dev>. The host configuration files in `hosts/azure` describe the NixOS configuration for the `binary-cache`, `builder`, and `jenkins-controller` hosts as outlined in [README-azure.md](https://github.com/tiiuae/ghaf-infra/blob/main/terraform/README-azure.md#image-based-builds).
 - In addition to the terraform Azure infra, this repository contains NixOS configurations for various other stand-alone hosts in Ghaf CI/CD infra.
   Following are examples of some of the stand-alone configurations and their current usage in the CI/CD infrastructure:
-  - `hosts/builders/hetzarm` defines the configuration for shared aarch64 builder, which currently runs in Hetzner cloud (hetzarm.vedenemo.dev). Developers can use `hetzarm.vedenemo.dev` as a remote builder for Ghaf aarch builds. Additionally, `hetzarm` is used both from Ghaf github actions and non-release Jenkins builds as a remote builder.
-  - `hosts/builders/build3` defines the configuration for shared x86_64 builder, which currently runs in Ficolo cloud (builder.vedenemo.dev). Developers can use the `builder.vedenemo.dev` as a remote builder for Ghaf x86 builds.
-  - `hosts/builders/build4` defines the configuration for an x86_64 builder, which currently runs in Ficolo cloud (build4.vedenemo.dev). Build4 is currently used as a remote builder both from Ghaf github actions and non-release Jenkins builds.
+  - `hosts/builders/hetz86` x86_64 remote builder in Hetzner cloud (hetz86.vedenemo.dev). Currently, `hetz86` is used as a remote builder for non-release Jenkins builds.
+  - `hosts/builders/hetzarm` aarch64 remote builder in Hetzner cloud (hetzarm.vedenemo.dev). Developers can use `hetzarm.vedenemo.dev` as a remote builder for Ghaf aarch builds. Additionally, `hetzarm` is used both from Ghaf github actions and non-release Jenkins builds as a remote builder.
+  - `hosts/builders/build1` x86_64 remote builder in Ficolo cloud (build1.vedenemo.dev). Currently, `build1` is used as a remote builder for Ghaf github actions (to be retired).
+  - `hosts/builders/build2` x86_64 remote builder in Ficolo cloud (build2.vedenemo.dev). Currently, `build2` is not assigned to any specific task (to be retired).
+  - `hosts/builders/build3` x86_64 remote builder in Ficolo cloud (builder.vedenemo.dev). Developers can use the `builder.vedenemo.dev` as a remote builder for Ghaf x86 builds (to be retired).
+  - `hosts/builders/build4` x86_64 remote builder in Ficolo cloud (build4.vedenemo.dev). Currently, `build4` is not assigned to any specific task (to be retired).
   - `hosts/builders/testagents/*` define the configuration for testagents used from Azure ghaf-infra.
 
 Usage and deployment of the Azure infra is described in [`terraform/README.md`](https://github.com/tiiuae/ghaf-infra/blob/main/terraform/README.md).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,11 +79,10 @@ locals {
   ws = substr(replace(lower(terraform.workspace), "/[^a-z0-9]/", ""), 0, 16)
 
   ext_builder_machines = [
-    "ssh://remote-build@build4.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 32 3 kvm,nixos-test,benchmark,big-parallel - -",
     "ssh://remote-build@hetz86.vedenemo.dev x86_64-linux /etc/secrets/remote-build-ssh-key 48 3 kvm,nixos-test,benchmark,big-parallel - -",
     "ssh://remote-build@hetzarm.vedenemo.dev aarch64-linux /etc/secrets/remote-build-ssh-key 40 3 kvm,nixos-test,benchmark,big-parallel - -"
   ]
-  ext_builder_keyscan = ["build4.vedenemo.dev", "hetzarm.vedenemo.dev", "hetz86.vedenemo.dev"]
+  ext_builder_keyscan = ["hetzarm.vedenemo.dev", "hetz86.vedenemo.dev"]
 
   # We can not automatically assign alternative names per environment type
   # since we support having potentially many environments of the same type.


### PR DESCRIPTION
Stop using build4.vedenemo.dev remote builder in azure/jenkins infra.