### PR TITLE
hosts/common.nix: Stop using prod-cache.vedenemo.dev

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -39,11 +39,9 @@ in
       # Subsituters
       trusted-public-keys = [
         "ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY="
-        "prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI="
       ];
       substituters = [
         "https://ghaf-dev.cachix.org?priority=20"
-        "https://prod-cache.vedenemo.dev"
       ];
       # Avoid copying unecessary stuff over SSH
       builders-use-substitutes = true;


### PR DESCRIPTION
 Stop using the (to-be-retired) 'prod-cache.vedenemo.dev' substituter