### PR TITLE
Add ghaf-installer testing

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
@@ -15,7 +15,7 @@ def TARGETS = [
     testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
-    testset: null,
+    testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
     testset: null,

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
@@ -15,7 +15,7 @@ def TARGETS = [
     testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
-    testset: null,
+    testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
     testset: null,

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -15,7 +15,7 @@ def TARGETS = [
     testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer",
-    testset: null,
+    testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
     testset: null,


### PR DESCRIPTION
Added installation and wiping pipeline steps for ghaf-installer image, for now only for nightly tests.
Ghaf-intaller build: https://ci-dev.vedenemo.dev/job/ghaf-hw-test/88/
Successful normal Ghaf build after that: https://ci-dev.vedenemo.dev/job/ghaf-hw-test/89/