### PR TITLE
Pin deploy-rs to old version to fix regression

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1749105467,
-        "narHash": "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=",
+        "lastModified": 1749102428,
+        "narHash": "sha256-6Tw+M4WWOcmEXNCvx8+rNABDSW2gizB4ijEqys6uXKM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "6bc76b872374845ba9d645a2f012b764fecd765f",
+        "rev": "5829cec63845eb50984dc8787b0edfe81bf5b980",
         "type": "github"
       },
       "original": {
         "owner": "serokell",
         "repo": "deploy-rs",
+        "rev": "5829cec63845eb50984dc8787b0edfe81bf5b980",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,9 @@
 
     # Used for deploying remote systems
     deploy-rs = {
-      url = "github:serokell/deploy-rs";
+      # pinned until this regression is fixed
+      # https://github.com/serokell/deploy-rs/issues/325
+      url = "github:serokell/deploy-rs/5829cec63845eb50984dc8787b0edfe81bf5b980";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-compat.follows = "flake-compat";

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -73,7 +73,6 @@
             reuse
             sops
             ssh-to-age
-            deploy-rs
             wget
             terragrunt
             (terraform.withPlugins (p: [
@@ -104,9 +103,10 @@
               p.sops
             ]))
           ])
-          ++ [
-            inputs'.nix-fast-build.packages.default
-          ];
+          ++ (with inputs'; [
+            nix-fast-build.packages.default
+            deploy-rs.packages.default
+          ]);
       };
     };
 }


### PR DESCRIPTION
With the flake update to nixos 25.05, deploy-rs was also updated to the newest version. This version breaks passing multiple `--targets` and build args (https://github.com/serokell/deploy-rs/issues/325).

As there is no upstream fix yet, I've pinned it to an older commit for now.