### PR TITLE
Use a shared machine details file

### DIFF
--- a/hosts/azure/jenkins-controller/configuration.nix
+++ b/hosts/azure/jenkins-controller/configuration.nix
@@ -5,6 +5,7 @@
   self,
   lib,
   inputs,
+  machines,
   ...
 }:
 let
@@ -223,27 +224,19 @@ in
   users.users = {
     testagent-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4 root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-dev.publicKey ];
     };
     testagent-prod = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-prod.publicKey ];
     };
     testagent-release = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H mytarget"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-release.publicKey ];
     };
     testagent-uae-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS root@fayad-X1-testagent"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-uae-dev.publicKey ];
     };
   };
 

--- a/hosts/builders/build3/configuration.nix
+++ b/hosts/builders/build3/configuration.nix
@@ -4,6 +4,7 @@
   self,
   inputs,
   config,
+  machines,
   ...
 }:
 {
@@ -63,7 +64,6 @@
   };
 
   programs.ssh.knownHosts = {
-    "hetzarm.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    "hetzarm.vedenemo.dev".publicKey = machines.hetzarm.publicKey;
   };
 }

--- a/hosts/builders/hetz86-builder/configuration.nix
+++ b/hosts/builders/hetz86-builder/configuration.nix
@@ -4,6 +4,7 @@
   self,
   inputs,
   config,
+  machines,
   ...
 }:
 {
@@ -63,8 +64,7 @@
   };
 
   programs.ssh.knownHosts = {
-    "hetzarm.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    "hetzarm.vedenemo.dev".publicKey = machines.hetzarm.publicKey;
   };
 
   services.monitoring = {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -8,9 +8,11 @@
   ...
 }:
 let
+  machines = import ./machines.nix;
+
   # make self and inputs available in nixos modules
   specialArgs = {
-    inherit self inputs;
+    inherit self inputs machines;
   };
 
   # Calls nixosSystem with a toplevel config
@@ -109,9 +111,7 @@ in
     ))
     // {
       hetzci-vm = inputs.nixpkgs.lib.nixosSystem {
-        specialArgs = {
-          inherit inputs self;
-        };
+        inherit specialArgs;
         modules = [
           (import ./vm-nixos-qemu.nix {
             disk_gb = 200;

--- a/hosts/ficolo-common.nix
+++ b/hosts/ficolo-common.nix
@@ -1,7 +1,12 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-{ self, lib, ... }:
+{
+  self,
+  lib,
+  machines,
+  ...
+}:
 {
   imports = [ self.nixosModules.service-monitoring ];
 
@@ -12,6 +17,6 @@
 
   services.monitoring = {
     metrics.openFirewall = true;
-    logs.lokiAddress = lib.mkDefault "http://172.18.20.108";
+    logs.lokiAddress = lib.mkDefault "http://${machines.monitoring.ip}";
   };
 }

--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -7,6 +7,7 @@
   modulesPath,
   lib,
   config,
+  machines,
   ...
 }:
 let
@@ -100,27 +101,19 @@ in
   users.users = {
     testagent-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4 root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-dev.publicKey ];
     };
     testagent-prod = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-prod.publicKey ];
     };
     testagent-release = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H mytarget"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-release.publicKey ];
     };
     testagent-uae-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS root@fayad-X1-testagent"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-uae-dev.publicKey ];
     };
   };
 
@@ -150,10 +143,10 @@ in
 
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
-    knownHosts."hetz86-1.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
-    knownHosts."hetzarm.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    knownHosts = {
+      "hetz86-1.vedenemo.dev".publicKey = machines.hetz86-1.publicKey;
+      "hetzarm.vedenemo.dev".publicKey = machines.hetzarm.publicKey;
+    };
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -7,6 +7,7 @@
   modulesPath,
   lib,
   config,
+  machines,
   ...
 }:
 let
@@ -100,27 +101,19 @@ in
   users.users = {
     testagent-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4 root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-dev.publicKey ];
     };
     testagent-prod = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-prod.publicKey ];
     };
     testagent-release = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H mytarget"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-release.publicKey ];
     };
     testagent-uae-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS root@fayad-X1-testagent"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-uae-dev.publicKey ];
     };
   };
 
