### PR TITLE
Whitelist ci domains to fix redirect after sign-in

### DIFF
--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -369,6 +369,7 @@ in
       provider-display-name = "Vedenemo Auth";
       custom-sign-in-logo = "-";
       client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
+      whitelist-domain = "ci-dev.vedenemo.dev";
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -369,6 +369,7 @@ in
       provider-display-name = "Vedenemo Auth";
       custom-sign-in-logo = "-";
       client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
+      whitelist-domain = "ci-prod.vedenemo.dev";
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };


### PR DESCRIPTION
Now when you click a link and you get redirected to the login page, you will be redirected to the original path after successful login, instead of the base domain.