### PR TITLE
Start monitoring hetzci-dev and -prod

### DIFF
--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -23,6 +23,7 @@ in
     ++ (with self.nixosModules; [
       common
       service-openssh
+      service-monitoring
       team-devenv
     ]);
 
@@ -324,12 +325,25 @@ in
       jenkins_api_token.owner = "jenkins";
       jenkins_github_webhook_secret.owner = "jenkins";
       jenkins_github_commit_status_token.owner = "jenkins";
+      loki_password.owner = "promtail";
     };
     templates.oauth2_proxy_env = {
       content = ''
         OAUTH2_PROXY_COOKIE_SECRET=${config.sops.placeholder.oauth2_proxy_cookie_secret}
       '';
       owner = "oauth2-proxy";
+    };
+  };
+
+  services.monitoring = {
+    metrics = {
+      enable = true;
+      ssh = true;
+    };
+    logs = {
+      enable = true;
+      lokiAddress = "https://monitoring.vedenemo.dev";
+      auth.password_file = config.sops.secrets.loki_password.path;
     };
   };
 

--- a/hosts/hetzci/dev/secrets.yaml
+++ b/hosts/hetzci/dev/secrets.yaml
@@ -4,12 +4,9 @@ oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:2peVU6TWd+OZ1AcD6+Cnsof6pYzkX5nQ
 jenkins_api_token: ENC[AES256_GCM,data:paXifH4nATF+6FqSv+ReDRGbsbEXbQ+SOKqaV9VFgNABLA==,iv:8dd7FvRhuW1VDaElgqaSQL1SxFHl+OugqIIRBGJ+Ls8=,tag:htfuumutvgGuy2gzcAq28A==,type:str]
 jenkins_github_webhook_secret: ENC[AES256_GCM,data:Xx604eclt+klNONw+VI/6duKWQj8yzcXfk3LnrdfxY8=,iv:tP5Y1Yr6pcnbk7YxdMAq+tztoUTSE3ua5j9DDLVKfoM=,tag:nFyPrZFxMHHPI+RF0EPGSw==,type:str]
 jenkins_github_commit_status_token: ENC[AES256_GCM,data:ftIy9XXgLebpB+51dfnkhP33FWKYtaknRATJ+UslS9r3pCkNEBlB2Q==,iv:xUaHChYVL3VS0stcuHUIJxr41KVlbMw5IXYmS+T4Eb8=,tag:QJBtEnUU3Ne/eBQAbfDNWg==,type:str]
