### PR TITLE
hetzci-dev: Initial configuration

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -24,6 +24,7 @@ keys:
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
   - &hetz86 age1ydut4g6l23rkkmv55vsg7sg2a80cv6ur343px9e4sdlm7wtxjumqacgndl
   - &hetzci-prod age1av993eefvndhv2apa4x7tpc7ezyhuj3jz9866vtulnrdwmjqe5hqrjc2z8
+  - &hetzci-dev age10xhyyjrhackyac2f042t3z8yqld3sh39ul3mukwkt6gyr7gn9upq8n30gm
   - &ghaf-log age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
   - &ghaf-coverity age1z825k99myjmfcml86pujcmtj96psvj8c3m08me8kkq03tkpwy9xql4jt9y
   - &ghaf-webserver age1f643hcr8xvzm6fha93xhn6dw552tfd6zvu7eulxk7vedgt09d9ysljsayq
@@ -145,6 +146,12 @@ creation_rules:
     key_groups:
     - age:
       - *hetzci-prod
+      - *hrosten
+      - *jrautiola
+  - path_regex: hosts/hetzci-dev/secrets.yaml$
+    key_groups:
+    - age:
+      - *hetzci-dev
       - *hrosten
       - *jrautiola
   - path_regex: hosts/testagent/credentials.yaml$

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -61,6 +61,7 @@ in
     nixos-ghaf-webserver = ./ghaf-webserver/configuration.nix;
     nixos-ghaf-auth = ./ghaf-auth/configuration.nix;
     nixos-testagent-uae-dev = ./testagent/uae-dev/configuration.nix;
+    nixos-hetzci-dev = ./hetzci-dev/configuration.nix;
     nixos-hetzci-prod = ./hetzci-prod/configuration.nix;
     nixos-hetz86 = ./builders/hetz86/configuration.nix;
   };
@@ -99,6 +100,7 @@ in
         "ghaf-webserver"
         "ghaf-auth"
         "testagent-uae-dev"
+        "hetzci-dev"
         "hetzci-prod"
         "hetz86"
       ]

--- a/hosts/ghaf-auth/configuration.nix
+++ b/hosts/ghaf-auth/configuration.nix
@@ -136,6 +136,12 @@
             redirectURIs = [ "https://hetzci-prod.vedenemo.dev/oauth2/callback" ];
             secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
           }
+          {
+            id = "hetzci-dev";
+            name = "hetzci-dev";
+            redirectURIs = [ "https://hetzci-dev.vedenemo.dev/oauth2/callback" ];
+            secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
+          }
         ];
     };
   };

--- a/hosts/hetzci-dev/casc/jenkins-casc.yaml
+++ b/hosts/hetzci-dev/casc/jenkins-casc.yaml
@@ -1,0 +1,224 @@
+appearance:
+  pipelineGraphView:
+    showGraphOnBuildPage: true
+
+jenkins:
+  authorizationStrategy:
+    globalMatrix:
+      entries:
+        - user:
+            name: api_user
+            permissions:
+              - Job/Build
+              - Job/Cancel
+              - Job/Read
+        - group:
+            name: authenticated
+            permissions:
+              - Overall/Read
+              - Job/Read
+        - group:
+            name: 'tiiuae:devenv-fi'
+            permissions:
+              - Overall/Administer
+        - group:
+            name: testagents
+            permissions:
+              - Agent/Connect
+  markupFormatter:
+    rawHtml:
+      disableSyntaxHighlighting: false
+  nodes:
+    - permanent:
+        labelString: lenovo-x1
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: dev-lenovo-x1
+        remoteFS: /var/lib/jenkins/agents/lenovo-x1
+        retentionStrategy: always
+    - permanent:
+        labelString: lenovo-x1
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: prod-lenovo-x1
+        remoteFS: /var/lib/jenkins/agents/lenovo-x1
+        retentionStrategy: always
+    - permanent:
+        labelString: lenovo-x1
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: release-lenovo-x1
+        remoteFS: /var/lib/jenkins/agents/lenovo-x1
+        retentionStrategy: always
+    - permanent:
+        labelString: nuc
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: dev-nuc
+        remoteFS: /var/lib/jenkins/agents/nuc
+        retentionStrategy: always
+    - permanent:
+        labelString: nuc
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: prod-nuc
+        remoteFS: /var/lib/jenkins/agents/nuc
+        retentionStrategy: always
+    - permanent:
+        labelString: nuc
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: release-nuc
+        remoteFS: /var/lib/jenkins/agents/nuc
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-agx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: dev-orin-agx
+        remoteFS: /var/lib/jenkins/agents/orin-agx
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-agx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: prod-orin-agx
+        remoteFS: /var/lib/jenkins/agents/orin-agx
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-agx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: release-orin-agx
+        remoteFS: /var/lib/jenkins/agents/orin-agx
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-nx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: dev-orin-nx
+        remoteFS: /var/lib/jenkins/agents/orin-nx
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-nx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: prod-orin-nx
+        remoteFS: /var/lib/jenkins/agents/orin-nx
+        retentionStrategy: always
+    - permanent:
+        labelString: orin-nx
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: release-orin-nx
+        remoteFS: /var/lib/jenkins/agents/orin-nx
+        retentionStrategy: always
+    - permanent:
+        labelString: dell-7330
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: dev-dell-7330
+        remoteFS: /var/lib/jenkins/agents/dell-7330
+        retentionStrategy: always
+    - permanent:
+        labelString: dell-7330
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: prod-dell-7330
+        remoteFS: /var/lib/jenkins/agents/dell-7330
+        retentionStrategy: always
+    - permanent:
+        labelString: dell-7330
+        launcher: inbound
+        mode: EXCLUSIVE
+        name: release-dell-7330
+        remoteFS: /var/lib/jenkins/agents/dell-7330
+        retentionStrategy: always
+  numExecutors: 4
+  securityRealm:
+    reverseProxy:
+      customLogOutUrl: /oauth2/sign_out
+      disableLdapEmailResolver: true
+      forwardedDisplayName: X-Forwarded-DisplayName
+      forwardedEmail: X-Forwarded-Mail
+      forwardedUser: X-Forwarded-User
+      headerGroups: X-Forwarded-Groups
+      headerGroupsDelimiter: ','
+      inhibitInferRootDN: false
+  log:
+    recorders:
+    - loggers:
+      - name: "org.jenkinsci.plugins.github"
+        level: "ALL"
+      name: "Debug"
+
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - string:
+              scope: GLOBAL
+              id: "jenkins-github-webhook-secret"
+              secret: "${file:/run/secrets/jenkins_github_webhook_secret}"
+              description: "Github webhook secret"
+          - string:
+              scope: GLOBAL
+              id: "jenkins-github-commit-status-token"
+              secret: "${file:/run/secrets/jenkins_github_commit_status_token}"
+              description: "Github token used to set the commit statuses"
+
+unclassified:
+  location:
+    url: "https://hetzci-dev.vedenemo.dev"
+  timestamper:
+    allPipelines: true
+  gitHubPluginConfig:
+    configs:
+    - credentialsId: "jenkins-github-commit-status-token"
+    hookSecretConfigs:
+    - credentialsId: "jenkins-github-webhook-secret"
+  lockableResourcesManager:
+    declaredResources:
+    - name: "evaluator"
+      description: "Nix evaluator lock"
+
+# https://plugins.jenkins.io/configuration-as-code-groovy/
+groovy:
+  # Setup jenkins api token:
+  - script: |
+      import jenkins.model.*
+      import hudson.model.*
+      import jenkins.security.ApiTokenProperty
+      def token = new File("/run/secrets/jenkins_api_token");
+      if (token.exists()) {
+        println("Setting up api token")
+        def user = User.get('api_user')
+        user.getProperty(ApiTokenProperty.class).tokenStore.addFixedNewToken("t1", token.text)
+        user.save()
+      }
+  # Load pipelines:
+  - script: |
+      import jenkins.model.*
+      import hudson.model.*
+      import org.jenkinsci.plugins.workflow.job.WorkflowJob
+      import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+      import groovy.io.FileType
+      println("Loading pipelines")
+      def pipelines = new File("/etc/jenkins/pipelines/")
+      pipelines.eachFile(FileType.FILES) { file ->
+        println("Loading pipeline from: " + file.name)
+        def pipeline_name = file.name.substring(0, file.name.lastIndexOf('.'))
+        def job = new WorkflowJob(Jenkins.getInstance(), pipeline_name)
+        job.definition = new CpsFlowDefinition(file.text, true)
+        job.save()
+      }
+      Jenkins.getInstance().reload()
+  # Trigger all pipelines on jenkins service (re)start:
+  - script: |
+      import jenkins.model.*
+      import hudson.model.*
+      def params = new ParametersAction([ new StringParameterValue("RELOAD_ONLY", "true")])
+      for (job in Jenkins.getInstance().getAllItems(Job)) {
+        println("Triggering job: " + job.getName())
+        job.scheduleBuild2(0, params);
+      }

--- a/hosts/hetzci-dev/casc/pipelines/ghaf-demo-manual.groovy
+++ b/hosts/hetzci-dev/casc/pipelines/ghaf-demo-manual.groovy
@@ -1,0 +1,84 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
+  parameters([
+    string(name: 'GITREF', defaultValue: 'main', description: 'Git reference (Commit/Branch/Tag)')
+  ])
+])
+pipeline {
+  agent { label 'built-in' }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            branches: [[name: params.GITREF]],
+            extensions: [[$class: 'WipeWorkspace']],
+            userRemoteConfigs: [[url: REPO_URL]]
+          )
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+}