@@ -150,10 +143,10 @@ in
 
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
-    knownHosts."hetz86-1.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
-    knownHosts."hetzarm.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    knownHosts = {
+      "hetz86-1.vedenemo.dev".publicKey = machines.hetz86-1.publicKey;
+      "hetzarm.vedenemo.dev".publicKey = machines.hetzarm.publicKey;
+    };
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -7,6 +7,7 @@
   modulesPath,
   lib,
   config,
+  machines,
   ...
 }:
 let
@@ -99,27 +100,19 @@ in
   users.users = {
     testagent-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4 root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-dev.publicKey ];
     };
     testagent-prod = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx root@nixos"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-prod.publicKey ];
     };
     testagent-release = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H mytarget"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-release.publicKey ];
     };
     testagent-uae-dev = {
       isNormalUser = true;
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS root@fayad-X1-testagent"
-      ];
+      openssh.authorizedKeys.keys = [ machines.testagent-uae-dev.publicKey ];
     };
   };
 
@@ -149,10 +142,10 @@ in
 
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
-    knownHosts."hetz86-1.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
-    knownHosts."hetzarm.vedenemo.dev".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    knownHosts = {
+      "hetz86-1.vedenemo.dev".publicKey = machines.hetz86-1.publicKey;
+      "hetzarm.vedenemo.dev".publicKey = machines.hetzarm.publicKey;
+    };
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  ghaf-log = {
+    ip = "95.217.177.197";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
+  };
+
+  ghaf-coverity = {
+    ip = "135.181.103.32";
+  };
+
+  ghaf-proxy = {
+    ip = "95.216.200.85";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
+  };
+
+  ghaf-webserver = {
+    ip = "37.27.204.82";
+  };
+
+  ghaf-auth = {
+    ip = "37.27.190.109";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPc04ZyZ7LgUKhV6Xr177qQn6Vf43FzUr1mS6g3jrSDj";
+  };
+
+  hetzarm = {
+    ip = "65.21.20.242";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+  };
+
+  hetz86-1 = {
+    ip = "37.27.170.242";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
+  };
+
+  hetz86-builder = {
+    ip = "65.108.7.79";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG68NdmOw3mhiBZwDv81dXitePoc1w//p/LpsHHA8QRp";
+  };
+
+  hetzci-dev = {
+    ip = "157.180.119.138";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ8XgXW7leM8yIOyU86aDztcWBGKkBAgTiu5yaAcJcvD";
+  };
+
+  hetzci-prod = {
+    ip = "157.180.43.236";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBdDmtt7At/xDNCF0aIDvXc2T9GTP0HWaAt4DEAejcE6";
+  };
+
+  build1 = {
+    ip = "172.18.20.102";
+  };
+
+  build2 = {
+    ip = "172.18.20.103";
+  };
+
+  build3 = {
+    ip = "172.18.20.104";
+  };
+
+  build4 = {
+    ip = "172.18.20.105";
+  };
+
+  monitoring = {
+    ip = "172.18.20.108";
+  };
+
+  binarycache = {
+    ip = "172.18.20.109";
+  };
+
+  testagent-dev = {
+    ip = "172.18.16.33";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4";
+  };
+
+  testagent-prod = {
+    ip = "172.18.16.60";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx";
+  };
+
+  testagent-release = {
+    ip = "172.18.16.32";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H";
+  };
+
+  testagent-uae-dev = {
+    ip = "172.19.16.12";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS";
+  };
+}

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -7,41 +7,47 @@
   ...
 }:
 let
+  machines = import ../hosts/machines.nix;
+
   inherit (inputs) deploy-rs;
 
