### PR TITLE
hetzci: Run perftest sequentially

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -72,7 +72,9 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            parallel PIPELINE
+            PIPELINE.each { key, value ->
+              value()
+            }
           }
         }
       }

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -75,7 +75,9 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            parallel PIPELINE
+            PIPELINE.each { key, value ->
+              value()
+            }
           }
         }
       }

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -75,7 +75,9 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            parallel PIPELINE
+            PIPELINE.each { key, value ->
+              value()
+            }
           }
         }
       }


### PR DESCRIPTION
This PR changes the perftest pipeline so all the targets run sequentially instead of parallel.

The change was requested by the test team because perftest results are apparently not reliable when multiple performance tests are executed at the same time.

Tested in dev: https://ci-dev.vedenemo.dev/job/ghaf-nightly-perftest/36/

