### PR TITLE
hetzci: Store jenkins build logs in artifacts

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -34,7 +34,10 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
+        sh """
+          mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/
+          ln -sf /var/lib/jenkins/jobs/${JOB_BASE_NAME}/builds/${BUILD_NUMBER}/log ${artifacts_local_dir}/log
+        """
         if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
           append_to_build_description(artifacts_href)
         }
@@ -57,6 +60,10 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          sh """
+            mkdir -v -p ${artifacts_local_dir}/test-results
+            cp /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log ${artifacts_local_dir}/test-results/${it.target}.log
+          """
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -34,7 +34,10 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
+        sh """
+          mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/
+          ln -sf /var/lib/jenkins/jobs/${JOB_BASE_NAME}/builds/${BUILD_NUMBER}/log ${artifacts_local_dir}/log
+        """
         if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
           append_to_build_description(artifacts_href)
         }
@@ -57,6 +60,10 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          sh """
+            mkdir -v -p ${artifacts_local_dir}/test-results
+            cp /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log ${artifacts_local_dir}/test-results/${it.target}.log
+          """
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -34,7 +34,10 @@ def create_pipeline(List<Map> targets) {
       }
       // Archive
       stage("Archive ${shortname}") {
-        sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
+        sh """
+          mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/
+          ln -sf /var/lib/jenkins/jobs/${JOB_BASE_NAME}/builds/${BUILD_NUMBER}/log ${artifacts_local_dir}/log
+        """
         if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
           append_to_build_description(artifacts_href)
         }
@@ -57,6 +60,10 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          sh """
+            mkdir -v -p ${artifacts_local_dir}/test-results
+            cp /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log ${artifacts_local_dir}/test-results/${it.target}.log
+          """
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"


### PR DESCRIPTION
Store jenkins build log in artifacts:
- Store the main jenkins build log as a symbolic link, so the link validity follows the [build validity set in each pipeline](https://github.com/tiiuae/ghaf-infra/blob/f353386cc2c09101c43363b1df1d58006372f8f8/hosts/hetzci/prod/casc/pipelines/ghaf-main.groovy#L52). Also, nix build logs can be relatively large, so we don't want to copy them
- Store the hw-test build log is copied (and not linked) to artifacts directory since hw-test build log is small. Also, if we didn't copy it, the hw-test build log might end up being removed before the triggering build artifact, in which case we would lose the hw-test log