--- a/hosts/hetzci-dev/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci-dev/casc/pipelines/ghaf-hw-test.groovy
@@ -1,0 +1,312 @@
+#!/usr/bin/env groovy
+
+// SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+////////////////////////////////////////////////////////////////////////////////
+
+def TMP_IMG_DIR = './image'
+def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
+
+////////////////////////////////////////////////////////////////////////////////
+
+properties([
+  parameters([
+    string(name: 'CI_TEST_REPO_URL', defaultValue: 'https://github.com/tiiuae/ci-test-automation.git', description: 'Select ci-test-automation repository.'),
+    string(name: 'CI_TEST_REPO_BRANCH', defaultValue: 'main', description: 'Select ci-test-automation branch to checkout.'),
+    string(name: 'IMG_URL', defaultValue: '', description: 'Target image url.'),
+    string(name: 'TESTSET', defaultValue: '_relayboot_', description: 'Target testset, e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.)')
+  ])
+])
+
+////////////////////////////////////////////////////////////////////////////////
+
+def init() {
+  if(!params || params.RELOAD_ONLY) {
+    return 'built-in'
+  }
+  if(params.IMG_URL.isEmpty() ) {
+    error("Missing IMG_URL parameter")
+  }
+  // Parse out the TARGET from the IMG_URL
+  def match = params.IMG_URL =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
+  if(match) {
+    env.TARGET = "${match.group(1)}"
+    match = null // https://stackoverflow.com/questions/40454558
+    println("Using TARGET: ${env.TARGET}")
+  } else {
+    error("Unexpected IMG_URL: ${params.IMG_URL}")
+  }
+  // Determine the device name
+  if(params.IMG_URL.contains("orin-agx-")) {
+    env.DEVICE_NAME = 'OrinAGX1'
+    env.DEVICE_TAG = 'orin-agx'
+  } else if(params.IMG_URL.contains("orin-agx64-")) {
+    env.DEVICE_NAME = 'OrinAGX64'
+    env.DEVICE_TAG = 'orin-agx-64'
+  } else if(params.IMG_URL.contains("orin-nx-")) {
+    env.DEVICE_NAME = 'OrinNX1'
+    env.DEVICE_TAG = 'orin-nx'
+  } else if(params.IMG_URL.contains("lenovo-x1-")) {
+    env.DEVICE_NAME = 'LenovoX1-1'
+    env.DEVICE_TAG = 'lenovo-x1'
+  } else if(params.IMG_URL.contains("generic-x86_64-")) {
+    env.DEVICE_NAME = 'NUC1'
+    env.DEVICE_TAG = 'nuc'
+  } else if(params.IMG_URL.contains("microchip-icicle-")) {
+    env.DEVICE_NAME = 'Polarfire1'
+    env.DEVICE_TAG = 'riscv'
+  } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
+    env.DEVICE_NAME = 'Dell7330'
+    env.DEVICE_TAG = 'dell-7330'
+  } else {
+    error("Unable to parse device config for image '${params.IMG_URL}'")
+  }
+  println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
+  println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
+  if(params.containsKey('DESC')) {
+    currentBuild.description = "${params.DESC}"
+  } else {
+    currentBuild.description = "${env.TARGET}"
+  }
+  def testagent_nodes = nodesByLabel(label: env.DEVICE_TAG, offline: false)
+  if (!testagent_nodes) {
+    error("No test agents online")
+  }
+  return env.DEVICE_TAG
+}
+
+def sh_ret_out(String cmd) {
+  // Run cmd returning stdout
+  return sh(script: cmd, returnStdout:true).trim()
+}
+
+def run_wget(String url, String to_dir) {
+  // Downlaod `url` setting the directory prefix `to_dir` preserving
+  // the hierarchy of directories locally.
+  sh "wget --show-progress --progress=dot:giga --force-directories --timestamping -P ${to_dir} ${url}"
+  // Re-run wget: this will not re-download anything, it's needed only to
+  // get the local path to the downloaded file
+  return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
+}
+
+def get_test_conf_property(String file_path, String device, String property) {
+  // Get the requested device property data from test_config.json file
+  def device_data = readJSON file: file_path
+  def property_data = "${device_data['addresses'][device][property]}"
+  println "Got device '${device}' property '${property}' value: '${property_data}'"
+  return property_data
+}
+
+def ghaf_robot_test(String testname='relayboot') {
+  if (!env.DEVICE_TAG) {
+    error("DEVICE_TAG not set")
+  }
+  if (!env.DEVICE_NAME) {
+    error("DEVICE_NAME not set")
+  }
+  if (testname.contains('turnoff')) {
+    env.INCLUDE_TEST_TAGS = "${testname}"
+  } else {
+    env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
+  }
+  dir("Robot-Framework/test-suites") {
+    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    // On failure, continue the pipeline execution
+    env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
+    try {
+      // Pass variables as environment variables to shell.
+      // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
+      sh '''
+        nix run .#ghaf-robot -- \
+          -v DEVICE:$DEVICE_NAME \
+          -v DEVICE_TYPE:$DEVICE_TAG \
+          -v BUILD_ID:${BUILD_NUMBER} \
+          -v COMMIT_HASH:$COMMIT_HASH \
+          -i $INCLUDE_TEST_TAGS .
+      '''
+      if (testname.contains('boot')) {
+        // Set an environment variable to indicate boot test passed
+        env.BOOT_PASSED = 'true'
+      }
+    } catch (Exception e) {
+      currentBuild.result = "FAILURE"
+      unstable("FAILED '${testname}': ${e.toString()}")
+    } finally {
+      // Move the test output (if any) to a subdirectory
+      sh """
+        rm -fr $testname; mkdir -p $testname
+        mv -f *.txt *.png output.xml report.html log.html $testname/ || true
+      """
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pipeline {
+  agent { label init() }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '100'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reload pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        checkout scmGit(
+          branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
+          extensions: [[$class: 'WipeWorkspace']],
+          userRemoteConfigs: [[url: CI_TEST_REPO_URL]]
+        )
+      }
+    }
+    stage('Setup') {
+      steps {
+        script {
+          env.TEST_CONFIG_DIR = 'Robot-Framework/config'
+          sh """
+            mkdir -p ${TEST_CONFIG_DIR}
+            rm -f ${TEST_CONFIG_DIR}/*.json
+            ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
+            echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+            ls -la ${TEST_CONFIG_DIR}
+          """
+        }
+      }
+    }
+    stage('Image download') {
+      steps {
+        script {
+          img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
+          println "Downloaded image to workspace: ${img_path}"
+          // Uncompress
+          if(img_path.endsWith(".zst")) {
+            sh "zstd -dfv ${img_path}"
+            // env.IMG_PATH stores the path to the uncompressed image
+            env.IMG_PATH = img_path.substring(0, img_path.lastIndexOf('.'))
+          } else {
+            env.IMG_PATH = img_path
+          }
+          println "Uncompressed image at: ${env.IMG_PATH}"
+        }
+      }
+    }
+    stage('Flash') {
+      steps {
+        // TODO: We should use ghaf flashing scripts or installers.
+        // We don't want to maintain these flashing details here:
+        script {
+          // Determine mount commands
+          def mount_cmd, unmount_cmd
+          if(params.IMG_URL.contains("microchip-icicle-")) {
+            def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
+            mount_cmd = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
+            unmount_cmd = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
+          } else {
+            def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
+            mount_cmd = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
+            unmount_cmd = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}"
+          }
+          // Mount the target disk
+          sh "${mount_cmd}"
+          // Read the device name
+          def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
+          println "Using device '$dev'"
+          // Wipe possible ZFS leftovers, more details here:
+          // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
+          if(params.IMG_URL.contains("lenovo-x1-")) {
+            echo "Wiping filesystem..."
+            def SECTOR = 512
+            def MIB_TO_SECTORS = 20480
+            // Disk size in 512-byte sectors
+            def SECTORS = sh(script: "/run/wrappers/bin/sudo blockdev --getsz /dev/disk/by-id/${dev}", returnStdout: true).trim()
+            // Unmount possible mounted filesystems
+            sh "sync; /run/wrappers/bin/sudo umount -q /dev/disk/by-id/${dev}* || true"
+            // Wipe first 10MiB of disk
+            sh "/run/wrappers/bin/sudo dd if=/dev/zero of=/dev/disk/by-id/${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} conv=fsync status=none"
+            // Wipe last 10MiB of disk
+            sh "/run/wrappers/bin/sudo dd if=/dev/zero of=/dev/disk/by-id/${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} seek=\$(( ${SECTORS} - ${MIB_TO_SECTORS} )) conv=fsync status=none"
+          }
+          // Write the image
+          sh "/run/wrappers/bin/sudo dd if=${env.IMG_PATH} of=/dev/disk/by-id/${dev} bs=1M status=progress conv=fsync"
+          // Unmount
+          sh "${unmount_cmd}"
+        }
+      }
+    }
+    stage('Relay Boot test') {
+      when { expression { env.TESTSET.contains('_relayboot_')} }
+      steps {
+        script {
+          env.BOOT_PASSED = 'false'
+          ghaf_robot_test('relayboot')
+          println "Relay boot test passed: ${env.BOOT_PASSED}"
+        }
+      }
+    }
+    stage('Pre-merge test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_pre-merge_')} }
+      steps {
+        script {
+          ghaf_robot_test('pre-merge')
+        }
+      }
+    }
+    stage('Bat test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_bat_')} }
+      steps {
+        script {
+          ghaf_robot_test('bat')
+        }
+      }
+    }
+    stage('GUI test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_gui_')} }
+      steps {
+        script {
+          ghaf_robot_test('gui')
+        }
+      }
+    }
+    stage('Perf test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_perf_')} }
+      steps {
+        script {
+          ghaf_robot_test('performance')
+        }
+      }
+    }
+    stage('Relay Turn off') {
+      steps {
+        script {
+          ghaf_robot_test('relay-turnoff')
+        }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        if (env.BOOT_PASSED != null) {
+          def test_artifacts = '' +
+            'Robot-Framework/test-suites/**/*.html, ' +
+            'Robot-Framework/test-suites/**/*.xml, ' +
+            'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.txt'
+          archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
+        }
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/hosts/hetzci-dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci-dev/casc/pipelines/modules/utils.groovy
@@ -1,0 +1,69 @@
+#!/usr/bin/env groovy
+
+def run_cmd(String cmd) {
+  return sh(script: cmd, returnStdout:true).trim()
+}
+
+def create_pipeline(List<Map> targets) {
+  def pipeline = [:]
+  def stamp = run_cmd('date +"%Y%m%d_%H%M%S"')
+  def commit = run_cmd('git rev-parse HEAD')
+  def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${commit}"
+  def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
+  def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
+  currentBuild.description = "${artifacts_href}"
+  sh "mkdir -p ${artifacts_local_dir}"
+  // Evaluate
+  stage("Eval") {
+    lock('evaluator') {
+      sh 'nix flake show --all-systems | ansi2txt'
+    }
+  }
+  targets.each {
+    def shortname = it.target.substring(it.target.lastIndexOf('.') + 1)
+    pipeline["${it.target}"] = {
+      // Build
+      stage("Build ${shortname}") {
+        sh "nix build -v .#${it.target} --out-link ${it.target}"
+      }
+      // Archive
+      stage("Archive ${shortname}") {
+        sh "cp -P ${it.target} ${artifacts_local_dir}/"
+      }
+      // Test
+      if (it.testset != null) {
+        stage("Test ${shortname}") {
+          def img_path = run_cmd("find -L ${it.target} -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit")
+          if (!img_path) {
+            error("No image found for target '${it.target}'")
+          }
+          def img_url = "${env.JENKINS_URL}/${artifacts}/${img_path}"
+          def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
+          def desc = "Triggered by ${build_href}<br>(${it.target})"
+          def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
+            parameters: [
+              string(name: "IMG_URL", value: img_url),
+              string(name: "TESTSET", value: it.testset),
+              string(name: "DESC", value: desc),
+              booleanParam(name: "RELOAD_ONLY", value: false),
+            ],
+          )
+          if (job.result != "SUCCESS") {
+            unstable("FAILED: ${it.target} ${it.testset}")
+            currentBuild.result = "FAILURE"
+            def test_href = "<a href=\"${job.absoluteUrl}\">⛔ ${shortname}</a>"
+            currentBuild.description = "${currentBuild.description}<br>${test_href}"
+          }
+          copyArtifacts(
+            projectName: "ghaf-hw-test",
+            selector: specific("${job.number}"),
+            target: "${artifacts_local_dir}/test-results/${it.target}",
+          )
+        }
+      }
+    }
+  }
+  return pipeline
+}
+
+return this

--- a/hosts/hetzci-dev/configuration.nix
+++ b/hosts/hetzci-dev/configuration.nix
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  pkgs,
+  inputs,
+  modulesPath,
+  lib,
+  config,
+  ...
+}:
+let
+  jenkins-casc = ./casc;
+in
+{
+  imports =
+    [
+      ./disk-config.nix
+      (modulesPath + "/profiles/qemu-guest.nix")
+      inputs.disko.nixosModules.disko
+      inputs.sops-nix.nixosModules.sops
+    ]
+    ++ (with self.nixosModules; [
+      common
+      service-openssh
+      team-devenv
+    ]);
+
+  # this server has been installed with 24.11
+  system.stateVersion = lib.mkForce "24.11";
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  hardware.enableRedistributableFirmware = true;
+
+  networking = {
+    hostName = "hetzci-dev";
+    useDHCP = true;
+  };
+
+  boot = {
+    # use predictable network interface names (eth0)
+    kernelParams = [ "net.ifnames=0" ];
+    loader.grub = {
+      efiSupport = true;
+      efiInstallAsRemovable = true;
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    screen
+    tmux
+  ];
+
+  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 100;
+  };
+  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 180;
+    "vm.watermark_boost_factor" = 0;
+    "vm.watermark_scale_factor" = 125;
+    "vm.page-cluster" = 0;
+  };
+
+  # Increase the maximum number of open files user limit, see ulimit -n
+  security.pam.loginLimits = [
+    {
+      domain = "*";
+      item = "nofile";
+      type = "-";
+      value = "8192";
+    }
+  ];
+  systemd.user.extraConfig = "DefaultLimitNOFILE=8192";
+
+  # Enable early out-of-memory killing.
+  # Make nix builds more likely to be killed over more important services.
+  services.earlyoom = {
+    enable = true;
+    # earlyoom sends SIGTERM once below 5% and SIGKILL when below half
+    # of freeMemThreshold
+    freeMemThreshold = 5;
+    extraArgs = [
+      "--prefer"
+      "^(nix-daemon)$"
+      "--avoid"
+      "^(java|jenkins-.*|sshd|systemd|systemd-.*)$"
+    ];
+  };
+  # Tell the Nix evaluator to garbage collect more aggressively
+  environment.variables.GC_INITIAL_HEAP_SIZE = "1M";
+  # Always overcommit: pretend there is always enough memory
+  # until it actually runs out
+  boot.kernel.sysctl."vm.overcommit_memory" = "1";
+
+  users.users = {
+    testagent-release = {
+      isNormalUser = true;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H"
+      ];
+    };
+  };
+
+  systemd.services.populate-builder-machines = {
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+    };
+    script = ''
+      mkdir -p /etc/nix
+      echo "ssh://build2.vedenemo.dev x86_64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >/etc/nix/machines
+      echo "ssh://hetzarm.vedenemo.dev aarch64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >>/etc/nix/machines
+    '';
+  };
+
+  nix.extraOptions = ''
+    connect-timeout = 5
+    system-features = nixos-test benchmark big-parallel kvm
+    builders = @/etc/nix/machines
+    max-jobs = 0
+    trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+    substituters = https://ghaf-dev.cachix.org https://cache.nixos.org
+    builders-use-substitutes = true
+  '';
+
+  programs.ssh = {
+    # Known builder host public keys, these go to /root/.ssh/known_hosts
+    knownHosts."build1.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrcs+NiYzO14n5FystgcN5WJSLeBc+BR67vGs2cwY7d";
+    knownHosts."build2.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILL40b7SbAcL1MK3D5U9IgVRR87myFLTzVdryQnVqb7p";
+    knownHosts."hetzarm.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+
+    # Custom options to /etc/ssh/ssh_config
+    extraConfig = lib.mkAfter ''
+      Host build1.vedenemo.dev
+      Hostname build1.vedenemo.dev
+      User remote-build
+      IdentityFile /run/secrets/vedenemo_builder_ssh_key
+
+      Host build2.vedenemo.dev
+      Hostname build2.vedenemo.dev
+      User remote-build
+      IdentityFile /run/secrets/vedenemo_builder_ssh_key
+
+      Host hetzarm.vedenemo.dev
+      Hostname hetzarm.vedenemo.dev
+      User remote-build
+      IdentityFile /run/secrets/vedenemo_builder_ssh_key
+    '';
+  };
+
+  services.jenkins = {
+    enable = true;
+    listenAddress = "localhost";
+    port = 8081;
+    withCLI = true;
+    packages = with pkgs; [
+      bashInteractive # 'sh' step in jenkins pipeline requires this
+      coreutils
+      colorized-logs
+      csvkit
+      curl
+      git
+      jq
+      nix
+      openssh
+      wget
+      zstd
+    ];
+    extraJavaOptions = [
+      # Useful when the 'sh' step fails:
+      "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"
+      # Point to configuration-as-code config
+      "-Dcasc.jenkins.config=${jenkins-casc}"
+      # Disable the intitial setup wizard, and the creation of initialAdminPassword.
+      "-Djenkins.install.runSetupWizard=false"
+      # Allow setting the following possibly undefined parameters
+      "-Dhudson.model.ParametersAction.safeParameters=DESC,RELOAD_ONLY"
+    ];
+    plugins =
+      let
+        manifest = builtins.fromJSON (builtins.readFile ./plugins.json);
+
+        mkJenkinsPlugin =
+          {
+            name,
+            version,
+            url,
+            sha256,
+          }:
+          lib.nameValuePair name (
+            pkgs.stdenv.mkDerivation {
+              inherit name version;
+              src = pkgs.fetchurl {
+                inherit url sha256;
+              };
+              phases = "installPhase";
+              installPhase = "cp \$src \$out";
+            }
+          );
+      in
+      builtins.listToAttrs (map mkJenkinsPlugin manifest);
+  };
+
+  systemd.services.jenkins = {
+    serviceConfig = {
+      Restart = "on-failure";
+    };
+  };
+  environment.etc."jenkins/pipelines".source = ./casc/pipelines;
+  environment.etc."jenkins/nix-fast-build.sh".source = "${self.outPath}/scripts/nix-fast-build.sh";
+
+  services.caddy = {
+    enable = true;
+    enableReload = false;
+    configFile = pkgs.writeText "Caddyfile" ''
+      # Disable the admin API, we don't want to reconfigure Caddy at runtime.
+      {
+        admin off
+      }
+
+      https://hetzci-dev.vedenemo.dev {
+
+        # Introduce /trigger/* api mapping requests directly to jenkins /job/*
+        # letting jenkins handle the authentication for /trigger/* paths.
+        # This makes it possible to authenticate with jenkins api token for
+        # requests on /trigger/* endpoints.
+        handle_path /trigger/* {
+          rewrite * /job{uri}
+          reverse_proxy localhost:8081
+        }
+        handle /login {
+          redir * /
+        }
+
+        # Route /artifacts requests to caddy file_server
+        handle_path /artifacts* {
+          root * /var/lib/jenkins/artifacts
+          file_server {
+            browse
+          }
+        }
+
+        @unauthenticated {
+          # github sends webhook triggers here
+          path /github-webhook /github-webhook/*
+
+          # testagents need these
+          path /jnlpJars /jnlpJars/*
+          path /wsagents /wsagents/*
+        }
+
+        handle @unauthenticated {
+          reverse_proxy localhost:8081
+        }
+
+        # Proxy all other requests to jenkins as-is, but delegate auth to
+        # oauth2-proxy.
+        # Also see https://oauth2-proxy.github.io/oauth2-proxy/configuration/integration#configuring-for-use-with-the-caddy-v2-forward_auth-directive
+
+        handle /oauth2/* {
+          reverse_proxy localhost:4180 {
+            # oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+            # The reverse_proxy directive automatically sets X-Forwarded-{For,Proto,Host} headers.
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-Uri {uri}
+          }
+        }
+
+        handle {
+          forward_auth localhost:4180 {
+            uri /oauth2/auth
+
+            # oauth2-proxy requires the X-Real-IP and X-Forwarded-{Proto,Host,Uri} headers.
+            # The forward_auth directive automatically sets the X-Forwarded-{For,Proto,Host,Method,Uri} headers.
+            header_up X-Real-IP {remote_host}
+
+            copy_headers {
+              X-Auth-Request-User>X-Forwarded-User
+              X-Auth-Request-Groups>X-Forwarded-Groups
+              X-Auth-Request-Email>X-Forwarded-Mail
+              X-Auth-Request-Preferred-Username>X-Forwarded-DisplayName
+            }
+
+            # If oauth2-proxy returns a 401 status, redirect the client to the sign-in page.
+            @error status 401
+            handle_response @error {
+              redir * /oauth2/sign_in?rd={scheme}://{host}{uri}
+            }
+          }
+          reverse_proxy localhost:8081
+        }
+      }
+    '';
+  };
+
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets = {
+      vedenemo_builder_ssh_key.owner = "root";
+      oauth2_proxy_client_secret.owner = "oauth2-proxy";
+      oauth2_proxy_cookie_secret.owner = "oauth2-proxy";
+      jenkins_api_token.owner = "jenkins";
+      jenkins_github_webhook_secret.owner = "jenkins";
+      jenkins_github_commit_status_token.owner = "jenkins";
+    };
+    templates.oauth2_proxy_env = {
+      content = ''
+        OAUTH2_PROXY_COOKIE_SECRET=${config.sops.placeholder.oauth2_proxy_cookie_secret}
+      '';
+      owner = "oauth2-proxy";
+    };
+  };
+
+  services.oauth2-proxy = {
+    enable = true;
+    clientID = "hetzci-dev";
+    clientSecret = null;
+    cookie.secret = null;
+    provider = "oidc";
+    oidcIssuerUrl = "https://auth.vedenemo.dev";
+    setXauthrequest = true;
+    cookie.secure = false;
+    extraConfig = {
+      email-domain = "*";
+      auth-logging = true;
+      request-logging = true;
+      standard-logging = true;
+      reverse-proxy = true;
+      scope = "openid profile email groups";
+      provider-display-name = "Vedenemo Auth";
+      custom-sign-in-logo = "-";
+      client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
+    };
+    keyFile = config.sops.templates.oauth2_proxy_env.path;
+  };
+
+  systemd.services.jenkins-purge-artifacts = {
+    after = [ "jenkins.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "jenkins";
+      WorkingDirectory = "/var/lib/jenkins";
+    };
+    script = builtins.readFile ./purge-jenkins-artifacts.sh;
+  };
+  systemd.timers.jenkins-purge-artifacts = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "hourly";
+    };
+  };
+
+  # Expose the HTTP[S] port. We still need HTTP for the HTTP-01 challenge.
+  # While TLS-ALPN-01 could be used, disabling HTTP-01 seems only possible from
+  # the JSON config, which won't work alongside Caddyfile.
+  networking.firewall.allowedTCPPorts = [
+    80
+    443
+  ];
+}

--- a/hosts/hetzci-dev/disk-config.nix
+++ b/hosts/hetzci-dev/disk-config.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_63735640";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "256M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/hetzci-dev/plugins.json
+++ b/hosts/hetzci-dev/plugins.json
@@ -1,0 +1,716 @@
+[
+  {
+    "name": "antisamy-markup-formatter",
+    "version": "173.v680e3a_b_69ff3",
+    "url": "https://updates.jenkins.io/download/plugins/antisamy-markup-formatter/173.v680e3a_b_69ff3/antisamy-markup-formatter.hpi",
+    "sha256": "0bqhs2p89vwyvnbj8dcm68la13nrszwxsci799bl8v7jjxbpdd19"
+  },
+  {
+    "name": "apache-httpcomponents-client-4-api",
+    "version": "4.5.14-269.vfa_2321039a_83",
+    "url": "https://updates.jenkins.io/download/plugins/apache-httpcomponents-client-4-api/4.5.14-269.vfa_2321039a_83/apache-httpcomponents-client-4-api.hpi",
+    "sha256": "0cwmr98jxdi69j5pba5l2l0b6v4cfwqpqxjbzmibk418qwfgd8nf"
+  },
+  {
+    "name": "asm-api",
+    "version": "9.8-135.vb_2239d08ee90",
+    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-135.vb_2239d08ee90/asm-api.hpi",
+    "sha256": "1m1ppbja2rn315sc720gxhi3ji64nqfdawa3rgdbd60ybry1zrwm"
+  },
+  {
+    "name": "block-queued-job",
+    "version": "0.2.0",
+    "url": "https://updates.jenkins.io/download/plugins/block-queued-job/0.2.0/block-queued-job.hpi",
+    "sha256": "008dfk2dh2n8sbqp02fx0cir4cmzpvnzkqlrn2z7fzblbbgr4vql"
+  },
+  {
+    "name": "blueocean-commons",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-commons/1.27.19/blueocean-commons.hpi",
+    "sha256": "1hdvyycm7xcss91d4vjf6a36qc84as3dgqpdcfdc8anqfbi9j5dy"
+  },
+  {
+    "name": "blueocean-core-js",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-core-js/1.27.19/blueocean-core-js.hpi",
+    "sha256": "033ix1b50k4vwcx3323wvqlzqxnv9zpd4kakiyf2wda0hyzny9wp"
+  },
+  {
+    "name": "blueocean-jwt",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-jwt/1.27.19/blueocean-jwt.hpi",
+    "sha256": "0sww5f12rs8z75n99aaabnyyx5d60by798nrgjknkg3hw971sk98"
+  },
+  {
+    "name": "blueocean-rest",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-rest/1.27.19/blueocean-rest.hpi",
+    "sha256": "1vrahm8fg709cvwx8a04qx3zd3g511f3p693jm0jkfjdrrn43mvb"
+  },
+  {
+    "name": "blueocean-rest-impl",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-rest-impl/1.27.19/blueocean-rest-impl.hpi",
+    "sha256": "1w6ckx6qhgb45z7wkysd6scsz559r1x9apb4aqh0n8l1wipbg3jz"
+  },
+  {
+    "name": "blueocean-web",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/blueocean-web/1.27.19/blueocean-web.hpi",
+    "sha256": "16n3526vn7m5lajig2hnhqi68m32pvgywl0i6rwpfjd5n8zfc595"
+  },
+  {
+    "name": "bootstrap5-api",
+    "version": "5.3.3-2",
+    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.3-2/bootstrap5-api.hpi",
+    "sha256": "06qmb6qqp3r7r622rhw7jili5lxrnm06ja5459mmpqch8lgbrgmk"
+  },
+  {
+    "name": "bouncycastle-api",
+    "version": "2.30.1.80-261.v00c0e2618ec3",
+    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.80-261.v00c0e2618ec3/bouncycastle-api.hpi",
+    "sha256": "1h06h7iqyvppi28x7mcw42gh1im3g0lay1rhxhimg42ly8fisa0n"
+  },
+  {
+    "name": "branch-api",
+    "version": "2.1217.v43d8b_b_d8b_2c7",
+    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1217.v43d8b_b_d8b_2c7/branch-api.hpi",
+    "sha256": "1dd0mw3xj9y9fwyfls0iwvzzxr295knxbhpl091fzk49fgkjrs4k"
+  },
+  {
+    "name": "caffeine-api",
+    "version": "3.2.0-166.v72a_6d74b_870f",
+    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.0-166.v72a_6d74b_870f/caffeine-api.hpi",
+    "sha256": "04zh7lnzwhrjjp534g5aaz2bd32d3lgvcjy0dxinbjg5214y6pnr"
+  },
+  {
+    "name": "checks-api",
+    "version": "370.vb_61a_c57328f3",
+    "url": "https://updates.jenkins.io/download/plugins/checks-api/370.vb_61a_c57328f3/checks-api.hpi",
+    "sha256": "1yz3y6insl48ykssl39cshskbzxihdmp1xk1klkp1xfn9dd3ijqq"
+  },
+  {
+    "name": "cloudbees-folder",
+    "version": "6.1012.v79a_86a_1ea_c1f",
+    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1012.v79a_86a_1ea_c1f/cloudbees-folder.hpi",
+    "sha256": "172wsl083l572jzc52md4zj86lipvm8nxj50sm1a8fcw83kb4nh9"
+  },
+  {
+    "name": "command-launcher",
+    "version": "123.v37cfdc92ef67",
+    "url": "https://updates.jenkins.io/download/plugins/command-launcher/123.v37cfdc92ef67/command-launcher.hpi",
+    "sha256": "1azr0spl8k80jim9r7p881rn057sydw5m7wzcgxzimsssqaq81kr"
+  },
+  {
+    "name": "commons-compress-api",
+    "version": "1.27.1-3",
+    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.27.1-3/commons-compress-api.hpi",
+    "sha256": "0abwp2kyh7fn63bsqmnbikyhj7yjj3z49859z65hkp4bwlkymgyq"
+  },
+  {
+    "name": "commons-lang3-api",
+    "version": "3.17.0-87.v5cf526e63b_8b_",
+    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.17.0-87.v5cf526e63b_8b_/commons-lang3-api.hpi",
+    "sha256": "1kslvyhh0kkpn98276rpl84ia2zlpwm9f7b4nzq7l3dnvdkx8m6n"
+  },
+  {
+    "name": "commons-text-api",
+    "version": "1.13.1-176.v74d88f22034b_",
+    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.13.1-176.v74d88f22034b_/commons-text-api.hpi",
+    "sha256": "0vbh3gz4v827i7y560lqf3g2mqy31pz920znxy0q5q80c7aqf60x"
+  },
+  {
+    "name": "conditional-buildstep",
+    "version": "1.5.0",
+    "url": "https://updates.jenkins.io/download/plugins/conditional-buildstep/1.5.0/conditional-buildstep.hpi",
+    "sha256": "0llb3zxr37kn4hba9m1dbrzz8lh5v64h4v3vkja0ai7bj50xsv7b"
+  },
+  {
+    "name": "config-file-provider",
+    "version": "988.v0461fcc2b_9d1",
+    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/988.v0461fcc2b_9d1/config-file-provider.hpi",
+    "sha256": "18nkwslzdhc7g5z9pzdhlfdqlap8mjah39mlhks4h85zx3hpnykh"
+  },
+  {
+    "name": "configuration-as-code",
+    "version": "1963.v24e046127a_3f",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1963.v24e046127a_3f/configuration-as-code.hpi",
+    "sha256": "1bd5pw780vzdmaam01g8dky52zyw76b4hl989h9symkk8smzmmjc"
+  },
+  {
+    "name": "configuration-as-code-groovy",
+    "version": "1.1",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code-groovy/1.1/configuration-as-code-groovy.hpi",
+    "sha256": "0rp88gy67n18yb8cq2p2ypaqalki647l1i396qj340ivbfjb8aiw"
+  },
+  {
+    "name": "copyartifact",
+    "version": "770.va_6c69e063442",
+    "url": "https://updates.jenkins.io/download/plugins/copyartifact/770.va_6c69e063442/copyartifact.hpi",
+    "sha256": "1abvdsnbkny8mb9dghm4bpx18ng450gggzansp48hl45pd7nk7gv"
+  },
+  {
+    "name": "credentials",
+    "version": "1415.v831096eb_5534",
+    "url": "https://updates.jenkins.io/download/plugins/credentials/1415.v831096eb_5534/credentials.hpi",
+    "sha256": "1462p5sq2kx76jann27vc1zkpl6wiiwzjapxai8l0gprpsjiv9m1"
+  },
+  {
+    "name": "credentials-binding",
+    "version": "687.v619cb_15e923f",
+    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/687.v619cb_15e923f/credentials-binding.hpi",
+    "sha256": "03bxygj33xmishd2pbqkrgnwwijs7akfyq1g5xwy68gwgc39qn1s"
+  },
+  {
+    "name": "data-tables-api",
+    "version": "2.2.2-1",
+    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.2.2-1/data-tables-api.hpi",
+    "sha256": "02k2bmy60f4q4psy90i0a4iila5ndl3fv4mahb8jgs925kk20cqc"
+  },
+  {
+    "name": "display-url-api",
+    "version": "2.209.v582ed814ff2f",
+    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.209.v582ed814ff2f/display-url-api.hpi",
+    "sha256": "09b81rsyk27p2d96zwhay42h1wallh66ckaxi9q6jdxrbgwpac21"
+  },
+  {
+    "name": "durable-task",
+    "version": "587.v84b_877235b_45",
+    "url": "https://updates.jenkins.io/download/plugins/durable-task/587.v84b_877235b_45/durable-task.hpi",
+    "sha256": "1d1rp7bf5iba88p1wkvqcilyfsm2bzzzgjb8gjrziyv7ay35sjpl"
+  },
+  {
+    "name": "echarts-api",
+    "version": "5.6.0-4",
+    "url": "https://updates.jenkins.io/download/plugins/echarts-api/5.6.0-4/echarts-api.hpi",
+    "sha256": "0b4yj1c4bxv1h1d8rxz3d9cjv8369y3spglyfgmkpwzc7s43n22j"
+  },
+  {
+    "name": "eddsa-api",
+    "version": "0.3.0.1-19.vc432d923e5ee",
+    "url": "https://updates.jenkins.io/download/plugins/eddsa-api/0.3.0.1-19.vc432d923e5ee/eddsa-api.hpi",
+    "sha256": "0fhl944wbkjnmlni94i14hy73xhagnn4rmd4lybcpb085k5xxirm"
+  },
+  {
+    "name": "email-ext",
+    "version": "1876.v28d8d38315b_d",
+    "url": "https://updates.jenkins.io/download/plugins/email-ext/1876.v28d8d38315b_d/email-ext.hpi",
+    "sha256": "0s31h0nnj7rmgjda5v6fgz9wa47l7j9h579x566jrz9kn4s6pz60"
+  },
+  {
+    "name": "favorite",
+    "version": "2.225.v68765b_b_a_1fa_3",
+    "url": "https://updates.jenkins.io/download/plugins/favorite/2.225.v68765b_b_a_1fa_3/favorite.hpi",
+    "sha256": "1j6fd1wddv6y6493yagvxpjhkyck30bazl2faqazn5in1c5xh2f6"
+  },
+  {
+    "name": "font-awesome-api",
+    "version": "6.7.2-1",
+    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/6.7.2-1/font-awesome-api.hpi",
+    "sha256": "0gyx355sv5c82bqkqh2yi4rnbm68qg2vv6kmwxbc4p7lc5n6g703"
+  },
+  {
+    "name": "git",
+    "version": "5.7.0",
+    "url": "https://updates.jenkins.io/download/plugins/git/5.7.0/git.hpi",
+    "sha256": "1sjw5rn4jahjhkkykrszzl25z7nwk0skwys41hdx78gxghdi5xr0"
+  },
+  {
+    "name": "git-client",
+    "version": "6.1.3",
+    "url": "https://updates.jenkins.io/download/plugins/git-client/6.1.3/git-client.hpi",
+    "sha256": "08f5x3ilfrarb6fhv6hxfg5fp2cvl5zqx6zq2mcj6443im6iq76d"
+  },
+  {
+    "name": "github",
+    "version": "1.43.0",
+    "url": "https://updates.jenkins.io/download/plugins/github/1.43.0/github.hpi",
+    "sha256": "0i8dn80xx7x0p79y6ifnl0kdaq86b2di5m3jirwgc69gc4f5g0xj"
+  },
+  {
+    "name": "github-api",
+    "version": "1.321-488.v9b_c0da_9533f8",
+    "url": "https://updates.jenkins.io/download/plugins/github-api/1.321-488.v9b_c0da_9533f8/github-api.hpi",
+    "sha256": "14b8cngv38qbpii4xrz6s2qn52g5v6rm27dcsnlhz2nzhwn4mvhl"
+  },
+  {
+    "name": "github-branch-source",
+    "version": "1815.v9152b_2ff7a_1b_",
+    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1815.v9152b_2ff7a_1b_/github-branch-source.hpi",
+    "sha256": "03852xlq1yh93hcxsv295vwjy9injjnv4l9byc6ayw08sr4zvayi"
+  },
+  {
+    "name": "github-pullrequest",
+    "version": "0.7.2",
+    "url": "https://updates.jenkins.io/download/plugins/github-pullrequest/0.7.2/github-pullrequest.hpi",
+    "sha256": "0gpsdxpms0q3ilswpqp3igspq9y3dpvwaxgjgglpn82s494xkjpd"
+  },
+  {
+    "name": "gson-api",
+    "version": "2.13.1-139.v4569c2ef303f",
+    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-139.v4569c2ef303f/gson-api.hpi",
+    "sha256": "0rz4a2kym62c9gf1p0ir1akdc8q09j394v0n314z49isf2n30hrj"
+  },
+  {
+    "name": "instance-identity",
+    "version": "203.v15e81a_1b_7a_38",
+    "url": "https://updates.jenkins.io/download/plugins/instance-identity/203.v15e81a_1b_7a_38/instance-identity.hpi",
+    "sha256": "062hvv0p5jrdkdcsjg2hrni5pxh50jk50ii95gqlhwhplq2k4ayz"
+  },
+  {
+    "name": "ionicons-api",
+    "version": "88.va_4187cb_eddf1",
+    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/88.va_4187cb_eddf1/ionicons-api.hpi",
+    "sha256": "0vzs1m251knzbjk3qpxk29pycs04dh50y1b0pw6vswkmb05a8vid"
+  },
+  {
+    "name": "jackson2-api",
+    "version": "2.18.3-402.v74c4eb_f122b_2",
+    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.18.3-402.v74c4eb_f122b_2/jackson2-api.hpi",
+    "sha256": "0y1jj13vwvdjn5vj99224fs9r6wvr3rhvdkz2g47jjy4aj3xd8kw"
+  },
+  {
+    "name": "jakarta-activation-api",
+    "version": "2.1.3-2",
+    "url": "https://updates.jenkins.io/download/plugins/jakarta-activation-api/2.1.3-2/jakarta-activation-api.hpi",
+    "sha256": "0lv7fwmqwj00yg6163azrxgxabpx75ssddqzqcvxrpw6ajlqfj3q"
+  },
+  {
+    "name": "jakarta-mail-api",
+    "version": "2.1.3-2",
+    "url": "https://updates.jenkins.io/download/plugins/jakarta-mail-api/2.1.3-2/jakarta-mail-api.hpi",
+    "sha256": "1hilgqhqa8zlyfyzj5ygmjh479n9qxhkrdr3gr7wljlybn935vc5"
+  },
+  {
+    "name": "javadoc",
+    "version": "327.vdfe586651ee0",
+    "url": "https://updates.jenkins.io/download/plugins/javadoc/327.vdfe586651ee0/javadoc.hpi",
+    "sha256": "1nf6bi37m4j54jf20c2gljngazf5ngipsgmh3qpgg1i44pp583v9"
+  },
+  {
+    "name": "javax-activation-api",
+    "version": "1.2.0-8",
+    "url": "https://updates.jenkins.io/download/plugins/javax-activation-api/1.2.0-8/javax-activation-api.hpi",
+    "sha256": "0q05i1jpcqrnbldal6j9sjimzad72726rcj5zc0bl1yz5v2qhvp9"
+  },
+  {
+    "name": "jaxb",
+    "version": "2.3.9-133.vb_ec76a_73f706",
+    "url": "https://updates.jenkins.io/download/plugins/jaxb/2.3.9-133.vb_ec76a_73f706/jaxb.hpi",
+    "sha256": "1s0yb7h68fxmk006liycakkk8l8srmf655wn3a22kdz5fmvxzvb2"
+  },
+  {
+    "name": "jenkins-design-language",
+    "version": "1.27.19",
+    "url": "https://updates.jenkins.io/download/plugins/jenkins-design-language/1.27.19/jenkins-design-language.hpi",
+    "sha256": "0h6wwpv1ci2w5dryfmp5v6kc3m11dfzh1j6qh8bibjks6warljph"
+  },
+  {
+    "name": "jjwt-api",
+    "version": "0.11.5-120.v0268cf544b_89",
+    "url": "https://updates.jenkins.io/download/plugins/jjwt-api/0.11.5-120.v0268cf544b_89/jjwt-api.hpi",
+    "sha256": "1294ynm62fnm1avx276mm4rxf6dh3rhy57l1kpnk3jrwazbwp2y8"
+  },
+  {
+    "name": "job-dsl",
+    "version": "1.92",
+    "url": "https://updates.jenkins.io/download/plugins/job-dsl/1.92/job-dsl.hpi",
+    "sha256": "182xk37ns5pk9lg75lzmi92l2fd40fy5c2sl0ha8g81dkj4psazk"
+  },
+  {
+    "name": "joda-time-api",
+    "version": "2.14.0-127.v7d9da_295a_d51",
+    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-127.v7d9da_295a_d51/joda-time-api.hpi",
+    "sha256": "0p5hakxs02c445dm3vzzm0vyrcqiv49ppqxnwx1kg897ns7qjwy2"
+  },
+  {
+    "name": "jquery3-api",
+    "version": "3.7.1-3",
+    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-3/jquery3-api.hpi",
+    "sha256": "0d1awnb0m5k9dg37333nmlma2s1991jm55zsmmsqqfq1jllg68qq"
+  },
+  {
+    "name": "jsch",
+    "version": "0.2.16-95.v3eecb_55fa_b_78",
+    "url": "https://updates.jenkins.io/download/plugins/jsch/0.2.16-95.v3eecb_55fa_b_78/jsch.hpi",
+    "sha256": "05h6vr6dnj883p53qsdr894is0sjiz3c7gq8lbihwb2dxl2d4q9c"
+  },
+  {
+    "name": "json-api",
+    "version": "20250107-125.v28b_a_ffa_eb_f01",
+    "url": "https://updates.jenkins.io/download/plugins/json-api/20250107-125.v28b_a_ffa_eb_f01/json-api.hpi",
+    "sha256": "0f7ahrw1538l4119dc6az831ian5v31hry88yhy718iwc9c93b3i"
+  },
+  {
+    "name": "json-path-api",
+    "version": "2.9.0-148.v22a_7ffe323ce",
+    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-148.v22a_7ffe323ce/json-path-api.hpi",
+    "sha256": "14arnnsz9w23mmv9j2m66ynvf3jy9l4mzr2s8vy2sabcdgsc3z4k"
+  },
+  {
+    "name": "jsoup",
+    "version": "1.20.1-46.ve5f1416988c2",
+    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.20.1-46.ve5f1416988c2/jsoup.hpi",
+    "sha256": "1w77qna5avr784xvr8sy2n7kl7mcxknp6snpkm6sb6biy4xzz6p7"
+  },
+  {
+    "name": "jucies",
+    "version": "0.2.1",
+    "url": "https://updates.jenkins.io/download/plugins/jucies/0.2.1/jucies.hpi",
+    "sha256": "1lwkxy0n2ww5hszpsyi6q0whm5mdjs8apxacv1lhkk5qplcmb14q"
+  },
+  {
+    "name": "junit",
+    "version": "1335.v6b_a_a_e18534e1",
+    "url": "https://updates.jenkins.io/download/plugins/junit/1335.v6b_a_a_e18534e1/junit.hpi",
+    "sha256": "0x1mykh9vvbfyp3q9qg6yy359p13k36a8pcb9bd3fq920yabc93w"
+  },
+  {
+    "name": "lockable-resources",
+    "version": "1349.v8b_ccb_c5487f7",
+    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1349.v8b_ccb_c5487f7/lockable-resources.hpi",
+    "sha256": "11fj40llz4diq93wqc9zaz3w4lsfb8fkrq09vw8lmjhri41qk5r8"
+  },
+  {
+    "name": "mailer",
+    "version": "489.vd4b_25144138f",
+    "url": "https://updates.jenkins.io/download/plugins/mailer/489.vd4b_25144138f/mailer.hpi",
+    "sha256": "183xa925xbpaigzmk87aiq8dkldayjj147cmiy8z65b51kinz0qx"
+  },
+  {
+    "name": "mapdb-api",
+    "version": "1.0.9-44.va_1e1310c9118",
+    "url": "https://updates.jenkins.io/download/plugins/mapdb-api/1.0.9-44.va_1e1310c9118/mapdb-api.hpi",
+    "sha256": "1akb362zkxv16xzfzn3724innchf3a0q2qlnj79vif980xjkrvz9"
+  },
+  {
+    "name": "matrix-auth",
+    "version": "3.2.6",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.6/matrix-auth.hpi",
+    "sha256": "1g3ij9f8ad6yhciyliwchv5dv7rlml7vghs64kmgrb9fff7pqgkj"
+  },
+  {
+    "name": "matrix-project",
+    "version": "849.v0cd64ed7e531",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-project/849.v0cd64ed7e531/matrix-project.hpi",
+    "sha256": "0rl2syrpi6dc6vylhqmsmr2y5mg7l73g2viv3cyrkgllj1gg3ixq"
+  },
+  {
+    "name": "maven-plugin",
+    "version": "3.26",
+    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.26/maven-plugin.hpi",
+    "sha256": "1cdxpxr7yfm5fazdj26zmw8aqla95nmmj1qymypv7w2yg8ahs49f"
+  },
+  {
+    "name": "metrics",
+    "version": "4.2.30-471.v55fa_495f2b_f5",
+    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.30-471.v55fa_495f2b_f5/metrics.hpi",
+    "sha256": "0spwph8mlks60wv3yr4f98914s4l17cv80l8qcb3gqr5ikk69jkc"
+  },
+  {
+    "name": "mina-sshd-api-common",
+    "version": "2.15.0-161.vb_200831a_c15b_",
+    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-common/2.15.0-161.vb_200831a_c15b_/mina-sshd-api-common.hpi",
+    "sha256": "0q394pj8nqmr8d67flaz6h9fwf1kyk91kzzz1ss6lspx7h6biiy8"
+  },
+  {
+    "name": "mina-sshd-api-core",
+    "version": "2.15.0-161.vb_200831a_c15b_",
+    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-core/2.15.0-161.vb_200831a_c15b_/mina-sshd-api-core.hpi",
+    "sha256": "0n8sp9k5n25lpjlmm6zpmr5iplah5220qx0m49lqsr9pv9698maf"
+  },
+  {
+    "name": "node-iterator-api",
+    "version": "72.vc90e81737df1",
+    "url": "https://updates.jenkins.io/download/plugins/node-iterator-api/72.vc90e81737df1/node-iterator-api.hpi",
+    "sha256": "1mivah6wr0wyvxhwy7zr1md6xlanjxi2n0rk1q5ln7gmmzzwsn1y"
+  },
+  {
+    "name": "okhttp-api",
+    "version": "4.11.0-189.v976fa_d3379d6",
+    "url": "https://updates.jenkins.io/download/plugins/okhttp-api/4.11.0-189.v976fa_d3379d6/okhttp-api.hpi",
+    "sha256": "0xyhxwp4n1m2myv52hjanlzsbg4wazbqp5iyx8n9yv9iqwjxd37h"
+  },
+  {
+    "name": "oss-symbols-api",
+    "version": "324.v432cce4172ca_",
+    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/324.v432cce4172ca_/oss-symbols-api.hpi",
+    "sha256": "0x1y2vl7pibraw246648r3k8aprcybvax2zzj5p12ng4in1fnqcb"
+  },
+  {
+    "name": "parameterized-trigger",
+    "version": "859.vb_e3907a_07a_16",
+    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/859.vb_e3907a_07a_16/parameterized-trigger.hpi",
+    "sha256": "1wyky5if74f490wwc1r375dsq0hl08059888qsw1kw6si4wbqi1q"
+  },
+  {
+    "name": "pipeline-build-step",
+    "version": "567.vea_ce550ece97",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-build-step/567.vea_ce550ece97/pipeline-build-step.hpi",
+    "sha256": "1wgfc9n0wbw41mci9q04fckfc3c5px3n19p18ppddvsipbwiqxrd"
+  },
+  {
+    "name": "pipeline-graph-analysis",
+    "version": "237.v2b_75640ca_888",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-analysis/237.v2b_75640ca_888/pipeline-graph-analysis.hpi",
+    "sha256": "03zx03h3lpl8q929b1rydqxkwfrwx6i4pag52ldbsrgwyc7byxwl"
+  },
+  {
+    "name": "pipeline-graph-view",
+    "version": "536.vd9674ce4b_46a_",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/536.vd9674ce4b_46a_/pipeline-graph-view.hpi",
+    "sha256": "07f2n14xqmvgl5s48vpwzbh9dl9vrilwjpwr80dsyk31qavizam6"
+  },
+  {
+    "name": "pipeline-groovy-lib",
+    "version": "752.vdddedf804e72",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-groovy-lib/752.vdddedf804e72/pipeline-groovy-lib.hpi",
+    "sha256": "1p4pp6g75l28f7axyjjlvc6n3qmqrrp9kachpgpanrydv840s5gd"
+  },
+  {
+    "name": "pipeline-input-step",
+    "version": "517.vf8e782ee645c",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/517.vf8e782ee645c/pipeline-input-step.hpi",
+    "sha256": "16dh4lfvfb77yr956lxpgl6nzdlzyi872fvbxpk5kf6g3p5h4jjk"
+  },
+  {
+    "name": "pipeline-milestone-step",
+    "version": "138.v78ca_76831a_43",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-milestone-step/138.v78ca_76831a_43/pipeline-milestone-step.hpi",
+    "sha256": "1lf4bgdz96krg3k8a8rmlkf5n63dx11kdx4c0gqjslk2garpykq7"
+  },
+  {
+    "name": "pipeline-model-api",
+    "version": "2.2255.v56a_15e805f12",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2255.v56a_15e805f12/pipeline-model-api.hpi",
+    "sha256": "16z4hjwh2nsrl3krs6ik5gi7wvsjz7y34glh99m9c5q5mf3d7whx"
+  },
+  {
+    "name": "pipeline-model-definition",
+    "version": "2.2255.v56a_15e805f12",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2255.v56a_15e805f12/pipeline-model-definition.hpi",
+    "sha256": "17rnjhy3yr2v1xrxglvdlzmkv8ixj7lkgi0mb39szk4101yj55sx"
+  },
+  {
+    "name": "pipeline-model-extensions",
+    "version": "2.2255.v56a_15e805f12",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2255.v56a_15e805f12/pipeline-model-extensions.hpi",
+    "sha256": "1qw1ikkdxdpgdm3il1hpmc0bcjcf1p2gxczhmypy6w1pdhkginrc"
+  },
+  {
+    "name": "pipeline-rest-api",
+    "version": "2.38",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-rest-api/2.38/pipeline-rest-api.hpi",
+    "sha256": "0cplnfgsx0rh88fxq2f1lcp1rvygwh8amrlg14czmqyqr32h49j3"
+  },
+  {
+    "name": "pipeline-stage-step",
+    "version": "322.vecffa_99f371c",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-step/322.vecffa_99f371c/pipeline-stage-step.hpi",
+    "sha256": "1jkm1bffff9fkckvnakzvah9jh5k54hkd796qimiawv0zww69vg4"
+  },
+  {
+    "name": "pipeline-stage-tags-metadata",
+    "version": "2.2255.v56a_15e805f12",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2255.v56a_15e805f12/pipeline-stage-tags-metadata.hpi",
+    "sha256": "0v2mcjc0kxl8nzdipjn6sak4y0l4k86rn9i3x2nlc61c9narl8cq"
+  },
+  {
+    "name": "pipeline-stage-view",
+    "version": "2.38",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-view/2.38/pipeline-stage-view.hpi",
+    "sha256": "069hlfh44rhmlgp9mhzp322mbgr973znv86p70iqmgpmnkgy81xg"
+  },
+  {
+    "name": "pipeline-utility-steps",
+    "version": "2.19.0",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-utility-steps/2.19.0/pipeline-utility-steps.hpi",
+    "sha256": "1ixkr68y4fwl2a839dzkivqdxz7azkkl2av7q6bvplnwk85kwwql"
+  },
+  {
+    "name": "plain-credentials",
+    "version": "195.vb_906e9073dee",
+    "url": "https://updates.jenkins.io/download/plugins/plain-credentials/195.vb_906e9073dee/plain-credentials.hpi",
+    "sha256": "0mlp7k9nf1zbalg53d68h1y7gmhqbirn8cvhg6mkrizwld6knsza"
+  },
+  {
+    "name": "plugin-util-api",
+    "version": "6.1.0",
+    "url": "https://updates.jenkins.io/download/plugins/plugin-util-api/6.1.0/plugin-util-api.hpi",
+    "sha256": "1l2518if3sy9zz54wi1hr2khmrwcf3v6z4ka812nzsfd1s9df1ca"
+  },
+  {
+    "name": "prism-api",
+    "version": "1.30.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/prism-api/1.30.0-1/prism-api.hpi",
+    "sha256": "0fpc7624pla68nyfsbrdfvaqa80k1ccm1ac1biqvyad4wfy2hgmj"
+  },
+  {
+    "name": "promoted-builds",
+    "version": "992.va_00888f21b_74",
+    "url": "https://updates.jenkins.io/download/plugins/promoted-builds/992.va_00888f21b_74/promoted-builds.hpi",
+    "sha256": "11icp071dasjdlhwa6xpafbfv48qcxmz580l9zlffakdhzmzk7f0"
+  },
+  {
+    "name": "rebuild",
+    "version": "338.va_0a_b_50e29397",
+    "url": "https://updates.jenkins.io/download/plugins/rebuild/338.va_0a_b_50e29397/rebuild.hpi",
+    "sha256": "01cvxwr6gdyf628bmq4svfxrhfxwn2p05cxl8rjiijcicw4sbis7"
+  },
+  {
+    "name": "reverse-proxy-auth-plugin",
+    "version": "238.v82ceca_8417a_6",
+    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/238.v82ceca_8417a_6/reverse-proxy-auth-plugin.hpi",
+    "sha256": "18dakdm8p7x1zw8fibvnbiyjrp6l7dzg5w2z44zva7s19may86aj"
+  },
+  {
+    "name": "robot",
+    "version": "6.0.0",
+    "url": "https://updates.jenkins.io/download/plugins/robot/6.0.0/robot.hpi",
+    "sha256": "1c3fixqkp9g39401scba2l4gkfkvkw9ik8h3bmiirxg76qcfv3yh"
+  },
+  {
+    "name": "run-condition",
+    "version": "243.v3c3f94e46a_8b_",
+    "url": "https://updates.jenkins.io/download/plugins/run-condition/243.v3c3f94e46a_8b_/run-condition.hpi",
+    "sha256": "1qznpcdcy2b4nd4x45ql74qcbkqgvh6nc639is2riin7rjg91j0y"
+  },
+  {
+    "name": "scm-api",
+    "version": "704.v3ce5c542825a_",
+    "url": "https://updates.jenkins.io/download/plugins/scm-api/704.v3ce5c542825a_/scm-api.hpi",
+    "sha256": "1j8hv8hl4mcmybmzzvjhvvn6133i4bym1pck3x1zh4dhd98j6wpf"
+  },
+  {
+    "name": "script-security",
+    "version": "1373.vb_b_4a_a_c26fa_00",
+    "url": "https://updates.jenkins.io/download/plugins/script-security/1373.vb_b_4a_a_c26fa_00/script-security.hpi",
+    "sha256": "09y4xysz3xjdyjmgspak78llhgac7zzcl6rkjmjpf5ab29igx6bi"
+  },
+  {
+    "name": "snakeyaml-api",
+    "version": "2.3-125.v4d77857a_b_402",
+    "url": "https://updates.jenkins.io/download/plugins/snakeyaml-api/2.3-125.v4d77857a_b_402/snakeyaml-api.hpi",
+    "sha256": "0hkyq457yqaxhkqvkwq9h0jv7jsk4c9ysa9293c8ymg1wwlz55c9"
+  },
+  {
+    "name": "ssh-credentials",
+    "version": "355.v9b_e5b_cde5003",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/355.v9b_e5b_cde5003/ssh-credentials.hpi",
+    "sha256": "0v3bvijg76v01jb4lp7n60qdn6yvp2kvg4d9gf14gws44cg1d1hl"
+  },
+  {
+    "name": "ssh-slaves",
+    "version": "3.1031.v72c6b_883b_869",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1031.v72c6b_883b_869/ssh-slaves.hpi",
+    "sha256": "0z7hn30wd3wd5h098pachjral0si15rp96q28c63mpqqbgqm1gwl"
+  },
+  {
+    "name": "structs",
+    "version": "343.vdcf37b_a_c81d5",
+    "url": "https://updates.jenkins.io/download/plugins/structs/343.vdcf37b_a_c81d5/structs.hpi",
+    "sha256": "12s2c7njw1xchwrxfvm7vl58f6n5768z6084md1y5b2jyqq8qw0h"
+  },
+  {
+    "name": "subversion",
+    "version": "1287.vd2d507146906",
+    "url": "https://updates.jenkins.io/download/plugins/subversion/1287.vd2d507146906/subversion.hpi",
+    "sha256": "11sv1xy2klbf9l09n7lry06xg448x5z5qbllja3kafib597183l2"
+  },
+  {
+    "name": "support-core",
+    "version": "1725.va_2a_9f06eed61",
+    "url": "https://updates.jenkins.io/download/plugins/support-core/1725.va_2a_9f06eed61/support-core.hpi",
+    "sha256": "0dcb29iq5a0nyc0pni95m2fx6sappylbmmclf9bagfi5i9v6x6gw"
+  },
+  {
+    "name": "timestamper",
+    "version": "1.29",
+    "url": "https://updates.jenkins.io/download/plugins/timestamper/1.29/timestamper.hpi",
+    "sha256": "120ma5v0vamkvmzbwjwnd6849j2mvr7zxc2kdfashm89afsqb5a7"
+  },
+  {
+    "name": "token-macro",
+    "version": "444.v52de7e9c573d",
+    "url": "https://updates.jenkins.io/download/plugins/token-macro/444.v52de7e9c573d/token-macro.hpi",
+    "sha256": "0slyazvqi63g4d57lm6jkmmnkcw1kkqfycnwvq1qlddmpqa9n3qv"
+  },
+  {
+    "name": "trilead-api",
+    "version": "2.209.v0e69b_c43c245",
+    "url": "https://updates.jenkins.io/download/plugins/trilead-api/2.209.v0e69b_c43c245/trilead-api.hpi",
+    "sha256": "1v91v2di7zr0apw10wlg08i1njyprivdcr964rz02kf2g9v0133y"
+  },
+  {
+    "name": "variant",
+    "version": "70.va_d9f17f859e0",
+    "url": "https://updates.jenkins.io/download/plugins/variant/70.va_d9f17f859e0/variant.hpi",
+    "sha256": "1bssqx5ny3rrml6vqzbr0kxmvbkl835ix22m3d3a8sa4d7m19qhj"
+  },
+  {
+    "name": "vsphere-cloud",
+    "version": "2.27",
+    "url": "https://updates.jenkins.io/download/plugins/vsphere-cloud/2.27/vsphere-cloud.hpi",
+    "sha256": "1smxrh2qx79v2mgzpi7n5r00ry0sw5vpc220fyj1zx6d2p2yi15m"
+  },
+  {
+    "name": "workflow-aggregator",
+    "version": "608.v67378e9d3db_1",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-aggregator/608.v67378e9d3db_1/workflow-aggregator.hpi",
+    "sha256": "1p2pyfpjvv0937rc0iyra4djyh9klga9m48l5hkbn0gs39y2553v"
+  },
+  {
+    "name": "workflow-api",
+    "version": "1373.v7b_813f10efa_b_",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1373.v7b_813f10efa_b_/workflow-api.hpi",
+    "sha256": "1c161pxxl15ydp1pzf7vd7gv9si8vlz55n528is6vgjbwv774rzm"
+  },
+  {
+    "name": "workflow-basic-steps",
+    "version": "1079.vce64b_a_929c5a_",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-basic-steps/1079.vce64b_a_929c5a_/workflow-basic-steps.hpi",
+    "sha256": "10hibnf4fb75dkfw6px05kkdwyas80h7ym0bmxw8yccmb3gc24ja"
+  },
+  {
+    "name": "workflow-cps",
+    "version": "4106.v7a_8a_8176d450",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4106.v7a_8a_8176d450/workflow-cps.hpi",
+    "sha256": "0af9f0786mnb4xh2zllwb68gm0924dqf5y50695j2lmg2v936xw2"
+  },
+  {
+    "name": "workflow-durable-task-step",
+    "version": "1405.v1fcd4a_d00096",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1405.v1fcd4a_d00096/workflow-durable-task-step.hpi",
+    "sha256": "0xg2cga1kvfkhhc7agjfyvr3p4n0ilxkf4a042md0qy8spibgwc2"
+  },
+  {
+    "name": "workflow-job",
+    "version": "1520.v56d65e3b_4566",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-job/1520.v56d65e3b_4566/workflow-job.hpi",
+    "sha256": "0mw4gwqw7nj1hgwrl0i91sijx2r6iw5ky7xnidk3pp6ivfkr54rl"
+  },
+  {
+    "name": "workflow-multibranch",
+    "version": "806.vb_b_688f609ee9",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/806.vb_b_688f609ee9/workflow-multibranch.hpi",
+    "sha256": "1gim0q59x8yzfdkhmk5svi4ns4v84m767wyq76jjik7xsb6mhw34"
+  },
+  {
+    "name": "workflow-scm-step",
+    "version": "437.v05a_f66b_e5ef8",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-scm-step/437.v05a_f66b_e5ef8/workflow-scm-step.hpi",
+    "sha256": "05jh4dd34dqi7brjmipsc1xkn8srk68qa4i87cix3l28kywrrzkj"
+  },
+  {
+    "name": "workflow-step-api",
+    "version": "700.v6e45cb_a_5a_a_21",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/700.v6e45cb_a_5a_a_21/workflow-step-api.hpi",
+    "sha256": "0j3y00idx8qm7lj6kl0c3rx5sgszfc7lzwpah3z8pf86jzv307i0"
+  },
+  {
+    "name": "workflow-support",
+    "version": "968.v8f17397e87b_8",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-support/968.v8f17397e87b_8/workflow-support.hpi",
+    "sha256": "0i1412z0ap79y4zix941z2l8i24inssfmirm7p7nkvgpa76mnlaz"
+  }
+]

--- a/hosts/hetzci-dev/plugins.txt
+++ b/hosts/hetzci-dev/plugins.txt
@@ -1,0 +1,17 @@
+antisamy-markup-formatter
+bootstrap5-api
+configuration-as-code
+configuration-as-code-groovy
+copyartifact
+github
+github-pullrequest
+lockable-resources
+matrix-auth
+pipeline-build-step
+pipeline-graph-view
+pipeline-stage-view
+pipeline-utility-steps
+reverse-proxy-auth-plugin
+robot
+timestamper
+workflow-aggregator

--- a/hosts/hetzci-dev/purge-jenkins-artifacts.sh
+++ b/hosts/hetzci-dev/purge-jenkins-artifacts.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eEuo pipefail
+
+# Find anything exactly two paths deep from the artifacts directory, i.e.:
+# /var/lib/jenkins/artifacts/*/*/. If the matching path directly contains
+# only broken symlinks or directories, the path is removed.
+while IFS= read -r path; do
+    if find "$path" -maxdepth 1 -mindepth 1 -not -xtype l -not -type d | read -r;
+    then
+        continue
+    fi
+    echo "Removing: '$path'"
+    rm -fr "$path"
+done < <(find /var/lib/jenkins/artifacts -maxdepth 2 -mindepth 2)

--- a/hosts/hetzci-dev/secrets.yaml
+++ b/hosts/hetzci-dev/secrets.yaml
@@ -1,0 +1,45 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:yVsDq9GNnJKSx5L/p18bogiRqeRwpcf77IKIS4qvZ77mDCXeVyqD82v2E7eg8rQXNeQuU7l+i3RrKj0W4IESlZbzLanC0YsmsU/X0IT2X3ZXFq8YDlkfYMMwu2+PwGSRenWZU9AG90Sh3qxnghBPLUkEIyP04lWizE24dytaHPRf5hC53cLbC2crAcsnh//pBrqFJjmltebUjR0Amq2B65gki0rXZR3CWY6HBOVibV+XJQGolCZnaF8HzbqEN/GcFDHq8prnqnlA3GGs/r9f1v9FnU1BhxD62lh5082TrNGQui1JSEe82yR1o4Fp08vwBp2EVAoi+9QzW7WbHKypUnZdrt4H9WOdV9mUK7ZnCMZOv3XG6yXaMl7iEfHMRd7xwelIwwn/7cDcUq0s5Bl1+5aZqht1/ODV0pOFLOPyyhiiH+z5gX395ttXBcDUvYl3Es8skBoTrhr5tBYc2t/9JQxrUu61EaGK7ELeQKWP48EEluL9qpxNzvPK9Oz2QZX5hkCxCh1uBgXBaoaZOudnKoTbqKwp/F+ariDO,iv:8LHXaM/EzM4z2Gyr4NE7qT2CAIjN7ZSEFcJ0hykZgG0=,tag:Cl3Wf2ZzWlKJzjXwK6+w5g==,type:str]
+oauth2_proxy_client_secret: ENC[AES256_GCM,data:ww3anrvRVkYknkeezrGqEA07i0Xf4yGPSSvFBa4XAWg=,iv:UF/W2HbtgWeuedM4wTRkiRb4eprDOto3Q3StLDuoYXg=,tag:52mPWiMcbcieGcfkv8Rv/A==,type:str]
+oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:2peVU6TWd+OZ1AcD6+Cnsof6pYzkX5nQYHqbUKFVSveVt9F/msXksjeWrg==,iv:vegMu1MSwENdruSr3RI1iBQIBnJ0Cwf3YZnK1j8FZhc=,tag:BITxYtU9P/BfDoS17Xy8qg==,type:str]
+jenkins_api_token: ENC[AES256_GCM,data:paXifH4nATF+6FqSv+ReDRGbsbEXbQ+SOKqaV9VFgNABLA==,iv:8dd7FvRhuW1VDaElgqaSQL1SxFHl+OugqIIRBGJ+Ls8=,tag:htfuumutvgGuy2gzcAq28A==,type:str]
+jenkins_github_webhook_secret: ENC[AES256_GCM,data:Xx604eclt+klNONw+VI/6duKWQj8yzcXfk3LnrdfxY8=,iv:tP5Y1Yr6pcnbk7YxdMAq+tztoUTSE3ua5j9DDLVKfoM=,tag:nFyPrZFxMHHPI+RF0EPGSw==,type:str]
+jenkins_github_commit_status_token: ENC[AES256_GCM,data:ftIy9XXgLebpB+51dfnkhP33FWKYtaknRATJ+UslS9r3pCkNEBlB2Q==,iv:xUaHChYVL3VS0stcuHUIJxr41KVlbMw5IXYmS+T4Eb8=,tag:QJBtEnUU3Ne/eBQAbfDNWg==,type:str]
+vedenemo_builder_ssh_key: ENC[AES256_GCM,data:w5iotEvbKgW1rM19DF9MWwENYFMXLel+kYkP+pOADImQpTi80HInX5DH8xZH0pMXmKwoMdmZ2OxObEZttXHI9geZ1/lbAkOYTEzRIdeVzyBDvNfI0mCd32YnNmJJr7lHAtf2rKLpie1nioByVFNa4jobwrC+Nwv65upEBCaZkweNchsJhMwkXA3FWXHmM+AOnR97jAwrCjmT5eqLD+H0O5WQT00NdRZ08Huuvmh9JMzlHmhP6+B9gSDn44bbS/Yz2YWb1CjLMYti46jOMH1SXoQrEV+34w1To1mFb9d+K54GgL7hSz+021POgyrXNGYjxPDGf1ZeLwmZ793LsAXzYA5VHmaU6uW2KqYY4YfNIaz7fz3Ex+pUN3awS/em9VBy3VFzpRNGJwny0+i46keWHNbN5w5D3vLeawcY3sGNdw9ZpSCRUUNU6IfEAHww1QMGk+Q3bmZdU7DaR5el9UHxNJBlv5XNrHJ+uOXIvkDIhz5qNZp8l2iVTatcdfVDSWFObHLg,iv:v9+3cStSVh7NYeyOU29bQw2mS2PyYSNymgmsbTez590=,tag:4OIm90aTMoFWl9+Czr4AlQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age10xhyyjrhackyac2f042t3z8yqld3sh39ul3mukwkt6gyr7gn9upq8n30gm
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxUStwZGJva0NlazlJNjBa
+            OFBnbWh1eWtOWWRBT3VGVUdFb05aM05ZRFdzCmhKK1cxQWE5ZXo4YmlnUjRWM3hQ
+            ZXNxVVpOSzZKYklvWnhPOUhXQ2h5SlUKLS0tIHY5S2JjZ056alVhWE40WE9Qa1Rx
+            Qm9KaVlHZ0M0SjJlc2VGMGJJQUp0M2sKeJp2s5tW+DpyDPglHS303fIaOirshDzr
+            PBzx43WtGtxO6hQrAa4IdAgN77qz4lgVF55/sGVc+18Hr9SGGluT6A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrRjJDeFU3ekdtKy9QWXd2
+            ZUgxd1hUWHNlRHQ5OEFYOHp4dXQvcVVTOTM0Ci9JNE5rME9hSGRUTGcyOTZSK0U1
+            Q2Z1dG9vSkVFcmZ5UzdGZkkyY01IYXcKLS0tIEFRV3J4MnFJcEQwTkg3dis0Zitq
+            eU1rUmpkTGxKSVdlU3FnRlRjV0Nxb1EKoPteTPPicJT9v6T9pyXPd/3DLT96B2gK
+            XUrbPxB4CuHZGfJnF2PRk47T598aurRMmCsWQOX7RPctKMglb/Tn+A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjLzNjd3JOYlJWRkN0Z2pM
+            bVpjSEo4SXF6bUkva2RVOG5XZ0xUZ25qZFJFClBQeWdrbHRBYXpBU3lxdlNJRzIv
+            SEFWTnpSbUdwQlFycnplelpoRjNlRlEKLS0tIE1JYndjOUdrVUxPNnd5UHRzQWVh
+            TDRuK3Vhb1lMZ2owdjJLUjRGS0VMa3cKF+7Q7xRFyYd6U8apfqlpWEiJ7xsF//xJ
+            zpc1bxl7gLKs9EH3kdv8ATYZzGXC/UCd9ccpmy9TYDogTcIqOGZYtQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-06-19T06:53:04Z"
+    mac: ENC[AES256_GCM,data:ZWPCaSi9h3DkDjArmsbh98yTEBJPAwzqvNE6IKZI7y25nlP0pfMNjZ4RqFH/cKNgZhWIPLvWn/qplSvYD3mQD4weS0yI4oWasqY4+8of2uG1yqeZu0bDgbHiiD7DR1ufOqNvy6GMPuzA8Ei1/RSipIZl1mEWEu+304HzlQ2kwGI=,iv:7ussTRztXL03rjcGKHggGkdLeRKPyj/YDppvbPS5GYM=,tag:JJ2Ohf+6AkRDnn53JwHX9Q==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -36,6 +36,7 @@ let
     ghaf-auth = mkDeployment "x86_64-linux" "ghaf-auth" "37.27.190.109";
     testagent-uae-dev = mkDeployment "x86_64-linux" "testagent-uae-dev" "172.19.16.12";
     hetzci-prod = mkDeployment "x86_64-linux" "hetzci-prod" "157.180.43.236";
+    hetzci-dev = mkDeployment "x86_64-linux" "hetzci-dev" "157.180.119.138";
     hetz86 = mkDeployment "x86_64-linux" "hetz86" "37.27.170.242";
   };
 

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -29,11 +29,18 @@
               --plugins-file "$FLAKE_ROOT"/hosts/hetzci-prod/plugins.txt \
               --output "$FLAKE_ROOT"/hosts/hetzci-prod/plugins.json
           }
+          prefetch-plugins-hetzci-dev () {
+            python "$FLAKE_ROOT"/scripts/resolve_plugins.py \
+              --jenkins-version ${pkgs.jenkins.version} \
+              --plugins-file "$FLAKE_ROOT"/hosts/hetzci-dev/plugins.txt \
+              --output "$FLAKE_ROOT"/hosts/hetzci-dev/plugins.json
+          }
           echo ""
           echo 1>&2 "Welcome to the development shell!"
           echo ""
           echo "This shell provides following helper commands:"
           echo " - prefetch-plugins-azure-controller"
+          echo " - prefetch-plugins-hetzci-dev"
           echo " - prefetch-plugins-hetzci-prod"
           echo ""
         '';


### PR DESCRIPTION
Add configuration for https://hetzci-dev.vedenemo.dev/ - Jenkins dev host on hetzner.
Configuration is copied from hetzci-prod with minor changes to relevant configuration options. We want to keep the dev config separate from `prod` to allow testing configuration changes on `dev` fully independent of `prod`.

