### PR TITLE
hetzci: Print ghaf-hw-test log in triggering call

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -57,6 +57,8 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          println("ghaf-hw-test log '${it.target}':")
+          sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -57,6 +57,8 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          println("ghaf-hw-test log '${it.target}':")
+          sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -57,6 +57,8 @@ def create_pipeline(List<Map> targets) {
               booleanParam(name: "RELOAD_ONLY", value: false),
             ],
           )
+          println("ghaf-hw-test log '${it.target}':")
+          sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
           if (job.result != "SUCCESS") {
             unstable("FAILED: ${it.target} ${it.testset}")
             currentBuild.result = "FAILURE"


### PR DESCRIPTION
Print ghaf-hw-test build log in the triggering job so that even if the ghaf-hw-test build gets removed, the triggering job log still includes the hw test console log.