### PR TITLE
Refactor auth clients

### DIFF
--- a/terraform/jenkins-controller.tf
+++ b/terraform/jenkins-controller.tf
@@ -61,7 +61,7 @@ module "jenkins_controller_vm" {
         content = join("\n", toset([
           "OAUTH2_PROXY_COOKIE_SECRET=${random_id.oauth2_proxy_cookie_secret.b64_url}",
           # client id and secret that are present in dex 
-          "OAUTH2_PROXY_CLIENT_ID=ghaf-jenkins-controller-${local.ws}",
+          "OAUTH2_PROXY_CLIENT_ID=ghaf-jenkins-controller-${azurerm_resource_group.infra.location}",
           "OAUTH2_PROXY_CLIENT_SECRET=${data.sops_file.secrets.data["oauth2_proxy_client_secret"]}",
           "OAUTH2_PROXY_COOKIE_DOMAINS=ghaf-jenkins-controller-${local.ws}.${azurerm_resource_group.infra.location}.cloudapp.azure.com",
         ])),


### PR DESCRIPTION
- Separate northeurope and uae envs under a different client IDs, with combined workspaces under them (requires redeploy of azure envs).
- Change the name that displays in the oauth dialog from `hetzci-prod` to `ci-prod.vedenemo.dev`. (and same for dev)
- Use more variables when values are repeated.