+loki_password: ENC[AES256_GCM,data:j2oxnJe+/xaiMqGbZB43+lEkOA==,iv:/QXPvCSd7luS7X3GxD6ZjlidojD9jZvyZMqpxJgz7ZA=,tag:Cj0jSC2AN4GL1lBYaqYHxQ==,type:str]
 vedenemo_builder_ssh_key: ENC[AES256_GCM,data:w5iotEvbKgW1rM19DF9MWwENYFMXLel+kYkP+pOADImQpTi80HInX5DH8xZH0pMXmKwoMdmZ2OxObEZttXHI9geZ1/lbAkOYTEzRIdeVzyBDvNfI0mCd32YnNmJJr7lHAtf2rKLpie1nioByVFNa4jobwrC+Nwv65upEBCaZkweNchsJhMwkXA3FWXHmM+AOnR97jAwrCjmT5eqLD+H0O5WQT00NdRZ08Huuvmh9JMzlHmhP6+B9gSDn44bbS/Yz2YWb1CjLMYti46jOMH1SXoQrEV+34w1To1mFb9d+K54GgL7hSz+021POgyrXNGYjxPDGf1ZeLwmZ793LsAXzYA5VHmaU6uW2KqYY4YfNIaz7fz3Ex+pUN3awS/em9VBy3VFzpRNGJwny0+i46keWHNbN5w5D3vLeawcY3sGNdw9ZpSCRUUNU6IfEAHww1QMGk+Q3bmZdU7DaR5el9UHxNJBlv5XNrHJ+uOXIvkDIhz5qNZp8l2iVTatcdfVDSWFObHLg,iv:v9+3cStSVh7NYeyOU29bQw2mS2PyYSNymgmsbTez590=,tag:4OIm90aTMoFWl9+Czr4AlQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age10xhyyjrhackyac2f042t3z8yqld3sh39ul3mukwkt6gyr7gn9upq8n30gm
           enc: |
@@ -38,8 +35,7 @@ sops:
             TDRuK3Vhb1lMZ2owdjJLUjRGS0VMa3cKF+7Q7xRFyYd6U8apfqlpWEiJ7xsF//xJ
             zpc1bxl7gLKs9EH3kdv8ATYZzGXC/UCd9ccpmy9TYDogTcIqOGZYtQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-19T06:53:04Z"
-    mac: ENC[AES256_GCM,data:ZWPCaSi9h3DkDjArmsbh98yTEBJPAwzqvNE6IKZI7y25nlP0pfMNjZ4RqFH/cKNgZhWIPLvWn/qplSvYD3mQD4weS0yI4oWasqY4+8of2uG1yqeZu0bDgbHiiD7DR1ufOqNvy6GMPuzA8Ei1/RSipIZl1mEWEu+304HzlQ2kwGI=,iv:7ussTRztXL03rjcGKHggGkdLeRKPyj/YDppvbPS5GYM=,tag:JJ2Ohf+6AkRDnn53JwHX9Q==,type:str]
-    pgp: []
+    lastmodified: "2025-07-07T15:34:01Z"
+    mac: ENC[AES256_GCM,data:n1QHXIndD2Rvb7s47j09gxJDicI/2ZaJgm4AIrurot+VMkZnwRPQnA6QOkmHwzgu4jfGb160PntK/rVrngmj8kHajrEmpvP5/jdiCqcF8MYSXMWQLWK4eM7Of6IMCDCfKVSyMIB0zrdklzkqigLmlaD2QkOjXY9LiWIL/HFX30Q=,iv:Jt3pUt1zutBmrHQavA/3EZKwsIpxij8JtnTDTDB4Ghs=,tag:y0HEAtGYxokOXG3vE4eliQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.4
+    version: 3.10.2

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -23,6 +23,7 @@ in
     ++ (with self.nixosModules; [
       common
       service-openssh
+      service-monitoring
       team-devenv
     ]);
 
@@ -324,12 +325,25 @@ in
       jenkins_api_token.owner = "jenkins";
       jenkins_github_webhook_secret.owner = "jenkins";
       jenkins_github_commit_status_token.owner = "jenkins";
+      loki_password.owner = "promtail";
     };
     templates.oauth2_proxy_env = {
       content = ''
         OAUTH2_PROXY_COOKIE_SECRET=${config.sops.placeholder.oauth2_proxy_cookie_secret}
       '';
       owner = "oauth2-proxy";
+    };
+  };
+
+  services.monitoring = {
+    metrics = {
+      enable = true;
+      ssh = true;
+    };
+    logs = {
+      enable = true;
+      lokiAddress = "https://monitoring.vedenemo.dev";
+      auth.password_file = config.sops.secrets.loki_password.path;
     };
   };
 

--- a/hosts/hetzci/prod/secrets.yaml
+++ b/hosts/hetzci/prod/secrets.yaml
@@ -4,12 +4,9 @@ oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:2peVU6TWd+OZ1AcD6+Cnsof6pYzkX5nQ
 jenkins_api_token: ENC[AES256_GCM,data:paXifH4nATF+6FqSv+ReDRGbsbEXbQ+SOKqaV9VFgNABLA==,iv:8dd7FvRhuW1VDaElgqaSQL1SxFHl+OugqIIRBGJ+Ls8=,tag:htfuumutvgGuy2gzcAq28A==,type:str]
 jenkins_github_webhook_secret: ENC[AES256_GCM,data:Xx604eclt+klNONw+VI/6duKWQj8yzcXfk3LnrdfxY8=,iv:tP5Y1Yr6pcnbk7YxdMAq+tztoUTSE3ua5j9DDLVKfoM=,tag:nFyPrZFxMHHPI+RF0EPGSw==,type:str]
 jenkins_github_commit_status_token: ENC[AES256_GCM,data:ftIy9XXgLebpB+51dfnkhP33FWKYtaknRATJ+UslS9r3pCkNEBlB2Q==,iv:xUaHChYVL3VS0stcuHUIJxr41KVlbMw5IXYmS+T4Eb8=,tag:QJBtEnUU3Ne/eBQAbfDNWg==,type:str]
