### PR TITLE
Enable the use of refresh tokens to keep auth session alive

### DIFF
--- a/hosts/ghaf-auth/configuration.nix
+++ b/hosts/ghaf-auth/configuration.nix
@@ -43,7 +43,6 @@ in
 
   services.dex = {
     enable = true;
-
     environmentFile = config.sops.secrets.dex_env.path;
 
     settings = {
@@ -55,12 +54,15 @@ in
         config.file = "/var/lib/dex/dex.db";
       };
 
-      web = {
-        http = "127.0.0.1:5556";
+      web.http = "127.0.0.1:5556";
+
+      frontend = {
+        issuer = "Vedenemo Auth";
+        theme = "dark";
       };
 
       oauth2 = {
-        skipApprovalScreen = true;
+        skipApprovalScreen = false;
         alwaysShowLoginScreen = false;
       };
 
@@ -82,50 +84,66 @@ in
         }
       ];
 
-      staticClients = [
-        {
-          id = "ghaf-jenkins-controller-uaenorth";
-          name = "Ghaf Jenkins controller (uaenorth)";
-          redirectURIs =
-            map (env: "https://ghaf-jenkins-controller-${env}.uaenorth.cloudapp.azure.com/oauth2/callback")
-              [
-                "dev"
-                "prod"
-                "release"
-              ];
-          secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
-        }
-        {
-          id = "ghaf-jenkins-controller-northeurope";
-          name = "Ghaf Jenkins controller (northeurope)";
-          redirectURIs =
-            map (env: "https://ghaf-jenkins-controller-${env}.northeurope.cloudapp.azure.com/oauth2/callback")
-              [
-                "release"
-                "alextserepov"
-                "cazfi"
-                "flokli"
-                "henri"
-                "jrautiola"
-                "kaitusa"
-                "vjuntunen"
-                "fayad"
-              ];
-          secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
-        }
-        {
-          id = "hetzci-prod";
-          name = "ci-prod.vedenemo.dev";
-          redirectURIs = [ "https://ci-prod.vedenemo.dev/oauth2/callback" ];
-          secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
-        }
-        {
-          id = "hetzci-dev";
-          name = "ci-dev.vedenemo.dev";
-          redirectURIs = [ "https://ci-dev.vedenemo.dev/oauth2/callback" ];
-          secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
-        }
-      ];
+      expiry = {
+        idTokens = "24h";
+        refreshTokens.absoluteLifetime = "168h"; # 7 days
+      };
+
+      staticClients =
+        let
+          grantTypes = [
+            "authorization_code"
+            "refresh_token"
+          ];
+        in
+        [
+          {
+            id = "ghaf-jenkins-controller-uaenorth";
+            name = "Ghaf Jenkins controller (uaenorth)";
+            redirectURIs =
+              map (env: "https://ghaf-jenkins-controller-${env}.uaenorth.cloudapp.azure.com/oauth2/callback")
+                [
+                  "dev"
+                  "prod"
+                  "release"
+                ];
+            secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
+            inherit grantTypes;
+          }
+          {
+            id = "ghaf-jenkins-controller-northeurope";
+            name = "Ghaf Jenkins controller (northeurope)";
+            redirectURIs =
+              map (env: "https://ghaf-jenkins-controller-${env}.northeurope.cloudapp.azure.com/oauth2/callback")
+                [
+                  "release"
+                  "alextserepov"
+                  "cazfi"
+                  "flokli"
+                  "henri"
+                  "jrautiola"
+                  "kaitusa"
+                  "vjuntunen"
+                  "fayad"
+                ];
+            secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
+            inherit grantTypes;
+          }
+          {
+            id = "hetzci-prod";
+            name = "ci-prod.vedenemo.dev";
+            redirectURIs = [ "https://ci-prod.vedenemo.dev/oauth2/callback" ];
+            secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
+            inherit grantTypes;
+          }
+          {
+            id = "hetzci-dev";
+            name = "ci-dev.vedenemo.dev";
+            redirectURIs = [ "https://ci-dev.vedenemo.dev/oauth2/callback" ];
+            secretEnv = "JENKINS_CONTROLLER_AUTH_SECRET";
+            inherit grantTypes;
+          }
+        ];
     };
   };
 

--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -340,9 +340,10 @@ in
       request-logging = true;
       standard-logging = true;
       reverse-proxy = true;
-      scope = "openid profile email groups";
-      provider-display-name = "Vedenemo Auth";
-      custom-sign-in-logo = "-";
+      scope = "openid profile email groups offline_access";
+      cookie-expire = "168h";
+      cookie-refresh = "24h";
+      skip-provider-button = true;
       client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
       whitelist-domain = "ci-dev.vedenemo.dev";
     };

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -340,9 +340,10 @@ in
       request-logging = true;
       standard-logging = true;
       reverse-proxy = true;
-      scope = "openid profile email groups";
-      provider-display-name = "Vedenemo Auth";
-      custom-sign-in-logo = "-";
+      scope = "openid profile email groups offline_access";
+      cookie-expire = "168h";
+      cookie-refresh = "24h";
+      skip-provider-button = true;
       client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
       whitelist-domain = "ci-prod.vedenemo.dev";
     };

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -278,9 +278,10 @@ in
       request-logging = true;
       standard-logging = true;
       reverse-proxy = true;
-      scope = "openid profile email groups";
-      provider-display-name = "Vedenemo Auth";
-      custom-sign-in-logo = "-";
+      scope = "openid profile email groups offline_access";
+      cookie-expire = "168h";
+      cookie-refresh = "24h";
+      skip-provider-button = true;
       client-secret-file = config.sops.secrets.oauth2_proxy_client_secret.path;
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;


### PR DESCRIPTION
- Skip provider button, makes logging in one click instead of two. We only have one provider (ghaf-auth/dex) so it's not useful.
- Request `offline_access` scope and grant `refresh_token` to clients, enabling the ability to refresh sessions. These tokens are valid for a week. The outcome of this changes is that you should not have to relogin to ci-dev and ci-prod so frequently anymore. Your session should be remembered for a week.
- Enable dark mode css