-  mkDeployment = arch: config: ip: {
+  mkDeployment = config: ip: {
     hostname = ip;
     inherit config; # used for installation script
-    profiles.system = {
-      user = "root";
-      path = deploy-rs.lib.${arch}.activate.nixos self.nixosConfigurations.${config};
-    };
+    profiles.system =
+      let
+        cfg = self.nixosConfigurations.${config};
+      in
+      {
+        user = "root";
+        path = deploy-rs.lib.${cfg.config.nixpkgs.hostPlatform.system}.activate.nixos cfg;
+      };
   };
 
   x86-nodes = {
-    build1 = mkDeployment "x86_64-linux" "build1" "172.18.20.102";
-    build2 = mkDeployment "x86_64-linux" "build2" "172.18.20.103";
-    build3 = mkDeployment "x86_64-linux" "build3" "172.18.20.104";
-    build4 = mkDeployment "x86_64-linux" "build4" "172.18.20.105";
-    monitoring = mkDeployment "x86_64-linux" "monitoring" "172.18.20.108";
-    binarycache = mkDeployment "x86_64-linux" "binarycache" "172.18.20.109";
-    testagent-prod = mkDeployment "x86_64-linux" "testagent-prod" "172.18.16.60";
-    testagent-dev = mkDeployment "x86_64-linux" "testagent-dev" "172.18.16.33";
-    testagent-release = mkDeployment "x86_64-linux" "testagent-release" "172.18.16.32";
-    ghaf-log = mkDeployment "x86_64-linux" "ghaf-log" "95.217.177.197";
-    ghaf-coverity = mkDeployment "x86_64-linux" "ghaf-coverity" "135.181.103.32";
-    ghaf-proxy = mkDeployment "x86_64-linux" "ghaf-proxy" "95.216.200.85";
-    ghaf-webserver = mkDeployment "x86_64-linux" "ghaf-webserver" "37.27.204.82";
-    ghaf-auth = mkDeployment "x86_64-linux" "ghaf-auth" "37.27.190.109";
-    testagent-uae-dev = mkDeployment "x86_64-linux" "testagent-uae-dev" "172.19.16.12";
-    hetzci-prod = mkDeployment "x86_64-linux" "hetzci-prod" "157.180.43.236";
-    hetzci-dev = mkDeployment "x86_64-linux" "hetzci-dev" "157.180.119.138";
-    hetz86-1 = mkDeployment "x86_64-linux" "hetz86-1" "37.27.170.242";
-    hetz86-builder = mkDeployment "x86_64-linux" "hetz86-builder" "65.108.7.79";
+    build1 = mkDeployment "build1" machines.build1.ip;
+    build2 = mkDeployment "build2" machines.build2.ip;
+    build3 = mkDeployment "build3" machines.build3.ip;
+    build4 = mkDeployment "build4" machines.build4.ip;
+    monitoring = mkDeployment "monitoring" machines.monitoring.ip;
+    binarycache = mkDeployment "binarycache" machines.binarycache.ip;
+    testagent-prod = mkDeployment "testagent-prod" machines.testagent-prod.ip;
+    testagent-dev = mkDeployment "testagent-dev" machines.testagent-dev.ip;
+    testagent-release = mkDeployment "testagent-release" machines.testagent-release.ip;
+    testagent-uae-dev = mkDeployment "testagent-uae-dev" machines.testagent-uae-dev.ip;
+    ghaf-log = mkDeployment "ghaf-log" machines.ghaf-log.ip;
+    ghaf-coverity = mkDeployment "ghaf-coverity" machines.ghaf-coverity.ip;
+    ghaf-proxy = mkDeployment "ghaf-proxy" machines.ghaf-proxy.ip;
+    ghaf-webserver = mkDeployment "ghaf-webserver" machines.ghaf-webserver.ip;
+    ghaf-auth = mkDeployment "ghaf-auth" machines.ghaf-auth.ip;
+    hetzci-prod = mkDeployment "hetzci-prod" machines.hetzci-prod.ip;
+    hetzci-dev = mkDeployment "hetzci-dev" machines.hetzci-dev.ip;
+    hetz86-1 = mkDeployment "hetz86-1" machines.hetz86-1.ip;
+    hetz86-builder = mkDeployment "hetz86-builder" machines.hetz86-builder.ip;
   };
 
   aarch64-nodes = {
-    hetzarm = mkDeployment "aarch64-linux" "hetzarm" "65.21.20.242";
+    hetzarm = mkDeployment "hetzarm" machines.hetzarm.ip;
   };
 in
 {


### PR DESCRIPTION
- New `hosts/machines.nix` file contains ip addreses and public keys for all of our hosts. This is a single source of truth and eliminates the need to remember or copy-paste ip addresses and public keys around. The file is added to `specialArgs` of all hosts, so it can be imported and read from.
- Monitoring server target configuration as well as deployment information are both now generated using this file.
- Removed the need to specify system arch in `mkDeployment` by reading it from the host configuration.