### PR TITLE
hetzci: Fix issue creating jenkins artifacts local dir

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -6,13 +6,13 @@ def run_cmd(String cmd) {
 
 def create_pipeline(List<Map> targets) {
   def pipeline = [:]
-  def stamp = run_cmd('date +"%Y%m%d_%H%M%S"')
+  def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def commit = run_cmd('git rev-parse HEAD')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -p ${artifacts_local_dir}"
+  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -6,13 +6,13 @@ def run_cmd(String cmd) {
 
 def create_pipeline(List<Map> targets) {
   def pipeline = [:]
-  def stamp = run_cmd('date +"%Y%m%d_%H%M%S"')
+  def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def commit = run_cmd('git rev-parse HEAD')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -p ${artifacts_local_dir}"
+  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -6,13 +6,13 @@ def run_cmd(String cmd) {
 
 def create_pipeline(List<Map> targets) {
   def pipeline = [:]
-  def stamp = run_cmd('date +"%Y%m%d_%H%M%S"')
+  def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def commit = run_cmd('git rev-parse HEAD')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -p ${artifacts_local_dir}"
+  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {


### PR DESCRIPTION
- Run `sync` after `mkdir -p` in an attempt to fix an issue where `mkdir -p` exits with no error, but directory is not created on the filesystem. Also, make `mkdir` verbose the log some more information in case the issue still occurs. Example build where the issue occured: https://ci-prod.vedenemo.dev/job/ghaf-pre-merge/18/, see the 'doc' target build.
- Make the timestamp in the artifacts directory (URL) millisecond precision to prevent a possible mix-up of the artifacts that might have been caused if the same pipeline was triggered twice on the same target commit less than one second apart.
  - Example artifact URL before this change: https://ci-prod.vedenemo.dev/artifacts/ghaf-pre-merge/20250702_090025-commit_876af3c32e05a1ed75b93b838a5c5fad238c3496/
  - Example artifact URL after this change: https://ci-dev.vedenemo.dev/artifacts/ghaf-manual/20250702_111646103-commit_7fb150daf3688c54db056d369b24acb0a235fa42/