### PR TITLE
Update nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -258,11 +258,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751211869,
-        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "lastModified": 1752866191,
+        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
         "type": "github"
       },
       "original": {

--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -101,6 +101,7 @@ in
     git
     htop
     nix-info
+    nixVersions.latest # use the latest version of 'nix'
   ];
 
   # Shell


### PR DESCRIPTION
- Update to latest from nixos/nixpkgs/nixos-25.05
- Use latest version of `nix` (currently 2.28.4 in nixos-25.05)