### PR TITLE
hetzci: Run perf test nightly

### DIFF
--- a/hosts/hetzci/dev/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/dev/casc/jenkins-casc.yaml
@@ -51,25 +51,25 @@ jenkins:
         remoteFS: /var/lib/jenkins/agents/lenovo-x1
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: dev-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: dev-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: prod-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: prod-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: release-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: release-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
         labelString: orin-agx

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("generic-x86_64-")) {
-    env.DEVICE_NAME = 'NUC1'
-    env.DEVICE_TAG = 'nuc'
   } else if(params.IMG_URL.contains("microchip-icicle-")) {
     env.DEVICE_NAME = 'Polarfire1'
     env.DEVICE_TAG = 'riscv'

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("microchip-icicle-")) {
-    env.DEVICE_NAME = 'Polarfire1'
-    env.DEVICE_TAG = 'riscv'
   } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
     env.DEVICE_NAME = 'Dell7330'
     env.DEVICE_TAG = 'dell-7330'

--- a/hosts/hetzci/prod/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/prod/casc/jenkins-casc.yaml
@@ -51,25 +51,25 @@ jenkins:
         remoteFS: /var/lib/jenkins/agents/lenovo-x1
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: dev-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: dev-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: prod-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: prod-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: release-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: release-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
         labelString: orin-agx

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("generic-x86_64-")) {
-    env.DEVICE_NAME = 'NUC1'
-    env.DEVICE_TAG = 'nuc'
   } else if(params.IMG_URL.contains("microchip-icicle-")) {
     env.DEVICE_NAME = 'Polarfire1'
     env.DEVICE_TAG = 'riscv'

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("microchip-icicle-")) {
-    env.DEVICE_NAME = 'Polarfire1'
-    env.DEVICE_TAG = 'riscv'
   } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
     env.DEVICE_NAME = 'Dell7330'
     env.DEVICE_TAG = 'dell-7330'

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -8,56 +8,23 @@ def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
-  [ target: "packages.x86_64-linux.doc",
-    testset: null,
-  ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
-    testset: '_relayboot_gui_regression_',
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null,
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx64-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx64-debug-from-x86_64",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.x86_64-linux.generic-x86_64-debug",
-    testset: null,
-  ],
-  [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
-    testset: null,
+    testset: '_relayboot_perf_',
   ],
 ]
 
@@ -67,7 +34,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 23 * * *')
+    cron('H 22 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
@@ -54,7 +54,7 @@ def TARGETS = [
     testset: '_relayboot_regression_',
   ],
   [ target: "packages.x86_64-linux.generic-x86_64-debug",
-    testset: '_relayboot_regression_',
+    testset: null,
   ],
   [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
     testset: null,

--- a/hosts/hetzci/vm/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/vm/casc/jenkins-casc.yaml
@@ -31,25 +31,25 @@ jenkins:
         remoteFS: /var/lib/jenkins/agents/lenovo-x1
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: dev-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: dev-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: prod-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: prod-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
-        labelString: nuc
+        labelString: orin-agx-64
         launcher: inbound
         mode: EXCLUSIVE
-        name: release-nuc
-        remoteFS: /var/lib/jenkins/agents/nuc
+        name: release-orin-agx-64
+        remoteFS: /var/lib/jenkins/agents/orin-agx-64
         retentionStrategy: always
     - permanent:
         labelString: orin-agx

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("generic-x86_64-")) {
-    env.DEVICE_NAME = 'NUC1'
-    env.DEVICE_TAG = 'nuc'
   } else if(params.IMG_URL.contains("microchip-icicle-")) {
     env.DEVICE_NAME = 'Polarfire1'
     env.DEVICE_TAG = 'riscv'

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
@@ -50,9 +50,6 @@ def init() {
   } else if(params.IMG_URL.contains("lenovo-x1-")) {
     env.DEVICE_NAME = 'LenovoX1-1'
     env.DEVICE_TAG = 'lenovo-x1'
-  } else if(params.IMG_URL.contains("microchip-icicle-")) {
-    env.DEVICE_NAME = 'Polarfire1'
-    env.DEVICE_TAG = 'riscv'
   } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
     env.DEVICE_NAME = 'Dell7330'
     env.DEVICE_TAG = 'dell-7330'

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -8,56 +8,23 @@ def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
-  [ target: "packages.x86_64-linux.doc",
-    testset: null,
-  ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
-    testset: '_relayboot_gui_regression_',
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug-installer",
-    testset: null,
-  ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null,
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx64-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx64-debug-from-x86_64",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
-    testset: '_relayboot_regression_',
+    testset: '_relayboot_perf_',
   ],
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
-    testset: '_relayboot_regression_',
-  ],
-  [ target: "packages.x86_64-linux.generic-x86_64-debug",
-    testset: null,
-  ],
-  [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
-    testset: null,
+    testset: '_relayboot_perf_',
   ],
 ]
 
@@ -67,7 +34,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 23 * * *')
+    cron('H 22 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -70,7 +70,7 @@ pipeline {
     cron('H 23 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -54,7 +54,7 @@ def TARGETS = [
     testset: '_relayboot_regression_',
   ],
   [ target: "packages.x86_64-linux.generic-x86_64-debug",
-    testset: '_relayboot_regression_',
+    testset: null,
   ],
   [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
     testset: null,


### PR DESCRIPTION
- Add pipeline 'ghaf-nightly-perftest' with same functionality as [ghaf-perftest-pipeline](https://github.com/tiiuae/ghaf-jenkins-pipeline/blob/main/ghaf-perftest-pipeline.groovy) in the Azure jenkins pipelines
- Retain build logs from nightly triggered pipelines from the last 30 builds instead of 10
- Add 'orin-agx-64' node removing 'nuc' and support for related HW tests, bringing hetzci on-par with Azure with this respect. Ref: [PR#453](https://github.com/tiiuae/ghaf-infra/pull/453), Azure [ghaf-hw-test](https://github.com/tiiuae/ghaf-jenkins-pipeline/blob/6c4fa3fa02a0ecb26953765ce197d68bb4558d2b/ghaf-hw-test.groovy#L200-L209) and [nightly](https://github.com/tiiuae/ghaf-jenkins-pipeline/blob/6c4fa3fa02a0ecb26953765ce197d68bb4558d2b/ghaf-nightly-pipeline.groovy#L131) pipelines.
- Remove HW-test pipeline support for riscv