### PR TITLE
hetzci: Fix missing artifacts directory

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -12,7 +12,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -28,7 +27,7 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "cp -P ${it.target} ${artifacts_local_dir}/"
+        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
       }
       // Test
       if (it.testset != null && !it.testset.isEmpty()) {

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -12,7 +12,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -28,7 +27,7 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "cp -P ${it.target} ${artifacts_local_dir}/"
+        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
       }
       // Test
       if (it.testset != null && !it.testset.isEmpty()) {

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -12,7 +12,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   currentBuild.description = "${artifacts_href}"
-  sh "mkdir -v -p ${artifacts_local_dir}; sync"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -28,7 +27,7 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "cp -P ${it.target} ${artifacts_local_dir}/"
+        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
       }
       // Test
       if (it.testset != null && !it.testset.isEmpty()) {


### PR DESCRIPTION
This is another fix for the same issue discussed earlier at: https://github.com/tiiuae/ghaf-infra/pull/509:
- `sync` should not be needed with `mkdir -p`
- What happens is, if there's delay between when the local artifact directory is created and when it's used, `jenkins-purge-artifacts` service removes the directory as if it was no longer needed. Moving the `mkdir` to the same shell command where the directory is used gets rid of this problem.