### PR TITLE
hetzci: Set jenkins home mode

### DIFF
--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -220,6 +220,8 @@ in
       in
       builtins.listToAttrs (map mkJenkinsPlugin manifest);
   };
+  # Jenkins home dir (by default at /var/lib/jenkins) mode needs to be 755
+  users.users.jenkins.homeMode = "755";
 
   systemd.services.jenkins = {
     serviceConfig = {

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -220,6 +220,8 @@ in
       in
       builtins.listToAttrs (map mkJenkinsPlugin manifest);
   };
+  # Jenkins home dir (by default at /var/lib/jenkins) mode needs to be 755
+  users.users.jenkins.homeMode = "755";
 
   systemd.services.jenkins = {
     serviceConfig = {

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -220,6 +220,8 @@ in
       in
       builtins.listToAttrs (map mkJenkinsPlugin manifest);
   };
+  # Jenkins home dir (by default at /var/lib/jenkins) mode needs to be 755
+  users.users.jenkins.homeMode = "755";
 
   systemd.services.jenkins = {
     serviceConfig = {


### PR DESCRIPTION
Set Jenkins home directory (currently at `/var/lib/jenkins`) mode to 755. This does not change the current mode, just states it explicitly to avoid possible issues in case it later changes for one reason or another.