+loki_password: ENC[AES256_GCM,data:tyf1ohJPWrLSAqCdL0u8MWddow==,iv:lWi9++mAe1YYVqExJS3n66tgaCeOCEGEvCYzX4laDVc=,tag:YebhDNCzvwH8u7/PDeVS3w==,type:str]
 vedenemo_builder_ssh_key: ENC[AES256_GCM,data:w5iotEvbKgW1rM19DF9MWwENYFMXLel+kYkP+pOADImQpTi80HInX5DH8xZH0pMXmKwoMdmZ2OxObEZttXHI9geZ1/lbAkOYTEzRIdeVzyBDvNfI0mCd32YnNmJJr7lHAtf2rKLpie1nioByVFNa4jobwrC+Nwv65upEBCaZkweNchsJhMwkXA3FWXHmM+AOnR97jAwrCjmT5eqLD+H0O5WQT00NdRZ08Huuvmh9JMzlHmhP6+B9gSDn44bbS/Yz2YWb1CjLMYti46jOMH1SXoQrEV+34w1To1mFb9d+K54GgL7hSz+021POgyrXNGYjxPDGf1ZeLwmZ793LsAXzYA5VHmaU6uW2KqYY4YfNIaz7fz3Ex+pUN3awS/em9VBy3VFzpRNGJwny0+i46keWHNbN5w5D3vLeawcY3sGNdw9ZpSCRUUNU6IfEAHww1QMGk+Q3bmZdU7DaR5el9UHxNJBlv5XNrHJ+uOXIvkDIhz5qNZp8l2iVTatcdfVDSWFObHLg,iv:v9+3cStSVh7NYeyOU29bQw2mS2PyYSNymgmsbTez590=,tag:4OIm90aTMoFWl9+Czr4AlQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1av993eefvndhv2apa4x7tpc7ezyhuj3jz9866vtulnrdwmjqe5hqrjc2z8
           enc: |
@@ -38,8 +35,7 @@ sops:
             MVd4MzZZcjlPTGptL0cyZnY2NldWRFkKgGSHqIHOfYPGxfBTwp97qqCWNTc489Jb
             jpA6QIU1VSNsg//J3BqQvNDMZbUrq+EK6RFDYyVDguv/sYSZqkeEOg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-21T06:26:06Z"
-    mac: ENC[AES256_GCM,data:Sz+bWrVru7gpjcX8XFDOLftyPp/cGP/W+MhngSQWJwo+fXxKx7ho41zc7lcPxhXf2xfp4LxuBr8/EiTqQBTwM+t77Z8WLG01ntZdU4Bftzdmk+u92J6TSwDaMvj+6wyM1LITukas19ZO6V3AcCPeg5OJSYDYrAj0fZtpGsL8io0=,iv:Ib+LkwWyVkgSra6uUZl5kIisbVEyDnhxm8Ui9avzKOE=,tag:gcpTqPF96i3YtuG+uioN5Q==,type:str]
-    pgp: []
+    lastmodified: "2025-07-07T15:34:25Z"
+    mac: ENC[AES256_GCM,data:0lXq9Rxn+vofi8uDCBYXqbuc+OJnUJAau40e8Q9LhlL0Qndv5ObS2BmoaGMGCmhSW59f0ZaQ9bmY2qC3hYLkUXJPCSShAYznGA33r5TZ7Y4aE3iGv5xgAGdAcC0fB3MN5vGG5YOeIxgEmFkPA5g5HJZBBU2PQAYivmQVIZunASM=,iv:Fhb3OYQD6W0HwVL+wpM9/KpGEvsCBLKroN8cnMkrijg=,tag:nvFfD7BvpU3fSZrw6VF92Q==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.4
+    version: 3.10.2

--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -63,6 +63,10 @@ in
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
     "65.108.7.79".publicKey =
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG68NdmOw3mhiBZwDv81dXitePoc1w//p/LpsHHA8QRp";
+    "157.180.119.138".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ8XgXW7leM8yIOyU86aDztcWBGKkBAgTiu5yaAcJcvD";
+    "157.180.43.236".publicKey =
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBdDmtt7At/xDNCF0aIDvXc2T9GTP0HWaAt4DEAejcE6";
   };
 
   systemd.services.populate-jenkins-known-hosts = {
@@ -368,6 +372,18 @@ in
             targets = [ "37.27.190.109:9100" ];
             labels = {
               machine_name = "ghaf-auth";
+            };
+          }
+          {
+            targets = [ "157.180.119.138:9100" ];
+            labels = {
+              machine_name = "hetzci-dev";
+            };
+          }
+          {
+            targets = [ "157.180.43.236:9100" ];
+            labels = {
+              machine_name = "hetzci-prod";
             };
           }
         ];

--- a/hosts/monitoring/configuration.nix
+++ b/hosts/monitoring/configuration.nix
@@ -398,7 +398,6 @@ in
           {
             targets = [
               "ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com"
-              "prod-cache.vedenemo.dev"
             ];
             labels = {
               env = "prod";


### PR DESCRIPTION
- Monitor metrics of `hetzci-dev` and `hetzci-prod` through sshified. Also send logs to Loki.
- Stop monitoring `prod-cache.vedenemo.dev`

Currently these changes are deployed to monitoring server and ci-dev