### PR TITLE
hetzci: Same pipelines in all environments

### DIFF
--- a/hosts/hetzci/README.md
+++ b/hosts/hetzci/README.md
@@ -111,21 +111,9 @@ After testing changes locally in a VM and optionally in a `dev` environment as e
 
 Which would a deploy the changes to https://ci-prod.vedenemo.dev
 
-## Jenkins pipeline overview
+## Jenkins Pipelines
 
-This section summarizes the jenkins pipelines and current availablility in each environment:
-
-|                       | prod | dev | vm |
-|-----------------------|------|-----|----|
-| ghaf-hw-test          | x    | x   | x  |
-| ghaf-main             | x    |     | x  |
-| ghaf-manual           | x    | x   | x  |
-| ghaf-nightly          | x    |     | x  |
-| ghaf-pre-merge        | x    |     | x  |
-| ghaf-pre-merge-manual |      | x   | x  |
-
-
-All pipelines can be tested locally in the `vm` environment, but obviously by default no testagents connect to your localhost, so HW tests would not run for pipelines triggered in local VM.
+All pipelines can be tested locally in the `vm` environment, but obviously no testagents can connect to your localhost, so HW tests would not run for pipelines triggered in a VM.
 
 #### ghaf-hw-test
 Runs Ghaf hw-tests given a ghaf image and a testset. Can be triggered manually to run a hw-test ad-hoc.
@@ -137,7 +125,10 @@ Runs on push to Ghaf main. Triggered by a GitHub webhook sent to `prod` environm
 Allows manually triggering a set of Ghaf builds and optionally run a specified set of hw-tests against the builds.
 
 #### ghaf-nightly
