### PR TITLE
hetzci: Change cron schedule for nightly triggered pipelines

### DIFF
--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -34,7 +34,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 22 * * *')
+    cron('0 0 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
@@ -67,7 +67,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 23 * * *')
+    cron('0 20 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -34,7 +34,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 22 * * *')
+    cron('0 0 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -67,7 +67,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   triggers {
-    cron('H 23 * * *')
+    cron('0 20 * * *')
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))


### PR DESCRIPTION
Trigger nightly pipelines on exact same schedule as in the [Azure pipelines](https://github.com/tiiuae/ghaf-jenkins-pipeline/tree/main):
- ghaf-nightly: daily at 20:00 UTC
- ghaf-nightly-perftest: daily at 00:00 UTC