### PR TITLE
Hetzner CI and builder updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ ghaf-infra
 │   │   ├── build2
 │   │   ├── build3
 │   │   ├── build4
-│   │   ├── hetz86
+│   │   ├── hetz86-1
+│   │   ├── hetz86-builder
 │   │   ├── hetzarm
 │   │   └── developers.nix # Users with access to build3 and hetzarm
+│   ├── hetzci-dev # Ghaf dev CI in hetzner (https://hetzci-dev.vedenemo.dev)
+│   ├── hetzci-prod # Ghaf prod CI in hetzner (https://hetzci-prod.vedenemo.dev)
 │   ├── ...
 │   └── testagent # Stand-alone testagent configurations
 │       ├── dev
@@ -73,7 +76,8 @@ The configuration in this repository is split in two parts:
 - `terraform/` directory contains the terraform configuration describing the image-based CI setup in Azure infra. An example instance is the 'prod' instance, which provides the Jenkins interface at: <https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/> as well as the Ghaf nix binary cache at: <https://prod-cache.vedenemo.dev>. The host configuration files in `hosts/azure` describe the NixOS configuration for the `binary-cache`, `builder`, and `jenkins-controller` hosts as outlined in [README-azure.md](https://github.com/tiiuae/ghaf-infra/blob/main/terraform/README-azure.md#image-based-builds).
 - In addition to the terraform Azure infra, this repository contains NixOS configurations for various other stand-alone hosts in Ghaf CI/CD infra.
   Following are examples of some of the stand-alone configurations and their current usage in the CI/CD infrastructure:
-  - `hosts/builders/hetz86` x86_64 remote builder in Hetzner cloud (hetz86.vedenemo.dev). Currently, `hetz86` is used as a remote builder for non-release Jenkins builds.
+  - `hosts/builders/hetz86-1` x86_64 remote builder in Hetzner cloud (hetz86-1.vedenemo.dev). Currently, `hetz86-1` is used as a remote builder for non-release Jenkins builds.
+  - `hosts/builders/hetz86-builder` x86_64 remote builder in Hetzner cloud. Hostname builder.vedenemo.dev will soon point to this host.
   - `hosts/builders/hetzarm` aarch64 remote builder in Hetzner cloud (hetzarm.vedenemo.dev). Developers can use `hetzarm.vedenemo.dev` as a remote builder for Ghaf aarch builds. Additionally, `hetzarm` is used both from Ghaf github actions and non-release Jenkins builds as a remote builder.
   - `hosts/builders/build1` x86_64 remote builder in Ficolo cloud (build1.vedenemo.dev). Currently, `build1` is used as a remote builder for Ghaf github actions (to be retired).
   - `hosts/builders/build2` x86_64 remote builder in Ficolo cloud (build2.vedenemo.dev). Currently, `build2` is not assigned to any specific task (to be retired).

--- a/hosts/builders/hetz86-1/configuration.nix
+++ b/hosts/builders/hetz86-1/configuration.nix
@@ -28,6 +28,7 @@
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       loki_password.owner = "promtail";
+      cachix-auth-token.owner = "root";
     };
   };
 