-Triggers nightly on schedule.
+Triggers the main nightly builds and tests on schedule.
+
+#### ghaf-nightly-perftest
+Triggers performance tests nightly on schedule.
 
 #### ghaf-pre-merge
 Runs on all changes to Ghaf PRs authored by tiiuae organization members. Triggered by a GitHub webhook sent to `prod` environment.

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
@@ -1,0 +1,100 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.doc",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx64-debug",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx64-debug-from-x86_64",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_bat_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_bat_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL)
+])
+pipeline {
+  agent { label 'built-in' }
+  triggers {
+    githubPush()
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  stages {
+    // githubPush() trigger requires checkout to be done at least once to
+    // activate the trigger. Therefore, the 'Checkout' stage needs to happen
+    // before 'Reload only', otherwise this pipeline would never trigger
+    // on githubPush().
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            branches: [[name: 'main']],
+            extensions: [[$class: 'WipeWorkspace']],
+            userRemoteConfigs: [[url: REPO_URL]]
+          )
+        }
+      }
+    }
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+}

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
@@ -12,14 +12,14 @@ properties([
   parameters([
     string(name: 'GITREF', defaultValue: 'main', description: 'Ghaf git reference (Commit/Branch/Tag)'),
     string(name: 'TESTSET', defaultValue: null, description: 'By default tests are skipped. To run hw-tests, define the target testset here; e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.)'),
-    booleanParam(name: 'doc', defaultValue: true, description: 'Enable target packages.x86_64-linux.doc'),
-    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
-    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7230-debug'),
-    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7330-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'doc', defaultValue: true, description: 'Build target packages.x86_64-linux.doc'),
+    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
+    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7230-debug'),
+    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7330-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
   ])
 ])
 pipeline {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -33,9 +33,6 @@ properties([
 ])
 pipeline {
   agent { label 'built-in' }
-  triggers {
-    cron('H 22 * * *')
-  }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -1,0 +1,84 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_perf_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_perf_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_perf_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_perf_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_perf_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_perf_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL)
+])
+pipeline {
+  agent { label 'built-in' }
+  triggers {
+    cron('H 22 * * *')
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            branches: [[name: 'main']],
+            extensions: [[$class: 'WipeWorkspace']],
+            userRemoteConfigs: [[url: REPO_URL]]
+          )
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+}

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
@@ -66,9 +66,6 @@ properties([
 ])
 pipeline {
   agent { label 'built-in' }
-  triggers {
-    cron('H 23 * * *')
-  }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
@@ -1,0 +1,117 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.doc",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_gui_regression_',
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release-installer",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-gen11-hardening-debug-installer",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx64-debug",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx64-debug-from-x86_64",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_regression_',
+  ],
+  [ target: "packages.x86_64-linux.generic-x86_64-debug",
+    testset: null,
+  ],
+  [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
+    testset: null,
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL)
+])
+pipeline {
+  agent { label 'built-in' }
+  triggers {
+    cron('H 23 * * *')
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            branches: [[name: 'main']],
+            extensions: [[$class: 'WipeWorkspace']],
+            userRemoteConfigs: [[url: REPO_URL]]
+          )
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+}

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
@@ -1,0 +1,172 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.doc",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
+  // https://www.jenkins.io/doc/pipeline/steps/params/pipelinetriggers/
+  pipelineTriggers([
+    githubPullRequests(
+      spec: '',
+      triggerMode: 'HEAVY_HOOKS',
+      events: [Open(), commitChanged(), close(), nonMergeable(skip: true)],
+      abortRunning: true,
+      cancelQueued: true,
+      preStatus: false,
+      skipFirstRun: false,
+      userRestriction: [users: '', orgs: 'tiiuae'],
+      repoProviders: [
+        githubPlugin(
+          repoPermission: 'PULL'
+        )
+      ]
+    )
+  ])
+])
+
+def setBuildStatus(String message, String state, String commit) {
+  if (!commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  return // TODO: remove this when we start running pre-merge in hetzci-prod
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
+pipeline {
+  agent { label 'built-in' }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          // https://www.jenkins.io/doc/pipeline/steps/params/scmgit/#scmgit
+          // https://github.com/KostyaSha/github-integration-plugin/blob/master/docs/Configuration.adoc
+          checkout scmGit(
+            userRemoteConfigs: [[
+              url: REPO_URL,
+              name: 'pr_origin',
+              // Below, we set two git remotes: 'pr_origin' and 'origin'
+              // We use '/merge' in pr_origin to build the PR as if it was
+              // merged to the PR target branch GITHUB_PR_TARGET_BRANCH.
+              // To build the PR head (without merge) you would replace
+              // '/merge' with '/head' in the pr_origin remote. We also
+              // need to set the 'origin' remote to be able to compare
+              // the PR changes against the correct target.
+              refspec: '+refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/pr_origin/pull/${GITHUB_PR_NUMBER}/merge +refs/heads/*:refs/remotes/origin/*',
+            ]],
+            branches: [[name: 'pr_origin/pull/${GITHUB_PR_NUMBER}/merge']],
+            extensions: [
+              [$class: 'WipeWorkspace'],
+              // We use the 'changelogToBranch' extension to correctly
+              // show the PR changed commits in Jenkins changes.
+              // References:
+              // https://issues.jenkins.io/browse/JENKINS-26354
+              // https://javadoc.jenkins.io/plugin/git/hudson/plugins/git/extensions/impl/ChangelogToBranch.html
+              changelogToBranch (
+                options: [
+                  compareRemote: 'origin',
+                  compareTarget: "${GITHUB_PR_TARGET_BRANCH}"
+                ]
+              )
+            ],
+          )
+          script {
+            sh 'git fetch pr_origin pull/${GITHUB_PR_NUMBER}/head:PR_head'
+            env.TARGET_COMMIT = sh(script: 'git rev-parse PR_head', returnStdout: true).trim()
+            println "TARGET_COMMIT: ${env.TARGET_COMMIT}"
+          }
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            setBuildStatus("Manual trigger: pending", "pending", env.TARGET_COMMIT)
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      script {
+        setBuildStatus("Manual trigger: success", "success", env.TARGET_COMMIT)
+      }
+    }
+    unsuccessful {
+      script {
+        setBuildStatus("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+      }
+    }
+  }
+}

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
@@ -59,7 +59,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '50'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -66,4 +66,26 @@ def create_pipeline(List<Map> targets) {
   return pipeline
 }
 
+def setBuildStatus(String message, String state, String commit) {
+  if (!commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  println "Setting GitHub commit status"
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
 return this

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
@@ -12,14 +12,14 @@ properties([
   parameters([
     string(name: 'GITREF', defaultValue: 'main', description: 'Ghaf git reference (Commit/Branch/Tag)'),
     string(name: 'TESTSET', defaultValue: null, description: 'By default tests are skipped. To run hw-tests, define the target testset here; e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.)'),
-    booleanParam(name: 'doc', defaultValue: true, description: 'Enable target packages.x86_64-linux.doc'),
-    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
-    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7230-debug'),
-    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7330-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'doc', defaultValue: true, description: 'Build target packages.x86_64-linux.doc'),
+    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
+    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7230-debug'),
+    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7330-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
   ])
 ])
 pipeline {

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge-manual.groovy
@@ -1,0 +1,145 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.doc",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
+  parameters([
+    string(name: 'GITHUB_PR_NUMBER', defaultValue: '', description: 'Ghaf PR number'),
+    booleanParam(name: 'SET_PR_STATUS', defaultValue: true, description: 'Write the commit status in GitHub PR')
+  ])
+])
+
+////////////////////////////////////////////////////////////////////////////////
+
+def setBuildStatus(String message, String state, String commit) {
+  if (!params.SET_PR_STATUS || !commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pipeline {
+  agent { label 'built-in' }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            userRemoteConfigs: [[
+              url: REPO_URL,
+              name: 'pr_origin',
+              // Below, we set the git remote: 'pr_origin'.
+              // We use '/merge' in pr_origin to build the PR as if it was
+              // merged to the PR target branch. To build the PR head (without
+              // merge) you would replace '/merge' with '/head'.
+              refspec: "+refs/pull/${params.GITHUB_PR_NUMBER}/merge:refs/remotes/pr_origin/pull/${params.GITHUB_PR_NUMBER}/merge",
+            ]],
+            branches: [[name: "pr_origin/pull/${params.GITHUB_PR_NUMBER}/merge"]],
+            extensions: [
+              [$class: 'WipeWorkspace'],
+            ],
+          )
+          script {
+            sh "git fetch pr_origin pull/${params.GITHUB_PR_NUMBER}/head:PR_head"
+            env.TARGET_COMMIT = sh(script: 'git rev-parse PR_head', returnStdout: true).trim()
+            println "TARGET_COMMIT: ${env.TARGET_COMMIT}"
+          }
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            setBuildStatus("Manual trigger: pending", "pending", env.TARGET_COMMIT)
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      script {
+        setBuildStatus("Manual trigger: success", "success", env.TARGET_COMMIT)
+      }
+    }
+    unsuccessful {
+      script {
+        setBuildStatus("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+      }
+    }
+  }
+}

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge.groovy
@@ -59,7 +59,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '50'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -66,4 +66,26 @@ def create_pipeline(List<Map> targets) {
   return pipeline
 }
 
+def setBuildStatus(String message, String state, String commit) {
+  if (!commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  println "Setting GitHub commit status"
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
 return this

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
@@ -12,14 +12,14 @@ properties([
   parameters([
     string(name: 'GITREF', defaultValue: 'main', description: 'Ghaf git reference (Commit/Branch/Tag)'),
     string(name: 'TESTSET', defaultValue: null, description: 'By default tests are skipped. To run hw-tests, define the target testset here; e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.)'),
-    booleanParam(name: 'doc', defaultValue: true, description: 'Enable target packages.x86_64-linux.doc'),
-    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
-    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7230-debug'),
-    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Enable target packages.x86_64-linux.dell-latitude-7330-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Enable target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
-    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Enable target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'doc', defaultValue: true, description: 'Build target packages.x86_64-linux.doc'),
+    booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
+    booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7230-debug'),
+    booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7330-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
   ])
 ])
 pipeline {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
@@ -1,0 +1,172 @@
+#!/usr/bin/env groovy
+
+import groovy.transform.Field
+@Field def MODULES = [:]
+
+def REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def WORKDIR  = 'checkout'
+def PIPELINE = [:]
+
+def TARGETS = [
+  [ target: "packages.x86_64-linux.doc",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
+    testset: null,
+  ],
+  [ target: "packages.x86_64-linux.dell-latitude-7330-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug",
+    testset: '_relayboot_pre-merge_',
+  ],
+  [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
+    testset: '_relayboot_pre-merge_',
+  ],
+]
+
+properties([
+  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
+  // https://www.jenkins.io/doc/pipeline/steps/params/pipelinetriggers/
+  pipelineTriggers([
+    githubPullRequests(
+      spec: '',
+      triggerMode: 'HEAVY_HOOKS',
+      events: [Open(), commitChanged(), close(), nonMergeable(skip: true)],
+      abortRunning: true,
+      cancelQueued: true,
+      preStatus: false,
+      skipFirstRun: false,
+      userRestriction: [users: '', orgs: 'tiiuae'],
+      repoProviders: [
+        githubPlugin(
+          repoPermission: 'PULL'
+        )
+      ]
+    )
+  ])
+])
+
+def setBuildStatus(String message, String state, String commit) {
+  if (!commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  return // TODO: remove this when we start running pre-merge in hetzci-prod
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
+pipeline {
+  agent { label 'built-in' }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+  }
+  stages {
+    stage('Reload only') {
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          // https://www.jenkins.io/doc/pipeline/steps/params/scmgit/#scmgit
+          // https://github.com/KostyaSha/github-integration-plugin/blob/master/docs/Configuration.adoc
+          checkout scmGit(
+            userRemoteConfigs: [[
+              url: REPO_URL,
+              name: 'pr_origin',
+              // Below, we set two git remotes: 'pr_origin' and 'origin'
+              // We use '/merge' in pr_origin to build the PR as if it was
+              // merged to the PR target branch GITHUB_PR_TARGET_BRANCH.
+              // To build the PR head (without merge) you would replace
+              // '/merge' with '/head' in the pr_origin remote. We also
+              // need to set the 'origin' remote to be able to compare
+              // the PR changes against the correct target.
+              refspec: '+refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/pr_origin/pull/${GITHUB_PR_NUMBER}/merge +refs/heads/*:refs/remotes/origin/*',
+            ]],
+            branches: [[name: 'pr_origin/pull/${GITHUB_PR_NUMBER}/merge']],
+            extensions: [
+              [$class: 'WipeWorkspace'],
+              // We use the 'changelogToBranch' extension to correctly
+              // show the PR changed commits in Jenkins changes.
+              // References:
+              // https://issues.jenkins.io/browse/JENKINS-26354
+              // https://javadoc.jenkins.io/plugin/git/hudson/plugins/git/extensions/impl/ChangelogToBranch.html
+              changelogToBranch (
+                options: [
+                  compareRemote: 'origin',
+                  compareTarget: "${GITHUB_PR_TARGET_BRANCH}"
+                ]
+              )
+            ],
+          )
+          script {
+            sh 'git fetch pr_origin pull/${GITHUB_PR_NUMBER}/head:PR_head'
+            env.TARGET_COMMIT = sh(script: 'git rev-parse PR_head', returnStdout: true).trim()
+            println "TARGET_COMMIT: ${env.TARGET_COMMIT}"
+          }
+        }
+      }
+    }
+    stage('Setup') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            setBuildStatus("Manual trigger: pending", "pending", env.TARGET_COMMIT)
+            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
+            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            parallel PIPELINE
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      script {
+        setBuildStatus("Manual trigger: success", "success", env.TARGET_COMMIT)
+      }
+    }
+    unsuccessful {
+      script {
+        setBuildStatus("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+      }
+    }
+  }
+}

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
@@ -59,7 +59,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '50'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -66,4 +66,26 @@ def create_pipeline(List<Map> targets) {
   return pipeline
 }
 
+def setBuildStatus(String message, String state, String commit) {
+  if (!commit) {
+    println "Skip setting GitHub commit status"
+    return
+  }
+  println "Setting GitHub commit status"
+  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+    env.TOKEN = "$TOKEN"
+    String status_url = "https://api.github.com/repos/tiiuae/ghaf/statuses/$commit"
+    sh """
+      # set -x
+      curl -H \"Authorization: token \$TOKEN\" \
+        -X POST \
+        -d '{\"description\": \"$message\", \
+             \"state\": \"$state\", \
+             \"context\": "jenkins-pre-merge", \
+             \"target_url\" : \"$BUILD_URL\" }' \
+        ${status_url}
+    """
+  }
+}
+
 return this


### PR DESCRIPTION
- Make all pipelines available in all Hetzner environments as requested by @milva-unikie, @azbeleva  and @leivos-unikie. However, I assume we don't want to auto-trigger nightly pipelines both in `prod` and `dev`, therefore this PR disables the cron trigger in nightly pipelines on `dev`
- Move the `setBuildStatus` function to `utils.groovy` now that it is used by many pipelines
- Retain 50 latest ghaf-pre-merge pipeline Jenkins build logs instead of 10
- Update README to match the changes from this PR

These changes have been deployed both to [dev](https://ci-dev.vedenemo.dev/) and [prod](https://ci-prod.vedenemo.dev/) already