### PR TITLE
hetzci: Fix regression in pre-merge-manual

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -18,7 +18,7 @@ def create_pipeline(List<Map> targets) {
   def pipeline = [:]
   def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def target_commit = run_cmd('git rev-parse HEAD')
-  def target_repo = run_cmd('git remote get-url origin')
+  def target_repo = run_cmd('git remote get-url origin || git remote get-url pr_origin')
   def host_name = run_cmd('hostname')
   def host_revision = run_cmd('/run/current-system/sw/bin/nixos-version --configuration-revision')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -18,7 +18,7 @@ def create_pipeline(List<Map> targets) {
   def pipeline = [:]
   def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def target_commit = run_cmd('git rev-parse HEAD')
-  def target_repo = run_cmd('git remote get-url origin')
+  def target_repo = run_cmd('git remote get-url origin || git remote get-url pr_origin')
   def host_name = run_cmd('hostname')
   def host_revision = run_cmd('/run/current-system/sw/bin/nixos-version --configuration-revision')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -18,7 +18,7 @@ def create_pipeline(List<Map> targets) {
   def pipeline = [:]
   def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def target_commit = run_cmd('git rev-parse HEAD')
-  def target_repo = run_cmd('git remote get-url origin')
+  def target_repo = run_cmd('git remote get-url origin || git remote get-url pr_origin')
   def host_name = run_cmd('hostname')
   def host_revision = run_cmd('/run/current-system/sw/bin/nixos-version --configuration-revision')
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"


### PR DESCRIPTION
Fix regression in pre-merge-manual caused by https://github.com/tiiuae/ghaf-infra/pull/529.

Example log with the error: https://ci-prod.vedenemo.dev/job/ghaf-pre-merge-manual/38/console.
The problem is, there's no 'origin' remote in the ghaf-pre-merge-manual pipeline.

Test run in dev with the changes from this PR: https://ci-dev.vedenemo.dev/job/ghaf-pre-merge-manual/27/