@@ -37,6 +38,13 @@
   networking = {
     hostName = "hetz86-1";
     useDHCP = true;
+  };
+
+  services.cachix-watch-store = {
+    enable = true;
+    verbose = true;
+    cacheName = "ghaf-dev";
+    cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
 
   services.monitoring = {

--- a/hosts/builders/hetz86-1/secrets.yaml
+++ b/hosts/builders/hetz86-1/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:TbxJiTyqVru8SgppyXwLuGyNOOHrJLxxITjbt4I/QkbPd6lqFwJsqu8GgRBmzhO68F4L+5lzPDDuabHP7o0Nx7G1+gJh4nkO9MItXyjT8iV0RZ4wMsFBUU/278iey9JTDiJ765ZjTdOtIUrdwUk5NM6HxODMHY0b3nGDkQb2LsY27+ZY+gcgY0WrEVhbhqjO5cWTdL9bqiB+bV7GqesDocdpdyWuhw7WW+8oIhQN0A6v3l0IASe8WkVhZvvRz8Ty1qdHnWiYGpG8oRHnsqeQsWdCeGYNz/NklYrx9kqLwDTgTPMZrgLHA4m9a26mMIMUSgSK7lAWGmSWPwf1uc13PyNatZxOWWRFawtawBLJ2jFKbVVIqeXtJC8FYxhkqrWL6SS/JhDDeaWOUYVhhDMf/Xgs3rzE6S93deGbHxQh+vPJktifG78usXq7gZOh2Nz7H/JRJJaPNgBipPc1p+BekXFUGYsSsi6R1rYu11IMhYqmw0Lwy6PnRh31mwmZiTEbQdqQoveyRQKKj7VFJaWM,iv:dF8zf0/7ERAX308CSUWPskWpARkf9IKcloLjJfoIfVc=,tag:NUkBRyUoHzYAMs8h/XWHjg==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:BOt4ZRd0BF8sKrn/dzYMYr+5OGmieKd3SbioIyU+Ix6jJU54KZw+5psq/zsfF9NdQKxHpxsvKg2jCYlVuDdJZthi8xDXTjb7ORLnNCtDDoFlz9AT2zTZICDsF7DRQFOP/Eip0Rb8U+JxC6NdbdOG/g2ekxxLpFF64T15Er+kg+hh2Rde3wcMZ8Cn40sOmH3iFvZ8dYH7,iv:FwN5wIjndncQDGWbSPznWEh4OdLNQWXzQFmuUa1363w=,tag:gHig7eBSwRTCsgAgsYWLyw==,type:str]
 loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
 sops:
     kms: []
@@ -42,8 +43,8 @@ sops:
             NDBHb0x0ZDByN01SQldQaGlNY2VLVWsKr++0Qk9AeBcwxa0gMBuVukBw9UhX59IM
             v+W+hnscpmiPBy6b1oCEKRbtczVYf4opRMaITfLPfDViYdKnJdC+hg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-23T09:38:28Z"
-    mac: ENC[AES256_GCM,data:tnuNzF2d254AkvJLAhhFafHxgn+PdKb0PBLw/nFoPjGaV56ICQJEX4OXk8B04h8qyu03c6zt7/OyFSxO5OPuPs0+ujIk2nVQkLCc7qiQiesdAFcrDZhnniATsjW6quYOEx3kHD4zkPJMQpFjqKLEOX+wDZgl7FixUccrl1ukHo0=,iv:7nldLDL4lTVz2lgy7EuWSAeLAPrBhLNr+YGCJnBmLA8=,tag:pl2VaAKlGczamFWIJywmYA==,type:str]
+    lastmodified: "2025-06-23T13:04:58Z"
+    mac: ENC[AES256_GCM,data:O0fecObqsU30Ra8Bk10qOPk4xAtHbtKuyqiHwYR18u56uUsdHxlBhSE3IFF1wI9OHDrtnbrfvcP2xlTZuU23YEDYoIu/sLJC81Bn/bvwYsK4tDkPfQ2dk3qGKPE5sbyr5EI80SOsDnGiHGGfMZ0jSHIPWYKQdkWRsm+1Gde+Duk=,iv:62XgFe05PH2aRjriDS/bct4/CkLlrksIT6mtvN28cbQ=,tag:88wfGAEdGgp1Lug6Z8pq4g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.9.4

--- a/hosts/hetzci-dev/configuration.nix
+++ b/hosts/hetzci-dev/configuration.nix
@@ -114,7 +114,7 @@ in
     };
     script = ''
       mkdir -p /etc/nix
-      echo "ssh://build2.vedenemo.dev x86_64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >/etc/nix/machines
+      echo "ssh://hetz86-1.vedenemo.dev x86_64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >/etc/nix/machines
       echo "ssh://hetzarm.vedenemo.dev aarch64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >>/etc/nix/machines
     '';
   };
@@ -131,22 +131,15 @@ in
 
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
-    knownHosts."build1.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrcs+NiYzO14n5FystgcN5WJSLeBc+BR67vGs2cwY7d";
-    knownHosts."build2.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILL40b7SbAcL1MK3D5U9IgVRR87myFLTzVdryQnVqb7p";
+    knownHosts."hetz86-1.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
     knownHosts."hetzarm.vedenemo.dev".publicKey =
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''
-      Host build1.vedenemo.dev
-      Hostname build1.vedenemo.dev
-      User remote-build
-      IdentityFile /run/secrets/vedenemo_builder_ssh_key
-
-      Host build2.vedenemo.dev
-      Hostname build2.vedenemo.dev
+      Host hetz86-1.vedenemo.dev
+      Hostname hetz86-1.vedenemo.dev
       User remote-build
       IdentityFile /run/secrets/vedenemo_builder_ssh_key
 

--- a/hosts/hetzci-prod/configuration.nix
+++ b/hosts/hetzci-prod/configuration.nix
@@ -114,7 +114,7 @@ in
     };
     script = ''
       mkdir -p /etc/nix
-      echo "ssh://build2.vedenemo.dev x86_64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >/etc/nix/machines
+      echo "ssh://hetz86-1.vedenemo.dev x86_64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >/etc/nix/machines
       echo "ssh://hetzarm.vedenemo.dev aarch64-linux - 20 10 kvm,nixos-test,benchmark,big-parallel" >>/etc/nix/machines
     '';
   };
@@ -131,22 +131,15 @@ in
 
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
-    knownHosts."build1.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrcs+NiYzO14n5FystgcN5WJSLeBc+BR67vGs2cwY7d";
-    knownHosts."build2.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILL40b7SbAcL1MK3D5U9IgVRR87myFLTzVdryQnVqb7p";
+    knownHosts."hetz86-1.vedenemo.dev".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
     knownHosts."hetzarm.vedenemo.dev".publicKey =
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''
-      Host build1.vedenemo.dev
-      Hostname build1.vedenemo.dev
-      User remote-build
-      IdentityFile /run/secrets/vedenemo_builder_ssh_key
-
-      Host build2.vedenemo.dev
-      Hostname build2.vedenemo.dev
+      Host hetz86-1.vedenemo.dev
+      Hostname hetz86-1.vedenemo.dev
       User remote-build
       IdentityFile /run/secrets/vedenemo_builder_ssh_key
 


### PR DESCRIPTION
- Stop using ficolo builders in hetzci, instead, use hetz86-1 builder
- Enable cachix-watch-store service in hetz86-1
- Update README.md with latest host overview