### PR TITLE
hetzci: Fix dell tests in ghaf-manual pipeline

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
@@ -64,11 +64,11 @@ pipeline {
             }
             if (params.dell_latitude_7230_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: params.TESTSET ])
+                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: null ])
             }
             if (params.dell_latitude_7330_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: null ])
+                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: params.TESTSET ])
             }
             if (params.nvidia_jetson_orin_agx_debug_from_x86_64) {
               TARGETS.push(

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
@@ -64,11 +64,11 @@ pipeline {
             }
             if (params.dell_latitude_7230_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: params.TESTSET ])
+                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: null ])
             }
             if (params.dell_latitude_7330_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: null ])
+                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: params.TESTSET ])
             }
             if (params.nvidia_jetson_orin_agx_debug_from_x86_64) {
               TARGETS.push(

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
@@ -64,11 +64,11 @@ pipeline {
             }
             if (params.dell_latitude_7230_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: params.TESTSET ])
+                [ target: "packages.x86_64-linux.dell-latitude-7230-debug", testset: null ])
             }
             if (params.dell_latitude_7330_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: null ])
+                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: params.TESTSET ])
             }
             if (params.nvidia_jetson_orin_agx_debug_from_x86_64) {
               TARGETS.push(


### PR DESCRIPTION
Fix a mix-up in ghaf-manual pipeline: we have no test hardware for dell-latitude-7230-debug so we should not execute any tests for it. Instead, tests should be executed for dell-latitude-7330-debug.