### PR TITLE
hetzci: Add provenance generation to all pipelines

### DIFF
--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -167,19 +167,25 @@ in
     listenAddress = "localhost";
     port = 8081;
     withCLI = true;
-    packages = with pkgs; [
-      bashInteractive # 'sh' step in jenkins pipeline requires this
-      coreutils
-      colorized-logs
-      csvkit
-      curl
-      git
-      jq
-      nix
-      openssh
-      wget
-      zstd
-    ];
+    packages =
+      with pkgs;
+      [
+        bashInteractive # 'sh' step in jenkins pipeline requires this
+        coreutils
+        colorized-logs
+        csvkit
+        curl
+        git
+        hostname
+        jq
+        nix
+        openssh
+        wget
+        zstd
+      ]
+      ++ [
+        inputs.sbomnix.packages.${pkgs.system}.sbomnix # provenance
+      ];
     extraJavaOptions = [
       # Useful when the 'sh' step fails:
       "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -167,19 +167,25 @@ in
     listenAddress = "localhost";
     port = 8081;
     withCLI = true;
-    packages = with pkgs; [
-      bashInteractive # 'sh' step in jenkins pipeline requires this
-      coreutils
-      colorized-logs
-      csvkit
-      curl
-      git
-      jq
-      nix
-      openssh
-      wget
-      zstd
-    ];
+    packages =
+      with pkgs;
+      [
+        bashInteractive # 'sh' step in jenkins pipeline requires this
+        coreutils
+        colorized-logs
+        csvkit
+        curl
+        git
+        hostname
+        jq
+        nix
+        openssh
+        wget
+        zstd
+      ]
+      ++ [
+        inputs.sbomnix.packages.${pkgs.system}.sbomnix # provenance
+      ];
     extraJavaOptions = [
       # Useful when the 'sh' step fails:
       "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -166,19 +166,25 @@ in
     listenAddress = "localhost";
     port = 8081;
     withCLI = true;
-    packages = with pkgs; [
-      bashInteractive # 'sh' step in jenkins pipeline requires this
-      coreutils
-      colorized-logs
-      csvkit
-      curl
-      git
-      jq
-      nix
-      openssh
-      wget
-      zstd
-    ];
+    packages =
+      with pkgs;
+      [
+        bashInteractive # 'sh' step in jenkins pipeline requires this
+        coreutils
+        colorized-logs
+        csvkit
+        curl
+        git
+        hostname
+        jq
+        nix
+        openssh
+        wget
+        zstd
+      ]
+      ++ [
+        inputs.sbomnix.packages.${pkgs.system}.sbomnix # provenance
+      ];
     extraJavaOptions = [
       # Useful when the 'sh' step fails:
       "-Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true"


### PR DESCRIPTION
- Add provenance file generation to all hetzci pipelines for `vm`, `dev` and `prod` environments.
- Add a placeholder step in ghaf-hw-test pipeline to verify the provenance. We can't properly verify the provenance yet, since we don't sign the provenance in hetzci as of now. Generating signature for the provenance (and other important build results) will be implemented in a follow-up PR, at which point the provenance verification step added in this PR should also be modified accordingly.

Example run in dev: https://ci-dev.vedenemo.dev/job/ghaf-main/22/ (see the 'scs' directory in 'Artifacts').

Example provenance file from that run, e.g.: https://ci-dev.vedenemo.dev/artifacts/ghaf-main/20250714_095103000-commit_60b5fb785178ac0243b8ee2083878c847ee4b08d/scs/packages.aarch64-linux.nvidia-jetson-orin-agx-debug/

Reference: https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/169#pullrequestreview-2960822668
