### PR TITLE
azure-common: Increase download-buffer-size

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -14,6 +14,8 @@ in
     settings = {
       # Enable flakes and 'nix' command
       experimental-features = "nix-command flakes";
+      # https://github.com/NixOS/nix/issues/11728
+      download-buffer-size = 524288000;
       # When free disk space in /nix/store drops below min-free during build,
       # perform a garbage-collection until max-free bytes are available or there
       # is no more garbage.


### PR DESCRIPTION
Increase download-buffer-size on azure hosts to get rid of the warnings:

```
warning: download buffer is full; consider increasing the 'download-buffer-size' setting
```

Ref: https://github.com/NixOS/nix/issues/11728