### PR TITLE
Enable dark theme for Jenkins

### DIFF
--- a/hosts/hetzci/dev/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/dev/casc/jenkins-casc.yaml
@@ -1,6 +1,8 @@
 appearance:
   pipelineGraphView:
     showGraphOnBuildPage: true
+  themeManager:
+    theme: "darkSystem" # follow system theme 
 
 jenkins:
   authorizationStrategy:

--- a/hosts/hetzci/dev/plugins.json
+++ b/hosts/hetzci/dev/plugins.json
@@ -162,6 +162,12 @@
     "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
+    "name": "dark-theme",
+    "version": "524.vd675b_22b_30cb_",
+    "url": "https://updates.jenkins.io/download/plugins/dark-theme/524.vd675b_22b_30cb_/dark-theme.hpi",
+    "sha256": "15h6l51805b4vkcc895z06h20nardxqn19h0mwkhkdcfqwr1jy11"
+  },
+  {
     "name": "data-tables-api",
     "version": "2.3.2-3",
     "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
@@ -640,6 +646,12 @@
     "version": "1758.v87f0f880c067",
     "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
     "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
+  },
+  {
+    "name": "theme-manager",
+    "version": "319.v9193461f9671",
+    "url": "https://updates.jenkins.io/download/plugins/theme-manager/319.v9193461f9671/theme-manager.hpi",
+    "sha256": "1b11kpb1663k1hw4as7r6iw1lzn27z1wnl69lvrl8ad60hpgar6j"
   },
   {
     "name": "timestamper",

--- a/hosts/hetzci/dev/plugins.json
+++ b/hosts/hetzci/dev/plugins.json
@@ -13,9 +13,9 @@
   },
   {
     "name": "asm-api",
-    "version": "9.8-135.vb_2239d08ee90",
-    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-135.vb_2239d08ee90/asm-api.hpi",
-    "sha256": "1m1ppbja2rn315sc720gxhi3ji64nqfdawa3rgdbd60ybry1zrwm"
+    "version": "9.8-163.vb_2a_96d3f9c3c",
+    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-163.vb_2a_96d3f9c3c/asm-api.hpi",
+    "sha256": "0jgwd9i1h0739v8d1jcvfc3wkjnyhknywzk2k3fi9avknlgc24rv"
   },
   {
     "name": "block-queued-job",
@@ -61,27 +61,27 @@
   },
   {
     "name": "bootstrap5-api",
-    "version": "5.3.7-1",
-    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-1/bootstrap5-api.hpi",
-    "sha256": "1d4r5766dl164jl8xzaw2hs4vf7wqafxi6zm6ls8jg5jdqnp539a"
+    "version": "5.3.7-2",
+    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-2/bootstrap5-api.hpi",
+    "sha256": "1w0gqk3fz3vrn0830liwk7asd2mlpmsifi3hcgwi0afa9mylriqn"
   },
   {
     "name": "bouncycastle-api",
-    "version": "2.30.1.80-261.v00c0e2618ec3",
-    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.80-261.v00c0e2618ec3/bouncycastle-api.hpi",
-    "sha256": "1h06h7iqyvppi28x7mcw42gh1im3g0lay1rhxhimg42ly8fisa0n"
+    "version": "2.30.1.81-264.v95c79c0e772c",
+    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.81-264.v95c79c0e772c/bouncycastle-api.hpi",
+    "sha256": "04vwrr5117pd6j51xgw4vkcqrmfhgig2l4chjnxw9jkqybadlwdg"
   },
   {
     "name": "branch-api",
-    "version": "2.1226.ve1e7e0b_4b_95f",
-    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1226.ve1e7e0b_4b_95f/branch-api.hpi",
-    "sha256": "0gv81jnmlzl75a40mq8mjw8nm1nnljafy1nvw0ylqdkdnkdx7rmx"
+    "version": "2.1244.vf95c81f1641c",
+    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1244.vf95c81f1641c/branch-api.hpi",
+    "sha256": "0sjspfg6chwabds0gm8bhjbw0irm2318yl9wj7m16abryfqinj77"
   },
   {
     "name": "caffeine-api",
-    "version": "3.2.0-166.v72a_6d74b_870f",
-    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.0-166.v72a_6d74b_870f/caffeine-api.hpi",
-    "sha256": "04zh7lnzwhrjjp534g5aaz2bd32d3lgvcjy0dxinbjg5214y6pnr"
+    "version": "3.2.2-178.v353b_8428ed56",
+    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.2-178.v353b_8428ed56/caffeine-api.hpi",
+    "sha256": "1da6kx4p06laafw9rnw772wsfsnyldiwdb02s0qfb75rwccngyx8"
   },
   {
     "name": "checks-api",
@@ -91,9 +91,9 @@
   },
   {
     "name": "cloudbees-folder",
-    "version": "6.1026.ve06dfa_cf31c3",
-    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1026.ve06dfa_cf31c3/cloudbees-folder.hpi",
-    "sha256": "1nic6xll8cwmw6hxx4759dkf40s384nscjxxw6b9p0j84zmmaa7g"
+    "version": "6.1037.v4cb_8573b_72a_a_",
+    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1037.v4cb_8573b_72a_a_/cloudbees-folder.hpi",
+    "sha256": "09wmaar2wj28a82b3h3grs8vy8p3n2wizv64m4y6517ja8w5vkwd"
   },
   {
     "name": "command-launcher",
@@ -103,21 +103,21 @@
   },
   {
     "name": "commons-compress-api",
-    "version": "1.27.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.27.1-3/commons-compress-api.hpi",
-    "sha256": "0abwp2kyh7fn63bsqmnbikyhj7yjj3z49859z65hkp4bwlkymgyq"
+    "version": "1.28.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.28.0-1/commons-compress-api.hpi",
+    "sha256": "1wv76vd1kgbsd5flpcznalkh38jxfvk5vipb6f14nwd1nb52pykp"
   },
   {
     "name": "commons-lang3-api",
-    "version": "3.17.0-87.v5cf526e63b_8b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.17.0-87.v5cf526e63b_8b_/commons-lang3-api.hpi",
-    "sha256": "1kslvyhh0kkpn98276rpl84ia2zlpwm9f7b4nzq7l3dnvdkx8m6n"
+    "version": "3.18.0-98.v3a_674c06072d",
+    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.18.0-98.v3a_674c06072d/commons-lang3-api.hpi",
+    "sha256": "198la3854akm1zlpcjcdxglr7q0mh7db0hdrd2yizzh535p3w0c2"
   },
   {
     "name": "commons-text-api",
-    "version": "1.13.1-176.v74d88f22034b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.13.1-176.v74d88f22034b_/commons-text-api.hpi",
-    "sha256": "0vbh3gz4v827i7y560lqf3g2mqy31pz920znxy0q5q80c7aqf60x"
+    "version": "1.14.0-194.v804a_dc3a_1b_d8",
+    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.14.0-194.v804a_dc3a_1b_d8/commons-text-api.hpi",
+    "sha256": "0plf0pwacva6gv3wwnmqih2w9czbqjdi2ybi2zvd73a76vdarsa9"
   },
   {
     "name": "conditional-buildstep",
@@ -127,15 +127,15 @@
   },
   {
     "name": "config-file-provider",
-    "version": "988.v0461fcc2b_9d1",
-    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/988.v0461fcc2b_9d1/config-file-provider.hpi",
-    "sha256": "18nkwslzdhc7g5z9pzdhlfdqlap8mjah39mlhks4h85zx3hpnykh"
+    "version": "994.v3d4a_5fa_f353a_",
+    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/994.v3d4a_5fa_f353a_/config-file-provider.hpi",
+    "sha256": "1q2niravbilrwwx0f762yvrnmpxcz7k00arac7lw881q5gzcrfvs"
   },
   {
     "name": "configuration-as-code",
-    "version": "1971.vf9280461ea_89",
-    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1971.vf9280461ea_89/configuration-as-code.hpi",
-    "sha256": "16x29fal06209zj3qbvs5sz748pwnhpryw8gvrydqy341r2sc6l4"
+    "version": "1985.vdda_32d0c4ea_b_",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1985.vdda_32d0c4ea_b_/configuration-as-code.hpi",
+    "sha256": "186wv8ma43bv73562m7hadhvs6cbqyx9r3mpdi63gh46v6y503sw"
   },
   {
     "name": "configuration-as-code-groovy",
@@ -151,39 +151,39 @@
   },
   {
     "name": "credentials",
-    "version": "1415.v831096eb_5534",
-    "url": "https://updates.jenkins.io/download/plugins/credentials/1415.v831096eb_5534/credentials.hpi",
-    "sha256": "1462p5sq2kx76jann27vc1zkpl6wiiwzjapxai8l0gprpsjiv9m1"
+    "version": "1419.v2337d1ceceef",
+    "url": "https://updates.jenkins.io/download/plugins/credentials/1419.v2337d1ceceef/credentials.hpi",
+    "sha256": "0a4pja7mvf3f6009c0jwf6979rd5wadgbs8wa1lw49bnrad1y4m4"
   },
   {
     "name": "credentials-binding",
-    "version": "687.v619cb_15e923f",
-    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/687.v619cb_15e923f/credentials-binding.hpi",
-    "sha256": "03bxygj33xmishd2pbqkrgnwwijs7akfyq1g5xwy68gwgc39qn1s"
+    "version": "702.vfe613e537e88",
+    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/702.vfe613e537e88/credentials-binding.hpi",
+    "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
     "name": "data-tables-api",
-    "version": "2.3.2-2",
-    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-2/data-tables-api.hpi",
-    "sha256": "1jgcznqj0zxyg6jwn0wyfbxij3dfxzi0nf1zq09rzqczj2df78h9"
+    "version": "2.3.2-3",
+    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
+    "sha256": "0sqhxzcmyvwl1lsw5k8fl0pfb662656ciq9albikgmpi9rjcyjpn"
   },
   {
     "name": "display-url-api",
-    "version": "2.209.v582ed814ff2f",
-    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.209.v582ed814ff2f/display-url-api.hpi",
-    "sha256": "09b81rsyk27p2d96zwhay42h1wallh66ckaxi9q6jdxrbgwpac21"
+    "version": "2.217.va_6b_de84cc74b_",
+    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.217.va_6b_de84cc74b_/display-url-api.hpi",
+    "sha256": "1jn03bkxr8i2bfj0gfn788x4jv0war40p42n8zgblldl73ksmvh7"
   },
   {
     "name": "durable-task",
-    "version": "587.v84b_877235b_45",
-    "url": "https://updates.jenkins.io/download/plugins/durable-task/587.v84b_877235b_45/durable-task.hpi",
-    "sha256": "1d1rp7bf5iba88p1wkvqcilyfsm2bzzzgjb8gjrziyv7ay35sjpl"
+    "version": "595.ve87b_f1318d67",
+    "url": "https://updates.jenkins.io/download/plugins/durable-task/595.ve87b_f1318d67/durable-task.hpi",
+    "sha256": "1lf32pdwl9hx956a2yijna6l3qd18id6gxr6dps9kvlabm3nfw9m"
   },
   {
     "name": "echarts-api",
-    "version": "5.6.0-5",
-    "url": "https://updates.jenkins.io/download/plugins/echarts-api/5.6.0-5/echarts-api.hpi",
-    "sha256": "0mhimldjv57fmirhwj74wq8rld6pjxwx4svglyj2b7gy3dxiaznl"
+    "version": "6.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/echarts-api/6.0.0-1/echarts-api.hpi",
+    "sha256": "15f3pwa84ih2prk0q1yyslyap6vpjyij0q8zirg8z5p2qcvs98bp"
   },
   {
     "name": "eddsa-api",
@@ -193,9 +193,9 @@
   },
   {
     "name": "email-ext",
-    "version": "1911.v19b_8e86f9815",
-    "url": "https://updates.jenkins.io/download/plugins/email-ext/1911.v19b_8e86f9815/email-ext.hpi",
-    "sha256": "0pidv9lv5s4l9ixxrlnzkyk22za7z47v0jh96fd2vjrqiqslgj35"
+    "version": "1925.v1598902b_58dd",
+    "url": "https://updates.jenkins.io/download/plugins/email-ext/1925.v1598902b_58dd/email-ext.hpi",
+    "sha256": "0qgkyyibij27aisrq129fw8n61lxmpf770lry4sx9cfgfzr8bdis"
   },
   {
     "name": "favorite",
@@ -205,9 +205,9 @@
   },
   {
     "name": "font-awesome-api",
-    "version": "6.7.2-1",
-    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/6.7.2-1/font-awesome-api.hpi",
-    "sha256": "0gyx355sv5c82bqkqh2yi4rnbm68qg2vv6kmwxbc4p7lc5n6g703"
+    "version": "7.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/7.0.0-1/font-awesome-api.hpi",
+    "sha256": "0hcwg70x1lyikdhfyfbzq8pgwy4n0dww7klkgfj9l0r6vkmcdwnk"
   },
   {
     "name": "git",
@@ -217,9 +217,9 @@
   },
   {
     "name": "git-client",
-    "version": "6.2.0",
-    "url": "https://updates.jenkins.io/download/plugins/git-client/6.2.0/git-client.hpi",
-    "sha256": "0ybjvxk3ivpg202jb6nw7xdcmfbjpidz99byiyy66wgsq3cr6qam"
+    "version": "6.3.0",
+    "url": "https://updates.jenkins.io/download/plugins/git-client/6.3.0/git-client.hpi",
+    "sha256": "0bbd14pjsp9bp20s2raqc7fd4vrj32gbmrxchcmxr0n746papwgm"
   },
   {
     "name": "git-server",
@@ -229,9 +229,9 @@
   },
   {
     "name": "github",
-    "version": "1.43.0",
-    "url": "https://updates.jenkins.io/download/plugins/github/1.43.0/github.hpi",
-    "sha256": "0i8dn80xx7x0p79y6ifnl0kdaq86b2di5m3jirwgc69gc4f5g0xj"
+    "version": "1.44.0",
+    "url": "https://updates.jenkins.io/download/plugins/github/1.44.0/github.hpi",
+    "sha256": "1xppsq1aaywn337agpy5wy88aygr6q1vxhzzfy0pacs12zgkw89h"
   },
   {
     "name": "github-api",
@@ -241,9 +241,9 @@
   },
   {
     "name": "github-branch-source",
-    "version": "1824.v046257273408",
-    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1824.v046257273408/github-branch-source.hpi",
-    "sha256": "08a53njlfphyyfkpx288bp7acvhwfvnjhqfp56d0fkwxzjhixmcx"
+    "version": "1834.v857721ea_74c6",
+    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1834.v857721ea_74c6/github-branch-source.hpi",
+    "sha256": "1qsm5a6m0ljafanq1vxbppnvki0w5rypl0v3fm6b392c93l493v9"
   },
   {
     "name": "github-pullrequest",
@@ -253,9 +253,9 @@
   },
   {
     "name": "gson-api",
-    "version": "2.13.1-139.v4569c2ef303f",
-    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-139.v4569c2ef303f/gson-api.hpi",
-    "sha256": "0rz4a2kym62c9gf1p0ir1akdc8q09j394v0n314z49isf2n30hrj"
+    "version": "2.13.1-153.vb_3d0c48a_a_b_4a_",
+    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-153.vb_3d0c48a_a_b_4a_/gson-api.hpi",
+    "sha256": "1xn6ydnqaj2v4j5nhk710gb5cyrar14cvg5bbywi3266yii4148a"
   },
   {
     "name": "instance-identity",
@@ -265,15 +265,15 @@
   },
   {
     "name": "ionicons-api",
-    "version": "88.va_4187cb_eddf1",
-    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/88.va_4187cb_eddf1/ionicons-api.hpi",
-    "sha256": "0vzs1m251knzbjk3qpxk29pycs04dh50y1b0pw6vswkmb05a8vid"
+    "version": "94.vcc3065403257",
+    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/94.vcc3065403257/ionicons-api.hpi",
+    "sha256": "0gxcfglxhn1ry61wcbg43qk318h6aqnz7kaw8a3xha6nfm1m1wwm"
   },
   {
     "name": "jackson2-api",
-    "version": "2.19.0-404.vb_b_0fd2fea_e10",
-    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.0-404.vb_b_0fd2fea_e10/jackson2-api.hpi",
-    "sha256": "1pp8sa78mi33v0hhxsa0msr9vrg2h2lxc14liq1v962hj62253gy"
+    "version": "2.19.2-408.v18248a_324cfe",
+    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.2-408.v18248a_324cfe/jackson2-api.hpi",
+    "sha256": "158fz044pldpyqaagq9d54y7xba6id93xd8bhyrsgvnd5vmkjwiz"
   },
   {
     "name": "jakarta-activation-api",
@@ -289,9 +289,9 @@
   },
   {
     "name": "javadoc",
-    "version": "327.vdfe586651ee0",
-    "url": "https://updates.jenkins.io/download/plugins/javadoc/327.vdfe586651ee0/javadoc.hpi",
-    "sha256": "1nf6bi37m4j54jf20c2gljngazf5ngipsgmh3qpgg1i44pp583v9"
+    "version": "354.vee1a_660b_4990",
+    "url": "https://updates.jenkins.io/download/plugins/javadoc/354.vee1a_660b_4990/javadoc.hpi",
+    "sha256": "05dvpnn2587r0qwfngylwf33qb7s9nrwr1xqgv4jj99z85957h3d"
   },
   {
     "name": "javax-activation-api",
@@ -325,15 +325,15 @@
   },
   {
     "name": "joda-time-api",
-    "version": "2.14.0-127.v7d9da_295a_d51",
-    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-127.v7d9da_295a_d51/joda-time-api.hpi",
-    "sha256": "0p5hakxs02c445dm3vzzm0vyrcqiv49ppqxnwx1kg897ns7qjwy2"
+    "version": "2.14.0-149.v1c3ce991d1b_9",
+    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-149.v1c3ce991d1b_9/joda-time-api.hpi",
+    "sha256": "08wa03insvaybkybzn120gc9dxvd15qhq9y9ghckfgfalla042y5"
   },
   {
     "name": "jquery3-api",
-    "version": "3.7.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-3/jquery3-api.hpi",
-    "sha256": "0d1awnb0m5k9dg37333nmlma2s1991jm55zsmmsqqfq1jllg68qq"
+    "version": "3.7.1-583.vda_6ca_102270d",
+    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-583.vda_6ca_102270d/jquery3-api.hpi",
+    "sha256": "0yk8zain5inr2vllr0pikywbiryc2294cqzxl99asdi1yycdvr04"
   },
   {
     "name": "jsch",
@@ -343,21 +343,21 @@
   },
   {
     "name": "json-api",
-    "version": "20250517-153.vc8a_a_d87c0ce3",
-    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-153.vc8a_a_d87c0ce3/json-api.hpi",
-    "sha256": "0v6i0i1vp5q17b10r4vnn92kv4b1lw0wa79sm8bbx0410p6pk6v2"
+    "version": "20250517-163.v1c5da_e99c775",
+    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-163.v1c5da_e99c775/json-api.hpi",
+    "sha256": "18pfvp9pxl1gfmszbgipgl8vy4smbhq0afgn6gy7rzmsixg7w3f6"
   },
   {
     "name": "json-path-api",
-    "version": "2.9.0-148.v22a_7ffe323ce",
-    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-148.v22a_7ffe323ce/json-path-api.hpi",
-    "sha256": "14arnnsz9w23mmv9j2m66ynvf3jy9l4mzr2s8vy2sabcdgsc3z4k"
+    "version": "2.9.0-178.vca_b_c71881321",
+    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-178.vca_b_c71881321/json-path-api.hpi",
+    "sha256": "1bbn7aldzms9n4kz78nhvrr1qgyzvaqrqyqczyp0xzq14srk3hwg"
   },
   {
     "name": "jsoup",
-    "version": "1.21.1-52.v96e4041b_60fd",
-    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-52.v96e4041b_60fd/jsoup.hpi",
-    "sha256": "057rdrlxp98f0yhdp901p1w75j87hdp76jsnq9f3brfg89kgax6j"
+    "version": "1.21.1-58.vfc578e6e2610",
+    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-58.vfc578e6e2610/jsoup.hpi",
+    "sha256": "0n37y54ch7g7iw16srkyni8p8dijf4p3vnq7lrf0ivjahyk8cz5n"
   },
   {
     "name": "jucies",
@@ -373,15 +373,15 @@
   },
   {
     "name": "lockable-resources",
-    "version": "1349.v8b_ccb_c5487f7",
-    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1349.v8b_ccb_c5487f7/lockable-resources.hpi",
-    "sha256": "11fj40llz4diq93wqc9zaz3w4lsfb8fkrq09vw8lmjhri41qk5r8"
+    "version": "1412.v3f305a_fb_a_117",
+    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1412.v3f305a_fb_a_117/lockable-resources.hpi",
+    "sha256": "18j8k6lk00qgy43kavlxrwc8w5in96pvd36wjdy2iszv0w2rkwrm"
   },
   {
     "name": "mailer",
-    "version": "509.vc54d23fc427e",
-    "url": "https://updates.jenkins.io/download/plugins/mailer/509.vc54d23fc427e/mailer.hpi",
-    "sha256": "1vpypmkpl2li54ajyy3xd04dcngsh3qcz6nzn4jjp41m6cfnzpgg"
+    "version": "515.vd788654779b_1",
+    "url": "https://updates.jenkins.io/download/plugins/mailer/515.vd788654779b_1/mailer.hpi",
+    "sha256": "0c6f10kby3r38cj6s3wh8w69qhbf4k4vx30wfx4vkbqalsam9rzv"
   },
   {
     "name": "mapdb-api",
@@ -391,27 +391,27 @@
   },
   {
     "name": "matrix-auth",
-    "version": "3.2.6",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.6/matrix-auth.hpi",
-    "sha256": "1g3ij9f8ad6yhciyliwchv5dv7rlml7vghs64kmgrb9fff7pqgkj"
+    "version": "3.2.7",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.7/matrix-auth.hpi",
+    "sha256": "0j7d2ca1p0glda5vwxwh63pbas4v0w724wdls8nxaq5sj7x3mcb6"
   },
   {
     "name": "matrix-project",
-    "version": "849.v0cd64ed7e531",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-project/849.v0cd64ed7e531/matrix-project.hpi",
-    "sha256": "0rl2syrpi6dc6vylhqmsmr2y5mg7l73g2viv3cyrkgllj1gg3ixq"
+    "version": "856.v4c352b_3a_b_23e",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-project/856.v4c352b_3a_b_23e/matrix-project.hpi",
+    "sha256": "1mvchdmqm0qwqipc35mam0lkk1j9vcbni1qywp6llrbx6kdlmpwf"
   },
   {
     "name": "maven-plugin",
-    "version": "3.26",
-    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.26/maven-plugin.hpi",
-    "sha256": "1cdxpxr7yfm5fazdj26zmw8aqla95nmmj1qymypv7w2yg8ahs49f"
+    "version": "3.27",
+    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.27/maven-plugin.hpi",
+    "sha256": "1zh5anab4w251x3p7k7znhns5hvhflvw7428sgvfn68vmms9zmk4"
   },
   {
     "name": "metrics",
-    "version": "4.2.32-476.v5042e1c1edd7",
-    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-476.v5042e1c1edd7/metrics.hpi",
-    "sha256": "1kz7sqm2wbss4x3s3g8bdxa898nbzkhaypx823j83ijhcyqkqkac"
+    "version": "4.2.32-481.v75f035fdc894",
+    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-481.v75f035fdc894/metrics.hpi",
+    "sha256": "1gda878bnkwx1635znqw7p5q3inx1xkg0l9f132ggz56b5rvxy1l"
   },
   {
     "name": "mina-sshd-api-common",
@@ -439,15 +439,15 @@
   },
   {
     "name": "oss-symbols-api",
-    "version": "356.v2da_d59a_3742b_",
-    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/356.v2da_d59a_3742b_/oss-symbols-api.hpi",
-    "sha256": "07x91ap75cchgqx175lshs706pb4n3wd2p5alcsg639xcvgwza62"
+    "version": "392.v27a_482d90083",
+    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/392.v27a_482d90083/oss-symbols-api.hpi",
+    "sha256": "0dilvhwi7hafr1dc322ngp1r0lk8bplpk0lj8gwg7fh8f4b2q0ig"
   },
   {
     "name": "parameterized-trigger",
-    "version": "859.vb_e3907a_07a_16",
-    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/859.vb_e3907a_07a_16/parameterized-trigger.hpi",
-    "sha256": "1wyky5if74f490wwc1r375dsq0hl08059888qsw1kw6si4wbqi1q"
+    "version": "873.v8b_e37dd8418f",
+    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/873.v8b_e37dd8418f/parameterized-trigger.hpi",
+    "sha256": "0r6vzwgfvrkgwcc9mk3pnlhr9z60hg02l7v55f8a9cxbh336k1fc"
   },
   {
     "name": "pipeline-build-step",
@@ -463,9 +463,9 @@
   },
   {
     "name": "pipeline-graph-view",
-    "version": "590.v06d574696250",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/590.v06d574696250/pipeline-graph-view.hpi",
-    "sha256": "0k61xy9yfmjysz6q1ym2jvh0ky3i8raddjpf8qc4hr0vww4fk61k"
+    "version": "619.v92f3fcdc39db_",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/619.v92f3fcdc39db_/pipeline-graph-view.hpi",
+    "sha256": "0sk51dzirw8bqrx8rbwlr8xk5mjbl2xyf3qg0if77l54w04d18a8"
   },
   {
     "name": "pipeline-groovy-lib",
@@ -475,9 +475,9 @@
   },
   {
     "name": "pipeline-input-step",
-    "version": "527.vd61b_1d3c5078",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/527.vd61b_1d3c5078/pipeline-input-step.hpi",
-    "sha256": "1309wfacpy1wjsb6paa6lxgsmhfgykd86pcbsbz2pl6qqb3i4bzq"
+    "version": "534.v352f0a_e98918",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/534.v352f0a_e98918/pipeline-input-step.hpi",
+    "sha256": "1vkyiw4384j8vqq91zv4wpsf1r25nzbd77gr48alkv84ikza55vs"
   },
   {
     "name": "pipeline-milestone-step",
@@ -487,21 +487,21 @@
   },
   {
     "name": "pipeline-model-api",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2255.v56a_15e805f12/pipeline-model-api.hpi",
-    "sha256": "16z4hjwh2nsrl3krs6ik5gi7wvsjz7y34glh99m9c5q5mf3d7whx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2265.v140e610fe9d5/pipeline-model-api.hpi",
+    "sha256": "0m8x4nkcl2v5mw6rv29d1sgwx6gqjszp28m3ippv1m5hr66nv7m3"
   },
   {
     "name": "pipeline-model-definition",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2255.v56a_15e805f12/pipeline-model-definition.hpi",
-    "sha256": "17rnjhy3yr2v1xrxglvdlzmkv8ixj7lkgi0mb39szk4101yj55sx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2265.v140e610fe9d5/pipeline-model-definition.hpi",
+    "sha256": "0bxv1534203dsgqjyg311r0ks92rbgi26brl28wp90dnipcdl852"
   },
   {
     "name": "pipeline-model-extensions",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2255.v56a_15e805f12/pipeline-model-extensions.hpi",
-    "sha256": "1qw1ikkdxdpgdm3il1hpmc0bcjcf1p2gxczhmypy6w1pdhkginrc"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2265.v140e610fe9d5/pipeline-model-extensions.hpi",
+    "sha256": "1zls5vz1znwp9fcniqkgv6hmhfcb17g3fw6x0kd01581zc6xr36f"
   },
   {
     "name": "pipeline-rest-api",
@@ -517,9 +517,9 @@
   },
   {
     "name": "pipeline-stage-tags-metadata",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2255.v56a_15e805f12/pipeline-stage-tags-metadata.hpi",
-    "sha256": "0v2mcjc0kxl8nzdipjn6sak4y0l4k86rn9i3x2nlc61c9narl8cq"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2265.v140e610fe9d5/pipeline-stage-tags-metadata.hpi",
+    "sha256": "02jld8bhjrn2k4hgd8gbhs00bv78sfkvm4ala39xk8c3my4szppq"
   },
   {
     "name": "pipeline-stage-view",
@@ -565,9 +565,9 @@
   },
   {
     "name": "reverse-proxy-auth-plugin",
-    "version": "238.v82ceca_8417a_6",
-    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/238.v82ceca_8417a_6/reverse-proxy-auth-plugin.hpi",
-    "sha256": "18dakdm8p7x1zw8fibvnbiyjrp6l7dzg5w2z44zva7s19may86aj"
+    "version": "245.v93f25b_b_b_3102",
+    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/245.v93f25b_b_b_3102/reverse-proxy-auth-plugin.hpi",
+    "sha256": "0hvhnmy6zvd4m20xvqaln8dl0912jfhaw1v6j2y685yl1z1216m0"
   },
   {
     "name": "robot",
@@ -583,21 +583,21 @@
   },
   {
     "name": "scm-api",
-    "version": "704.v3ce5c542825a_",
-    "url": "https://updates.jenkins.io/download/plugins/scm-api/704.v3ce5c542825a_/scm-api.hpi",
-    "sha256": "1j8hv8hl4mcmybmzzvjhvvn6133i4bym1pck3x1zh4dhd98j6wpf"
+    "version": "707.v749f968369d4",
+    "url": "https://updates.jenkins.io/download/plugins/scm-api/707.v749f968369d4/scm-api.hpi",
+    "sha256": "15154mwr8bibxyb0jgdma799k6ahjl3jjagvjiiw1pzcyivxbiw7"
   },
   {
     "name": "script-security",
-    "version": "1373.vb_b_4a_a_c26fa_00",
-    "url": "https://updates.jenkins.io/download/plugins/script-security/1373.vb_b_4a_a_c26fa_00/script-security.hpi",
-    "sha256": "09y4xysz3xjdyjmgspak78llhgac7zzcl6rkjmjpf5ab29igx6bi"
+    "version": "1378.vf25626395f49",
+    "url": "https://updates.jenkins.io/download/plugins/script-security/1378.vf25626395f49/script-security.hpi",
+    "sha256": "1qlrpwqydl598zqljp4204j2hgb25vkd1rma4723j0r9gkbfmn1d"
   },
   {
     "name": "scriptler",
-    "version": "397.vc46f19cb_3c18",
-    "url": "https://updates.jenkins.io/download/plugins/scriptler/397.vc46f19cb_3c18/scriptler.hpi",
-    "sha256": "1sj4sbz7yfrb35l0mgis12y3a23y811wfznbzx2cw7alvsi8ykr2"
+    "version": "425.v09a_dc03401b_0",
+    "url": "https://updates.jenkins.io/download/plugins/scriptler/425.v09a_dc03401b_0/scriptler.hpi",
+    "sha256": "0ynkwlw06nsp0k3xg989nlai3jnni2nvl1l6q4y5lpnnsaa33zvk"
   },
   {
     "name": "snakeyaml-api",
@@ -607,39 +607,39 @@
   },
   {
     "name": "ssh-credentials",
-    "version": "359.v2191c4cf635f",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/359.v2191c4cf635f/ssh-credentials.hpi",
-    "sha256": "0idq2yfjh3bmrlyi3lbi599zahjmpbvx6v9qfqlfcjik5y863c20"
+    "version": "361.vb_f6760818e8c",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/361.vb_f6760818e8c/ssh-credentials.hpi",
+    "sha256": "0nilaf2ds1favqi3l4xi3qlclyip9v23di0spgh9gq7xzxacg00y"
   },
   {
     "name": "ssh-slaves",
-    "version": "3.1031.v72c6b_883b_869",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1031.v72c6b_883b_869/ssh-slaves.hpi",
-    "sha256": "0z7hn30wd3wd5h098pachjral0si15rp96q28c63mpqqbgqm1gwl"
+    "version": "3.1071.v0d059c7b_c555",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1071.v0d059c7b_c555/ssh-slaves.hpi",
+    "sha256": "0mdbbf1ffiyi3q866rayxd0zs8q1593c0qibh3qllksw99ir8zb8"
   },
   {
     "name": "sshd",
-    "version": "3.372.v5d04a_e92d8cf",
-    "url": "https://updates.jenkins.io/download/plugins/sshd/3.372.v5d04a_e92d8cf/sshd.hpi",
-    "sha256": "0gmwss6csr8ssmvjad7p91hcxya9k1kfpp4wpgnhsgfhrnggxfw1"
+    "version": "3.374.v19b_d59ce6610",
+    "url": "https://updates.jenkins.io/download/plugins/sshd/3.374.v19b_d59ce6610/sshd.hpi",
+    "sha256": "0ix0x0rxj730gsglvny7dp734qphs7pyny77k03vjqz2zm4c9p3k"
   },
   {
     "name": "structs",
-    "version": "350.v3b_30f09f2363",
-    "url": "https://updates.jenkins.io/download/plugins/structs/350.v3b_30f09f2363/structs.hpi",
-    "sha256": "16g71kczi0p298g4lsswvjy8n1ariby1ng9krl6srq2cdsqfhhg3"
+    "version": "353.v261ea_40a_80fb_",
+    "url": "https://updates.jenkins.io/download/plugins/structs/353.v261ea_40a_80fb_/structs.hpi",
+    "sha256": "0bkkgbvxg0632ybrw8aip0xsl832dq0009pqcbazzxkbfpqws8cy"
   },
   {
     "name": "subversion",
-    "version": "1287.vd2d507146906",
-    "url": "https://updates.jenkins.io/download/plugins/subversion/1287.vd2d507146906/subversion.hpi",
-    "sha256": "11sv1xy2klbf9l09n7lry06xg448x5z5qbllja3kafib597183l2"
+    "version": "1292.ve8cf25770ee3",
+    "url": "https://updates.jenkins.io/download/plugins/subversion/1292.ve8cf25770ee3/subversion.hpi",
+    "sha256": "178sbcvzggda8f1m4ya99hvkd1vfrsrczhh2lk6lrrij7wsj3i1h"
   },
   {
     "name": "support-core",
-    "version": "1739.v0d10c0a_57cb_e",
-    "url": "https://updates.jenkins.io/download/plugins/support-core/1739.v0d10c0a_57cb_e/support-core.hpi",
-    "sha256": "0bml1pfv0w3979fqyda26r5286c8rlsrz3v23rf8y3ym4byn9svh"
+    "version": "1758.v87f0f880c067",
+    "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
+    "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
   },
   {
     "name": "timestamper",
@@ -649,9 +649,9 @@
   },
   {
     "name": "token-macro",
-    "version": "444.v52de7e9c573d",
-    "url": "https://updates.jenkins.io/download/plugins/token-macro/444.v52de7e9c573d/token-macro.hpi",
-    "sha256": "0slyazvqi63g4d57lm6jkmmnkcw1kkqfycnwvq1qlddmpqa9n3qv"
+    "version": "477.vd4f0dc3cb_cf1",
+    "url": "https://updates.jenkins.io/download/plugins/token-macro/477.vd4f0dc3cb_cf1/token-macro.hpi",
+    "sha256": "0axlnsvnj1r58k7x9x9hwbpvl0qi1p2f3b15i6bffwbm8rxy967g"
   },
   {
     "name": "trilead-api",
@@ -685,9 +685,9 @@
   },
   {
     "name": "workflow-api",
-    "version": "1373.v7b_813f10efa_b_",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1373.v7b_813f10efa_b_/workflow-api.hpi",
-    "sha256": "1c161pxxl15ydp1pzf7vd7gv9si8vlz55n528is6vgjbwv774rzm"
+    "version": "1384.vdc05a_48f535f",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1384.vdc05a_48f535f/workflow-api.hpi",
+    "sha256": "10hfhzzfhh2nmhj9qy13d4q9bcw0rg034iy1kjlha2kwg5dqg1yj"
   },
   {
     "name": "workflow-basic-steps",
@@ -697,15 +697,15 @@
   },
   {
     "name": "workflow-cps",
-    "version": "4150.ve20ca_b_a_a_2815",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4150.ve20ca_b_a_a_2815/workflow-cps.hpi",
-    "sha256": "0b26r675s2h8n3dnd3r3k79a5vjs18wk5j9r6qdyzphv3rn8m652"
+    "version": "4183.v94b_6fd39da_c1",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4183.v94b_6fd39da_c1/workflow-cps.hpi",
+    "sha256": "1malwfi5cj2ha3d1xgbkrkw746cwmk1b0j1yqvfkm5i3yi434zsn"
   },
   {
     "name": "workflow-durable-task-step",
-    "version": "1434.v1b_595c29ddd7",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1434.v1b_595c29ddd7/workflow-durable-task-step.hpi",
-    "sha256": "1k34ymais9xacs1nakdhiv09p1mvd3a5nsp97967cxyvg0gvm85i"
+    "version": "1452.v0ee719c104a_7",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1452.v0ee719c104a_7/workflow-durable-task-step.hpi",
+    "sha256": "0asfz07plmaghh8kky1ffmfwfhb3qw5wk0ydnr3m8632k607n2fb"
   },
   {
     "name": "workflow-job",
@@ -715,9 +715,9 @@
   },
   {
     "name": "workflow-multibranch",
-    "version": "806.vb_b_688f609ee9",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/806.vb_b_688f609ee9/workflow-multibranch.hpi",
-    "sha256": "1gim0q59x8yzfdkhmk5svi4ns4v84m767wyq76jjik7xsb6mhw34"
+    "version": "811.vcd33d074c2a_0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/811.vcd33d074c2a_0/workflow-multibranch.hpi",
+    "sha256": "0mm10a3wfbi8qizmixkipgf07jl1yhvyw7nmwwwkgv6nvzxvzjhi"
   },
   {
     "name": "workflow-scm-step",
@@ -727,14 +727,14 @@
   },
   {
     "name": "workflow-step-api",
-    "version": "700.v6e45cb_a_5a_a_21",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/700.v6e45cb_a_5a_a_21/workflow-step-api.hpi",
-    "sha256": "0j3y00idx8qm7lj6kl0c3rx5sgszfc7lzwpah3z8pf86jzv307i0"
+    "version": "706.v518c5dcb_24c0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/706.v518c5dcb_24c0/workflow-step-api.hpi",
+    "sha256": "1q0vsc4xjqzqnzjs5wn72pkjq7kgzq15zj7p8pw7w8mr1k08wpb8"
   },
   {
     "name": "workflow-support",
-    "version": "968.v8f17397e87b_8",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-support/968.v8f17397e87b_8/workflow-support.hpi",
-    "sha256": "0i1412z0ap79y4zix941z2l8i24inssfmirm7p7nkvgpa76mnlaz"
+    "version": "976.vb_d9493c2eb_09",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-support/976.vb_d9493c2eb_09/workflow-support.hpi",
+    "sha256": "0s9px2czgyqankln5sb5arv61pb30i0byks49c82vgwd9hqf0v0w"
   }
 ]

--- a/hosts/hetzci/dev/plugins.txt
+++ b/hosts/hetzci/dev/plugins.txt
@@ -16,3 +16,4 @@ robot
 timestamper
 uno-choice
 workflow-aggregator
+dark-theme

--- a/hosts/hetzci/prod/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/prod/casc/jenkins-casc.yaml
@@ -1,6 +1,8 @@
 appearance:
   pipelineGraphView:
     showGraphOnBuildPage: true
+  themeManager:
+    theme: "darkSystem" # follow system theme 
 
 jenkins:
   authorizationStrategy:

--- a/hosts/hetzci/prod/plugins.json
+++ b/hosts/hetzci/prod/plugins.json
@@ -162,6 +162,12 @@
     "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
+    "name": "dark-theme",
+    "version": "524.vd675b_22b_30cb_",
+    "url": "https://updates.jenkins.io/download/plugins/dark-theme/524.vd675b_22b_30cb_/dark-theme.hpi",
+    "sha256": "15h6l51805b4vkcc895z06h20nardxqn19h0mwkhkdcfqwr1jy11"
+  },
+  {
     "name": "data-tables-api",
     "version": "2.3.2-3",
     "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
@@ -640,6 +646,12 @@
     "version": "1758.v87f0f880c067",
     "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
     "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
+  },
+  {
+    "name": "theme-manager",
+    "version": "319.v9193461f9671",
+    "url": "https://updates.jenkins.io/download/plugins/theme-manager/319.v9193461f9671/theme-manager.hpi",
+    "sha256": "1b11kpb1663k1hw4as7r6iw1lzn27z1wnl69lvrl8ad60hpgar6j"
   },
   {
     "name": "timestamper",

--- a/hosts/hetzci/prod/plugins.json
+++ b/hosts/hetzci/prod/plugins.json
@@ -13,9 +13,9 @@
   },
   {
     "name": "asm-api",
-    "version": "9.8-135.vb_2239d08ee90",
-    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-135.vb_2239d08ee90/asm-api.hpi",
-    "sha256": "1m1ppbja2rn315sc720gxhi3ji64nqfdawa3rgdbd60ybry1zrwm"
+    "version": "9.8-163.vb_2a_96d3f9c3c",
+    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-163.vb_2a_96d3f9c3c/asm-api.hpi",
+    "sha256": "0jgwd9i1h0739v8d1jcvfc3wkjnyhknywzk2k3fi9avknlgc24rv"
   },
   {
     "name": "block-queued-job",
@@ -61,27 +61,27 @@
   },
   {
     "name": "bootstrap5-api",
-    "version": "5.3.7-1",
-    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-1/bootstrap5-api.hpi",
-    "sha256": "1d4r5766dl164jl8xzaw2hs4vf7wqafxi6zm6ls8jg5jdqnp539a"
+    "version": "5.3.7-2",
+    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-2/bootstrap5-api.hpi",
+    "sha256": "1w0gqk3fz3vrn0830liwk7asd2mlpmsifi3hcgwi0afa9mylriqn"
   },
   {
     "name": "bouncycastle-api",
-    "version": "2.30.1.80-261.v00c0e2618ec3",
-    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.80-261.v00c0e2618ec3/bouncycastle-api.hpi",
-    "sha256": "1h06h7iqyvppi28x7mcw42gh1im3g0lay1rhxhimg42ly8fisa0n"
+    "version": "2.30.1.81-264.v95c79c0e772c",
+    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.81-264.v95c79c0e772c/bouncycastle-api.hpi",
+    "sha256": "04vwrr5117pd6j51xgw4vkcqrmfhgig2l4chjnxw9jkqybadlwdg"
   },
   {
     "name": "branch-api",
-    "version": "2.1226.ve1e7e0b_4b_95f",
-    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1226.ve1e7e0b_4b_95f/branch-api.hpi",
-    "sha256": "0gv81jnmlzl75a40mq8mjw8nm1nnljafy1nvw0ylqdkdnkdx7rmx"
+    "version": "2.1244.vf95c81f1641c",
+    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1244.vf95c81f1641c/branch-api.hpi",
+    "sha256": "0sjspfg6chwabds0gm8bhjbw0irm2318yl9wj7m16abryfqinj77"
   },
   {
     "name": "caffeine-api",
-    "version": "3.2.0-166.v72a_6d74b_870f",
-    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.0-166.v72a_6d74b_870f/caffeine-api.hpi",
-    "sha256": "04zh7lnzwhrjjp534g5aaz2bd32d3lgvcjy0dxinbjg5214y6pnr"
+    "version": "3.2.2-178.v353b_8428ed56",
+    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.2-178.v353b_8428ed56/caffeine-api.hpi",
+    "sha256": "1da6kx4p06laafw9rnw772wsfsnyldiwdb02s0qfb75rwccngyx8"
   },
   {
     "name": "checks-api",
@@ -91,9 +91,9 @@
   },
   {
     "name": "cloudbees-folder",
-    "version": "6.1026.ve06dfa_cf31c3",
-    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1026.ve06dfa_cf31c3/cloudbees-folder.hpi",
-    "sha256": "1nic6xll8cwmw6hxx4759dkf40s384nscjxxw6b9p0j84zmmaa7g"
+    "version": "6.1037.v4cb_8573b_72a_a_",
+    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1037.v4cb_8573b_72a_a_/cloudbees-folder.hpi",
+    "sha256": "09wmaar2wj28a82b3h3grs8vy8p3n2wizv64m4y6517ja8w5vkwd"
   },
   {
     "name": "command-launcher",
@@ -103,21 +103,21 @@
   },
   {
     "name": "commons-compress-api",
-    "version": "1.27.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.27.1-3/commons-compress-api.hpi",
-    "sha256": "0abwp2kyh7fn63bsqmnbikyhj7yjj3z49859z65hkp4bwlkymgyq"
+    "version": "1.28.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.28.0-1/commons-compress-api.hpi",
+    "sha256": "1wv76vd1kgbsd5flpcznalkh38jxfvk5vipb6f14nwd1nb52pykp"
   },
   {
     "name": "commons-lang3-api",
-    "version": "3.17.0-87.v5cf526e63b_8b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.17.0-87.v5cf526e63b_8b_/commons-lang3-api.hpi",
-    "sha256": "1kslvyhh0kkpn98276rpl84ia2zlpwm9f7b4nzq7l3dnvdkx8m6n"
+    "version": "3.18.0-98.v3a_674c06072d",
+    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.18.0-98.v3a_674c06072d/commons-lang3-api.hpi",
+    "sha256": "198la3854akm1zlpcjcdxglr7q0mh7db0hdrd2yizzh535p3w0c2"
   },
   {
     "name": "commons-text-api",
-    "version": "1.13.1-176.v74d88f22034b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.13.1-176.v74d88f22034b_/commons-text-api.hpi",
-    "sha256": "0vbh3gz4v827i7y560lqf3g2mqy31pz920znxy0q5q80c7aqf60x"
+    "version": "1.14.0-194.v804a_dc3a_1b_d8",
+    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.14.0-194.v804a_dc3a_1b_d8/commons-text-api.hpi",
+    "sha256": "0plf0pwacva6gv3wwnmqih2w9czbqjdi2ybi2zvd73a76vdarsa9"
   },
   {
     "name": "conditional-buildstep",
@@ -127,15 +127,15 @@
   },
   {
     "name": "config-file-provider",
-    "version": "988.v0461fcc2b_9d1",
-    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/988.v0461fcc2b_9d1/config-file-provider.hpi",
-    "sha256": "18nkwslzdhc7g5z9pzdhlfdqlap8mjah39mlhks4h85zx3hpnykh"
+    "version": "994.v3d4a_5fa_f353a_",
+    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/994.v3d4a_5fa_f353a_/config-file-provider.hpi",
+    "sha256": "1q2niravbilrwwx0f762yvrnmpxcz7k00arac7lw881q5gzcrfvs"
   },
   {
     "name": "configuration-as-code",
-    "version": "1971.vf9280461ea_89",
-    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1971.vf9280461ea_89/configuration-as-code.hpi",
-    "sha256": "16x29fal06209zj3qbvs5sz748pwnhpryw8gvrydqy341r2sc6l4"
+    "version": "1985.vdda_32d0c4ea_b_",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1985.vdda_32d0c4ea_b_/configuration-as-code.hpi",
+    "sha256": "186wv8ma43bv73562m7hadhvs6cbqyx9r3mpdi63gh46v6y503sw"
   },
   {
     "name": "configuration-as-code-groovy",
@@ -151,39 +151,39 @@
   },
   {
     "name": "credentials",
-    "version": "1415.v831096eb_5534",
-    "url": "https://updates.jenkins.io/download/plugins/credentials/1415.v831096eb_5534/credentials.hpi",
-    "sha256": "1462p5sq2kx76jann27vc1zkpl6wiiwzjapxai8l0gprpsjiv9m1"
+    "version": "1419.v2337d1ceceef",
+    "url": "https://updates.jenkins.io/download/plugins/credentials/1419.v2337d1ceceef/credentials.hpi",
+    "sha256": "0a4pja7mvf3f6009c0jwf6979rd5wadgbs8wa1lw49bnrad1y4m4"
   },
   {
     "name": "credentials-binding",
-    "version": "687.v619cb_15e923f",
-    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/687.v619cb_15e923f/credentials-binding.hpi",
-    "sha256": "03bxygj33xmishd2pbqkrgnwwijs7akfyq1g5xwy68gwgc39qn1s"
+    "version": "702.vfe613e537e88",
+    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/702.vfe613e537e88/credentials-binding.hpi",
+    "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
     "name": "data-tables-api",
-    "version": "2.3.2-2",
-    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-2/data-tables-api.hpi",
-    "sha256": "1jgcznqj0zxyg6jwn0wyfbxij3dfxzi0nf1zq09rzqczj2df78h9"
+    "version": "2.3.2-3",
+    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
+    "sha256": "0sqhxzcmyvwl1lsw5k8fl0pfb662656ciq9albikgmpi9rjcyjpn"
   },
   {
     "name": "display-url-api",
-    "version": "2.209.v582ed814ff2f",
-    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.209.v582ed814ff2f/display-url-api.hpi",
-    "sha256": "09b81rsyk27p2d96zwhay42h1wallh66ckaxi9q6jdxrbgwpac21"
+    "version": "2.217.va_6b_de84cc74b_",
+    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.217.va_6b_de84cc74b_/display-url-api.hpi",
+    "sha256": "1jn03bkxr8i2bfj0gfn788x4jv0war40p42n8zgblldl73ksmvh7"
   },
   {
     "name": "durable-task",
-    "version": "587.v84b_877235b_45",
-    "url": "https://updates.jenkins.io/download/plugins/durable-task/587.v84b_877235b_45/durable-task.hpi",
-    "sha256": "1d1rp7bf5iba88p1wkvqcilyfsm2bzzzgjb8gjrziyv7ay35sjpl"
+    "version": "595.ve87b_f1318d67",
+    "url": "https://updates.jenkins.io/download/plugins/durable-task/595.ve87b_f1318d67/durable-task.hpi",
+    "sha256": "1lf32pdwl9hx956a2yijna6l3qd18id6gxr6dps9kvlabm3nfw9m"
   },
   {
     "name": "echarts-api",
-    "version": "5.6.0-5",
-    "url": "https://updates.jenkins.io/download/plugins/echarts-api/5.6.0-5/echarts-api.hpi",
-    "sha256": "0mhimldjv57fmirhwj74wq8rld6pjxwx4svglyj2b7gy3dxiaznl"
+    "version": "6.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/echarts-api/6.0.0-1/echarts-api.hpi",
+    "sha256": "15f3pwa84ih2prk0q1yyslyap6vpjyij0q8zirg8z5p2qcvs98bp"
   },
   {
     "name": "eddsa-api",
@@ -193,9 +193,9 @@
   },
   {
     "name": "email-ext",
-    "version": "1911.v19b_8e86f9815",
-    "url": "https://updates.jenkins.io/download/plugins/email-ext/1911.v19b_8e86f9815/email-ext.hpi",
-    "sha256": "0pidv9lv5s4l9ixxrlnzkyk22za7z47v0jh96fd2vjrqiqslgj35"
+    "version": "1925.v1598902b_58dd",
+    "url": "https://updates.jenkins.io/download/plugins/email-ext/1925.v1598902b_58dd/email-ext.hpi",
+    "sha256": "0qgkyyibij27aisrq129fw8n61lxmpf770lry4sx9cfgfzr8bdis"
   },
   {
     "name": "favorite",
@@ -205,9 +205,9 @@
   },
   {
     "name": "font-awesome-api",
-    "version": "6.7.2-1",
-    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/6.7.2-1/font-awesome-api.hpi",
-    "sha256": "0gyx355sv5c82bqkqh2yi4rnbm68qg2vv6kmwxbc4p7lc5n6g703"
+    "version": "7.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/7.0.0-1/font-awesome-api.hpi",
+    "sha256": "0hcwg70x1lyikdhfyfbzq8pgwy4n0dww7klkgfj9l0r6vkmcdwnk"
   },
   {
     "name": "git",
@@ -217,9 +217,9 @@
   },
   {
     "name": "git-client",
-    "version": "6.2.0",
-    "url": "https://updates.jenkins.io/download/plugins/git-client/6.2.0/git-client.hpi",
-    "sha256": "0ybjvxk3ivpg202jb6nw7xdcmfbjpidz99byiyy66wgsq3cr6qam"
+    "version": "6.3.0",
+    "url": "https://updates.jenkins.io/download/plugins/git-client/6.3.0/git-client.hpi",
+    "sha256": "0bbd14pjsp9bp20s2raqc7fd4vrj32gbmrxchcmxr0n746papwgm"
   },
   {
     "name": "git-server",
@@ -229,9 +229,9 @@
   },
   {
     "name": "github",
-    "version": "1.43.0",
-    "url": "https://updates.jenkins.io/download/plugins/github/1.43.0/github.hpi",
-    "sha256": "0i8dn80xx7x0p79y6ifnl0kdaq86b2di5m3jirwgc69gc4f5g0xj"
+    "version": "1.44.0",
+    "url": "https://updates.jenkins.io/download/plugins/github/1.44.0/github.hpi",
+    "sha256": "1xppsq1aaywn337agpy5wy88aygr6q1vxhzzfy0pacs12zgkw89h"
   },
   {
     "name": "github-api",
@@ -241,9 +241,9 @@
   },
   {
     "name": "github-branch-source",
-    "version": "1824.v046257273408",
-    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1824.v046257273408/github-branch-source.hpi",
-    "sha256": "08a53njlfphyyfkpx288bp7acvhwfvnjhqfp56d0fkwxzjhixmcx"
+    "version": "1834.v857721ea_74c6",
+    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1834.v857721ea_74c6/github-branch-source.hpi",
+    "sha256": "1qsm5a6m0ljafanq1vxbppnvki0w5rypl0v3fm6b392c93l493v9"
   },
   {
     "name": "github-pullrequest",
@@ -253,9 +253,9 @@
   },
   {
     "name": "gson-api",
-    "version": "2.13.1-139.v4569c2ef303f",
-    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-139.v4569c2ef303f/gson-api.hpi",
-    "sha256": "0rz4a2kym62c9gf1p0ir1akdc8q09j394v0n314z49isf2n30hrj"
+    "version": "2.13.1-153.vb_3d0c48a_a_b_4a_",
+    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-153.vb_3d0c48a_a_b_4a_/gson-api.hpi",
+    "sha256": "1xn6ydnqaj2v4j5nhk710gb5cyrar14cvg5bbywi3266yii4148a"
   },
   {
     "name": "instance-identity",
@@ -265,15 +265,15 @@
   },
   {
     "name": "ionicons-api",
-    "version": "88.va_4187cb_eddf1",
-    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/88.va_4187cb_eddf1/ionicons-api.hpi",
-    "sha256": "0vzs1m251knzbjk3qpxk29pycs04dh50y1b0pw6vswkmb05a8vid"
+    "version": "94.vcc3065403257",
+    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/94.vcc3065403257/ionicons-api.hpi",
+    "sha256": "0gxcfglxhn1ry61wcbg43qk318h6aqnz7kaw8a3xha6nfm1m1wwm"
   },
   {
     "name": "jackson2-api",
-    "version": "2.19.0-404.vb_b_0fd2fea_e10",
-    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.0-404.vb_b_0fd2fea_e10/jackson2-api.hpi",
-    "sha256": "1pp8sa78mi33v0hhxsa0msr9vrg2h2lxc14liq1v962hj62253gy"
+    "version": "2.19.2-408.v18248a_324cfe",
+    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.2-408.v18248a_324cfe/jackson2-api.hpi",
+    "sha256": "158fz044pldpyqaagq9d54y7xba6id93xd8bhyrsgvnd5vmkjwiz"
   },
   {
     "name": "jakarta-activation-api",
@@ -289,9 +289,9 @@
   },
   {
     "name": "javadoc",
-    "version": "327.vdfe586651ee0",
-    "url": "https://updates.jenkins.io/download/plugins/javadoc/327.vdfe586651ee0/javadoc.hpi",
-    "sha256": "1nf6bi37m4j54jf20c2gljngazf5ngipsgmh3qpgg1i44pp583v9"
+    "version": "354.vee1a_660b_4990",
+    "url": "https://updates.jenkins.io/download/plugins/javadoc/354.vee1a_660b_4990/javadoc.hpi",
+    "sha256": "05dvpnn2587r0qwfngylwf33qb7s9nrwr1xqgv4jj99z85957h3d"
   },
   {
     "name": "javax-activation-api",
@@ -325,15 +325,15 @@
   },
   {
     "name": "joda-time-api",
-    "version": "2.14.0-127.v7d9da_295a_d51",
-    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-127.v7d9da_295a_d51/joda-time-api.hpi",
-    "sha256": "0p5hakxs02c445dm3vzzm0vyrcqiv49ppqxnwx1kg897ns7qjwy2"
+    "version": "2.14.0-149.v1c3ce991d1b_9",
+    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-149.v1c3ce991d1b_9/joda-time-api.hpi",
+    "sha256": "08wa03insvaybkybzn120gc9dxvd15qhq9y9ghckfgfalla042y5"
   },
   {
     "name": "jquery3-api",
-    "version": "3.7.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-3/jquery3-api.hpi",
-    "sha256": "0d1awnb0m5k9dg37333nmlma2s1991jm55zsmmsqqfq1jllg68qq"
+    "version": "3.7.1-583.vda_6ca_102270d",
+    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-583.vda_6ca_102270d/jquery3-api.hpi",
+    "sha256": "0yk8zain5inr2vllr0pikywbiryc2294cqzxl99asdi1yycdvr04"
   },
   {
     "name": "jsch",
@@ -343,21 +343,21 @@
   },
   {
     "name": "json-api",
-    "version": "20250517-153.vc8a_a_d87c0ce3",
-    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-153.vc8a_a_d87c0ce3/json-api.hpi",
-    "sha256": "0v6i0i1vp5q17b10r4vnn92kv4b1lw0wa79sm8bbx0410p6pk6v2"
+    "version": "20250517-163.v1c5da_e99c775",
+    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-163.v1c5da_e99c775/json-api.hpi",
+    "sha256": "18pfvp9pxl1gfmszbgipgl8vy4smbhq0afgn6gy7rzmsixg7w3f6"
   },
   {
     "name": "json-path-api",
-    "version": "2.9.0-148.v22a_7ffe323ce",
-    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-148.v22a_7ffe323ce/json-path-api.hpi",
-    "sha256": "14arnnsz9w23mmv9j2m66ynvf3jy9l4mzr2s8vy2sabcdgsc3z4k"
+    "version": "2.9.0-178.vca_b_c71881321",
+    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-178.vca_b_c71881321/json-path-api.hpi",
+    "sha256": "1bbn7aldzms9n4kz78nhvrr1qgyzvaqrqyqczyp0xzq14srk3hwg"
   },
   {
     "name": "jsoup",
-    "version": "1.21.1-52.v96e4041b_60fd",
-    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-52.v96e4041b_60fd/jsoup.hpi",
-    "sha256": "057rdrlxp98f0yhdp901p1w75j87hdp76jsnq9f3brfg89kgax6j"
+    "version": "1.21.1-58.vfc578e6e2610",
+    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-58.vfc578e6e2610/jsoup.hpi",
+    "sha256": "0n37y54ch7g7iw16srkyni8p8dijf4p3vnq7lrf0ivjahyk8cz5n"
   },
   {
     "name": "jucies",
@@ -373,15 +373,15 @@
   },
   {
     "name": "lockable-resources",
-    "version": "1349.v8b_ccb_c5487f7",
-    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1349.v8b_ccb_c5487f7/lockable-resources.hpi",
-    "sha256": "11fj40llz4diq93wqc9zaz3w4lsfb8fkrq09vw8lmjhri41qk5r8"
+    "version": "1412.v3f305a_fb_a_117",
+    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1412.v3f305a_fb_a_117/lockable-resources.hpi",
+    "sha256": "18j8k6lk00qgy43kavlxrwc8w5in96pvd36wjdy2iszv0w2rkwrm"
   },
   {
     "name": "mailer",
-    "version": "509.vc54d23fc427e",
-    "url": "https://updates.jenkins.io/download/plugins/mailer/509.vc54d23fc427e/mailer.hpi",
-    "sha256": "1vpypmkpl2li54ajyy3xd04dcngsh3qcz6nzn4jjp41m6cfnzpgg"
+    "version": "515.vd788654779b_1",
+    "url": "https://updates.jenkins.io/download/plugins/mailer/515.vd788654779b_1/mailer.hpi",
+    "sha256": "0c6f10kby3r38cj6s3wh8w69qhbf4k4vx30wfx4vkbqalsam9rzv"
   },
   {
     "name": "mapdb-api",
@@ -391,27 +391,27 @@
   },
   {
     "name": "matrix-auth",
-    "version": "3.2.6",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.6/matrix-auth.hpi",
-    "sha256": "1g3ij9f8ad6yhciyliwchv5dv7rlml7vghs64kmgrb9fff7pqgkj"
+    "version": "3.2.7",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.7/matrix-auth.hpi",
+    "sha256": "0j7d2ca1p0glda5vwxwh63pbas4v0w724wdls8nxaq5sj7x3mcb6"
   },
   {
     "name": "matrix-project",
-    "version": "849.v0cd64ed7e531",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-project/849.v0cd64ed7e531/matrix-project.hpi",
-    "sha256": "0rl2syrpi6dc6vylhqmsmr2y5mg7l73g2viv3cyrkgllj1gg3ixq"
+    "version": "856.v4c352b_3a_b_23e",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-project/856.v4c352b_3a_b_23e/matrix-project.hpi",
+    "sha256": "1mvchdmqm0qwqipc35mam0lkk1j9vcbni1qywp6llrbx6kdlmpwf"
   },
   {
     "name": "maven-plugin",
-    "version": "3.26",
-    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.26/maven-plugin.hpi",
-    "sha256": "1cdxpxr7yfm5fazdj26zmw8aqla95nmmj1qymypv7w2yg8ahs49f"
+    "version": "3.27",
+    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.27/maven-plugin.hpi",
+    "sha256": "1zh5anab4w251x3p7k7znhns5hvhflvw7428sgvfn68vmms9zmk4"
   },
   {
     "name": "metrics",
-    "version": "4.2.32-476.v5042e1c1edd7",
-    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-476.v5042e1c1edd7/metrics.hpi",
-    "sha256": "1kz7sqm2wbss4x3s3g8bdxa898nbzkhaypx823j83ijhcyqkqkac"
+    "version": "4.2.32-481.v75f035fdc894",
+    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-481.v75f035fdc894/metrics.hpi",
+    "sha256": "1gda878bnkwx1635znqw7p5q3inx1xkg0l9f132ggz56b5rvxy1l"
   },
   {
     "name": "mina-sshd-api-common",
@@ -439,15 +439,15 @@
   },
   {
     "name": "oss-symbols-api",
-    "version": "356.v2da_d59a_3742b_",
-    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/356.v2da_d59a_3742b_/oss-symbols-api.hpi",
-    "sha256": "07x91ap75cchgqx175lshs706pb4n3wd2p5alcsg639xcvgwza62"
+    "version": "392.v27a_482d90083",
+    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/392.v27a_482d90083/oss-symbols-api.hpi",
+    "sha256": "0dilvhwi7hafr1dc322ngp1r0lk8bplpk0lj8gwg7fh8f4b2q0ig"
   },
   {
     "name": "parameterized-trigger",
-    "version": "859.vb_e3907a_07a_16",
-    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/859.vb_e3907a_07a_16/parameterized-trigger.hpi",
-    "sha256": "1wyky5if74f490wwc1r375dsq0hl08059888qsw1kw6si4wbqi1q"
+    "version": "873.v8b_e37dd8418f",
+    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/873.v8b_e37dd8418f/parameterized-trigger.hpi",
+    "sha256": "0r6vzwgfvrkgwcc9mk3pnlhr9z60hg02l7v55f8a9cxbh336k1fc"
   },
   {
     "name": "pipeline-build-step",
@@ -463,9 +463,9 @@
   },
   {
     "name": "pipeline-graph-view",
-    "version": "590.v06d574696250",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/590.v06d574696250/pipeline-graph-view.hpi",
-    "sha256": "0k61xy9yfmjysz6q1ym2jvh0ky3i8raddjpf8qc4hr0vww4fk61k"
+    "version": "619.v92f3fcdc39db_",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/619.v92f3fcdc39db_/pipeline-graph-view.hpi",
+    "sha256": "0sk51dzirw8bqrx8rbwlr8xk5mjbl2xyf3qg0if77l54w04d18a8"
   },
   {
     "name": "pipeline-groovy-lib",
@@ -475,9 +475,9 @@
   },
   {
     "name": "pipeline-input-step",
-    "version": "527.vd61b_1d3c5078",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/527.vd61b_1d3c5078/pipeline-input-step.hpi",
-    "sha256": "1309wfacpy1wjsb6paa6lxgsmhfgykd86pcbsbz2pl6qqb3i4bzq"
+    "version": "534.v352f0a_e98918",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/534.v352f0a_e98918/pipeline-input-step.hpi",
+    "sha256": "1vkyiw4384j8vqq91zv4wpsf1r25nzbd77gr48alkv84ikza55vs"
   },
   {
     "name": "pipeline-milestone-step",
@@ -487,21 +487,21 @@
   },
   {
     "name": "pipeline-model-api",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2255.v56a_15e805f12/pipeline-model-api.hpi",
-    "sha256": "16z4hjwh2nsrl3krs6ik5gi7wvsjz7y34glh99m9c5q5mf3d7whx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2265.v140e610fe9d5/pipeline-model-api.hpi",
+    "sha256": "0m8x4nkcl2v5mw6rv29d1sgwx6gqjszp28m3ippv1m5hr66nv7m3"
   },
   {
     "name": "pipeline-model-definition",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2255.v56a_15e805f12/pipeline-model-definition.hpi",
-    "sha256": "17rnjhy3yr2v1xrxglvdlzmkv8ixj7lkgi0mb39szk4101yj55sx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2265.v140e610fe9d5/pipeline-model-definition.hpi",
+    "sha256": "0bxv1534203dsgqjyg311r0ks92rbgi26brl28wp90dnipcdl852"
   },
   {
     "name": "pipeline-model-extensions",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2255.v56a_15e805f12/pipeline-model-extensions.hpi",
-    "sha256": "1qw1ikkdxdpgdm3il1hpmc0bcjcf1p2gxczhmypy6w1pdhkginrc"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2265.v140e610fe9d5/pipeline-model-extensions.hpi",
+    "sha256": "1zls5vz1znwp9fcniqkgv6hmhfcb17g3fw6x0kd01581zc6xr36f"
   },
   {
     "name": "pipeline-rest-api",
@@ -517,9 +517,9 @@
   },
   {
     "name": "pipeline-stage-tags-metadata",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2255.v56a_15e805f12/pipeline-stage-tags-metadata.hpi",
-    "sha256": "0v2mcjc0kxl8nzdipjn6sak4y0l4k86rn9i3x2nlc61c9narl8cq"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2265.v140e610fe9d5/pipeline-stage-tags-metadata.hpi",
+    "sha256": "02jld8bhjrn2k4hgd8gbhs00bv78sfkvm4ala39xk8c3my4szppq"
   },
   {
     "name": "pipeline-stage-view",
@@ -565,9 +565,9 @@
   },
   {
     "name": "reverse-proxy-auth-plugin",
-    "version": "238.v82ceca_8417a_6",
-    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/238.v82ceca_8417a_6/reverse-proxy-auth-plugin.hpi",
-    "sha256": "18dakdm8p7x1zw8fibvnbiyjrp6l7dzg5w2z44zva7s19may86aj"
+    "version": "245.v93f25b_b_b_3102",
+    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/245.v93f25b_b_b_3102/reverse-proxy-auth-plugin.hpi",
+    "sha256": "0hvhnmy6zvd4m20xvqaln8dl0912jfhaw1v6j2y685yl1z1216m0"
   },
   {
     "name": "robot",
@@ -583,21 +583,21 @@
   },
   {
     "name": "scm-api",
-    "version": "704.v3ce5c542825a_",
-    "url": "https://updates.jenkins.io/download/plugins/scm-api/704.v3ce5c542825a_/scm-api.hpi",
-    "sha256": "1j8hv8hl4mcmybmzzvjhvvn6133i4bym1pck3x1zh4dhd98j6wpf"
+    "version": "707.v749f968369d4",
+    "url": "https://updates.jenkins.io/download/plugins/scm-api/707.v749f968369d4/scm-api.hpi",
+    "sha256": "15154mwr8bibxyb0jgdma799k6ahjl3jjagvjiiw1pzcyivxbiw7"
   },
   {
     "name": "script-security",
-    "version": "1373.vb_b_4a_a_c26fa_00",
-    "url": "https://updates.jenkins.io/download/plugins/script-security/1373.vb_b_4a_a_c26fa_00/script-security.hpi",
-    "sha256": "09y4xysz3xjdyjmgspak78llhgac7zzcl6rkjmjpf5ab29igx6bi"
+    "version": "1378.vf25626395f49",
+    "url": "https://updates.jenkins.io/download/plugins/script-security/1378.vf25626395f49/script-security.hpi",
+    "sha256": "1qlrpwqydl598zqljp4204j2hgb25vkd1rma4723j0r9gkbfmn1d"
   },
   {
     "name": "scriptler",
-    "version": "397.vc46f19cb_3c18",
-    "url": "https://updates.jenkins.io/download/plugins/scriptler/397.vc46f19cb_3c18/scriptler.hpi",
-    "sha256": "1sj4sbz7yfrb35l0mgis12y3a23y811wfznbzx2cw7alvsi8ykr2"
+    "version": "425.v09a_dc03401b_0",
+    "url": "https://updates.jenkins.io/download/plugins/scriptler/425.v09a_dc03401b_0/scriptler.hpi",
+    "sha256": "0ynkwlw06nsp0k3xg989nlai3jnni2nvl1l6q4y5lpnnsaa33zvk"
   },
   {
     "name": "snakeyaml-api",
@@ -607,39 +607,39 @@
   },
   {
     "name": "ssh-credentials",
-    "version": "359.v2191c4cf635f",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/359.v2191c4cf635f/ssh-credentials.hpi",
-    "sha256": "0idq2yfjh3bmrlyi3lbi599zahjmpbvx6v9qfqlfcjik5y863c20"
+    "version": "361.vb_f6760818e8c",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/361.vb_f6760818e8c/ssh-credentials.hpi",
+    "sha256": "0nilaf2ds1favqi3l4xi3qlclyip9v23di0spgh9gq7xzxacg00y"
   },
   {
     "name": "ssh-slaves",
-    "version": "3.1031.v72c6b_883b_869",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1031.v72c6b_883b_869/ssh-slaves.hpi",
-    "sha256": "0z7hn30wd3wd5h098pachjral0si15rp96q28c63mpqqbgqm1gwl"
+    "version": "3.1071.v0d059c7b_c555",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1071.v0d059c7b_c555/ssh-slaves.hpi",
+    "sha256": "0mdbbf1ffiyi3q866rayxd0zs8q1593c0qibh3qllksw99ir8zb8"
   },
   {
     "name": "sshd",
-    "version": "3.372.v5d04a_e92d8cf",
-    "url": "https://updates.jenkins.io/download/plugins/sshd/3.372.v5d04a_e92d8cf/sshd.hpi",
-    "sha256": "0gmwss6csr8ssmvjad7p91hcxya9k1kfpp4wpgnhsgfhrnggxfw1"
+    "version": "3.374.v19b_d59ce6610",
+    "url": "https://updates.jenkins.io/download/plugins/sshd/3.374.v19b_d59ce6610/sshd.hpi",
+    "sha256": "0ix0x0rxj730gsglvny7dp734qphs7pyny77k03vjqz2zm4c9p3k"
   },
   {
     "name": "structs",
-    "version": "350.v3b_30f09f2363",
-    "url": "https://updates.jenkins.io/download/plugins/structs/350.v3b_30f09f2363/structs.hpi",
-    "sha256": "16g71kczi0p298g4lsswvjy8n1ariby1ng9krl6srq2cdsqfhhg3"
+    "version": "353.v261ea_40a_80fb_",
+    "url": "https://updates.jenkins.io/download/plugins/structs/353.v261ea_40a_80fb_/structs.hpi",
+    "sha256": "0bkkgbvxg0632ybrw8aip0xsl832dq0009pqcbazzxkbfpqws8cy"
   },
   {
     "name": "subversion",
-    "version": "1287.vd2d507146906",
-    "url": "https://updates.jenkins.io/download/plugins/subversion/1287.vd2d507146906/subversion.hpi",
-    "sha256": "11sv1xy2klbf9l09n7lry06xg448x5z5qbllja3kafib597183l2"
+    "version": "1292.ve8cf25770ee3",
+    "url": "https://updates.jenkins.io/download/plugins/subversion/1292.ve8cf25770ee3/subversion.hpi",
+    "sha256": "178sbcvzggda8f1m4ya99hvkd1vfrsrczhh2lk6lrrij7wsj3i1h"
   },
   {
     "name": "support-core",
-    "version": "1739.v0d10c0a_57cb_e",
-    "url": "https://updates.jenkins.io/download/plugins/support-core/1739.v0d10c0a_57cb_e/support-core.hpi",
-    "sha256": "0bml1pfv0w3979fqyda26r5286c8rlsrz3v23rf8y3ym4byn9svh"
+    "version": "1758.v87f0f880c067",
+    "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
+    "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
   },
   {
     "name": "timestamper",
@@ -649,9 +649,9 @@
   },
   {
     "name": "token-macro",
-    "version": "444.v52de7e9c573d",
-    "url": "https://updates.jenkins.io/download/plugins/token-macro/444.v52de7e9c573d/token-macro.hpi",
-    "sha256": "0slyazvqi63g4d57lm6jkmmnkcw1kkqfycnwvq1qlddmpqa9n3qv"
+    "version": "477.vd4f0dc3cb_cf1",
+    "url": "https://updates.jenkins.io/download/plugins/token-macro/477.vd4f0dc3cb_cf1/token-macro.hpi",
+    "sha256": "0axlnsvnj1r58k7x9x9hwbpvl0qi1p2f3b15i6bffwbm8rxy967g"
   },
   {
     "name": "trilead-api",
@@ -685,9 +685,9 @@
   },
   {
     "name": "workflow-api",
-    "version": "1373.v7b_813f10efa_b_",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1373.v7b_813f10efa_b_/workflow-api.hpi",
-    "sha256": "1c161pxxl15ydp1pzf7vd7gv9si8vlz55n528is6vgjbwv774rzm"
+    "version": "1384.vdc05a_48f535f",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1384.vdc05a_48f535f/workflow-api.hpi",
+    "sha256": "10hfhzzfhh2nmhj9qy13d4q9bcw0rg034iy1kjlha2kwg5dqg1yj"
   },
   {
     "name": "workflow-basic-steps",
@@ -697,15 +697,15 @@
   },
   {
     "name": "workflow-cps",
-    "version": "4150.ve20ca_b_a_a_2815",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4150.ve20ca_b_a_a_2815/workflow-cps.hpi",
-    "sha256": "0b26r675s2h8n3dnd3r3k79a5vjs18wk5j9r6qdyzphv3rn8m652"
+    "version": "4183.v94b_6fd39da_c1",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4183.v94b_6fd39da_c1/workflow-cps.hpi",
+    "sha256": "1malwfi5cj2ha3d1xgbkrkw746cwmk1b0j1yqvfkm5i3yi434zsn"
   },
   {
     "name": "workflow-durable-task-step",
-    "version": "1434.v1b_595c29ddd7",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1434.v1b_595c29ddd7/workflow-durable-task-step.hpi",
-    "sha256": "1k34ymais9xacs1nakdhiv09p1mvd3a5nsp97967cxyvg0gvm85i"
+    "version": "1452.v0ee719c104a_7",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1452.v0ee719c104a_7/workflow-durable-task-step.hpi",
+    "sha256": "0asfz07plmaghh8kky1ffmfwfhb3qw5wk0ydnr3m8632k607n2fb"
   },
   {
     "name": "workflow-job",
@@ -715,9 +715,9 @@
   },
   {
     "name": "workflow-multibranch",
-    "version": "806.vb_b_688f609ee9",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/806.vb_b_688f609ee9/workflow-multibranch.hpi",
-    "sha256": "1gim0q59x8yzfdkhmk5svi4ns4v84m767wyq76jjik7xsb6mhw34"
+    "version": "811.vcd33d074c2a_0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/811.vcd33d074c2a_0/workflow-multibranch.hpi",
+    "sha256": "0mm10a3wfbi8qizmixkipgf07jl1yhvyw7nmwwwkgv6nvzxvzjhi"
   },
   {
     "name": "workflow-scm-step",
@@ -727,14 +727,14 @@
   },
   {
     "name": "workflow-step-api",
-    "version": "700.v6e45cb_a_5a_a_21",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/700.v6e45cb_a_5a_a_21/workflow-step-api.hpi",
-    "sha256": "0j3y00idx8qm7lj6kl0c3rx5sgszfc7lzwpah3z8pf86jzv307i0"
+    "version": "706.v518c5dcb_24c0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/706.v518c5dcb_24c0/workflow-step-api.hpi",
+    "sha256": "1q0vsc4xjqzqnzjs5wn72pkjq7kgzq15zj7p8pw7w8mr1k08wpb8"
   },
   {
     "name": "workflow-support",
-    "version": "968.v8f17397e87b_8",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-support/968.v8f17397e87b_8/workflow-support.hpi",
-    "sha256": "0i1412z0ap79y4zix941z2l8i24inssfmirm7p7nkvgpa76mnlaz"
+    "version": "976.vb_d9493c2eb_09",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-support/976.vb_d9493c2eb_09/workflow-support.hpi",
+    "sha256": "0s9px2czgyqankln5sb5arv61pb30i0byks49c82vgwd9hqf0v0w"
   }
 ]

--- a/hosts/hetzci/prod/plugins.txt
+++ b/hosts/hetzci/prod/plugins.txt
@@ -16,3 +16,4 @@ robot
 timestamper
 uno-choice
 workflow-aggregator
+dark-theme

--- a/hosts/hetzci/vm/casc/jenkins-casc.yaml
+++ b/hosts/hetzci/vm/casc/jenkins-casc.yaml
@@ -1,6 +1,8 @@
 appearance:
   pipelineGraphView:
     showGraphOnBuildPage: true
+  themeManager:
+    theme: "darkSystem" # follow system theme 
 
 jenkins:
   # Disable authentication for hetzci-vm Jenkins instance

--- a/hosts/hetzci/vm/plugins.json
+++ b/hosts/hetzci/vm/plugins.json
@@ -162,6 +162,12 @@
     "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
+    "name": "dark-theme",
+    "version": "524.vd675b_22b_30cb_",
+    "url": "https://updates.jenkins.io/download/plugins/dark-theme/524.vd675b_22b_30cb_/dark-theme.hpi",
+    "sha256": "15h6l51805b4vkcc895z06h20nardxqn19h0mwkhkdcfqwr1jy11"
+  },
+  {
     "name": "data-tables-api",
     "version": "2.3.2-3",
     "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
@@ -640,6 +646,12 @@
     "version": "1758.v87f0f880c067",
     "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
     "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
+  },
+  {
+    "name": "theme-manager",
+    "version": "319.v9193461f9671",
+    "url": "https://updates.jenkins.io/download/plugins/theme-manager/319.v9193461f9671/theme-manager.hpi",
+    "sha256": "1b11kpb1663k1hw4as7r6iw1lzn27z1wnl69lvrl8ad60hpgar6j"
   },
   {
     "name": "timestamper",

--- a/hosts/hetzci/vm/plugins.json
+++ b/hosts/hetzci/vm/plugins.json
@@ -13,9 +13,9 @@
   },
   {
     "name": "asm-api",
-    "version": "9.8-135.vb_2239d08ee90",
-    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-135.vb_2239d08ee90/asm-api.hpi",
-    "sha256": "1m1ppbja2rn315sc720gxhi3ji64nqfdawa3rgdbd60ybry1zrwm"
+    "version": "9.8-163.vb_2a_96d3f9c3c",
+    "url": "https://updates.jenkins.io/download/plugins/asm-api/9.8-163.vb_2a_96d3f9c3c/asm-api.hpi",
+    "sha256": "0jgwd9i1h0739v8d1jcvfc3wkjnyhknywzk2k3fi9avknlgc24rv"
   },
   {
     "name": "block-queued-job",
@@ -61,27 +61,27 @@
   },
   {
     "name": "bootstrap5-api",
-    "version": "5.3.7-1",
-    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-1/bootstrap5-api.hpi",
-    "sha256": "1d4r5766dl164jl8xzaw2hs4vf7wqafxi6zm6ls8jg5jdqnp539a"
+    "version": "5.3.7-2",
+    "url": "https://updates.jenkins.io/download/plugins/bootstrap5-api/5.3.7-2/bootstrap5-api.hpi",
+    "sha256": "1w0gqk3fz3vrn0830liwk7asd2mlpmsifi3hcgwi0afa9mylriqn"
   },
   {
     "name": "bouncycastle-api",
-    "version": "2.30.1.80-261.v00c0e2618ec3",
-    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.80-261.v00c0e2618ec3/bouncycastle-api.hpi",
-    "sha256": "1h06h7iqyvppi28x7mcw42gh1im3g0lay1rhxhimg42ly8fisa0n"
+    "version": "2.30.1.81-264.v95c79c0e772c",
+    "url": "https://updates.jenkins.io/download/plugins/bouncycastle-api/2.30.1.81-264.v95c79c0e772c/bouncycastle-api.hpi",
+    "sha256": "04vwrr5117pd6j51xgw4vkcqrmfhgig2l4chjnxw9jkqybadlwdg"
   },
   {
     "name": "branch-api",
-    "version": "2.1226.ve1e7e0b_4b_95f",
-    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1226.ve1e7e0b_4b_95f/branch-api.hpi",
-    "sha256": "0gv81jnmlzl75a40mq8mjw8nm1nnljafy1nvw0ylqdkdnkdx7rmx"
+    "version": "2.1244.vf95c81f1641c",
+    "url": "https://updates.jenkins.io/download/plugins/branch-api/2.1244.vf95c81f1641c/branch-api.hpi",
+    "sha256": "0sjspfg6chwabds0gm8bhjbw0irm2318yl9wj7m16abryfqinj77"
   },
   {
     "name": "caffeine-api",
-    "version": "3.2.0-166.v72a_6d74b_870f",
-    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.0-166.v72a_6d74b_870f/caffeine-api.hpi",
-    "sha256": "04zh7lnzwhrjjp534g5aaz2bd32d3lgvcjy0dxinbjg5214y6pnr"
+    "version": "3.2.2-178.v353b_8428ed56",
+    "url": "https://updates.jenkins.io/download/plugins/caffeine-api/3.2.2-178.v353b_8428ed56/caffeine-api.hpi",
+    "sha256": "1da6kx4p06laafw9rnw772wsfsnyldiwdb02s0qfb75rwccngyx8"
   },
   {
     "name": "checks-api",
@@ -91,9 +91,9 @@
   },
   {
     "name": "cloudbees-folder",
-    "version": "6.1026.ve06dfa_cf31c3",
-    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1026.ve06dfa_cf31c3/cloudbees-folder.hpi",
-    "sha256": "1nic6xll8cwmw6hxx4759dkf40s384nscjxxw6b9p0j84zmmaa7g"
+    "version": "6.1037.v4cb_8573b_72a_a_",
+    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1037.v4cb_8573b_72a_a_/cloudbees-folder.hpi",
+    "sha256": "09wmaar2wj28a82b3h3grs8vy8p3n2wizv64m4y6517ja8w5vkwd"
   },
   {
     "name": "command-launcher",
@@ -103,21 +103,21 @@
   },
   {
     "name": "commons-compress-api",
-    "version": "1.27.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.27.1-3/commons-compress-api.hpi",
-    "sha256": "0abwp2kyh7fn63bsqmnbikyhj7yjj3z49859z65hkp4bwlkymgyq"
+    "version": "1.28.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.28.0-1/commons-compress-api.hpi",
+    "sha256": "1wv76vd1kgbsd5flpcznalkh38jxfvk5vipb6f14nwd1nb52pykp"
   },
   {
     "name": "commons-lang3-api",
-    "version": "3.17.0-87.v5cf526e63b_8b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.17.0-87.v5cf526e63b_8b_/commons-lang3-api.hpi",
-    "sha256": "1kslvyhh0kkpn98276rpl84ia2zlpwm9f7b4nzq7l3dnvdkx8m6n"
+    "version": "3.18.0-98.v3a_674c06072d",
+    "url": "https://updates.jenkins.io/download/plugins/commons-lang3-api/3.18.0-98.v3a_674c06072d/commons-lang3-api.hpi",
+    "sha256": "198la3854akm1zlpcjcdxglr7q0mh7db0hdrd2yizzh535p3w0c2"
   },
   {
     "name": "commons-text-api",
-    "version": "1.13.1-176.v74d88f22034b_",
-    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.13.1-176.v74d88f22034b_/commons-text-api.hpi",
-    "sha256": "0vbh3gz4v827i7y560lqf3g2mqy31pz920znxy0q5q80c7aqf60x"
+    "version": "1.14.0-194.v804a_dc3a_1b_d8",
+    "url": "https://updates.jenkins.io/download/plugins/commons-text-api/1.14.0-194.v804a_dc3a_1b_d8/commons-text-api.hpi",
+    "sha256": "0plf0pwacva6gv3wwnmqih2w9czbqjdi2ybi2zvd73a76vdarsa9"
   },
   {
     "name": "conditional-buildstep",
@@ -127,15 +127,15 @@
   },
   {
     "name": "config-file-provider",
-    "version": "988.v0461fcc2b_9d1",
-    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/988.v0461fcc2b_9d1/config-file-provider.hpi",
-    "sha256": "18nkwslzdhc7g5z9pzdhlfdqlap8mjah39mlhks4h85zx3hpnykh"
+    "version": "994.v3d4a_5fa_f353a_",
+    "url": "https://updates.jenkins.io/download/plugins/config-file-provider/994.v3d4a_5fa_f353a_/config-file-provider.hpi",
+    "sha256": "1q2niravbilrwwx0f762yvrnmpxcz7k00arac7lw881q5gzcrfvs"
   },
   {
     "name": "configuration-as-code",
-    "version": "1971.vf9280461ea_89",
-    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1971.vf9280461ea_89/configuration-as-code.hpi",
-    "sha256": "16x29fal06209zj3qbvs5sz748pwnhpryw8gvrydqy341r2sc6l4"
+    "version": "1985.vdda_32d0c4ea_b_",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/1985.vdda_32d0c4ea_b_/configuration-as-code.hpi",
+    "sha256": "186wv8ma43bv73562m7hadhvs6cbqyx9r3mpdi63gh46v6y503sw"
   },
   {
     "name": "configuration-as-code-groovy",
@@ -151,39 +151,39 @@
   },
   {
     "name": "credentials",
-    "version": "1415.v831096eb_5534",
-    "url": "https://updates.jenkins.io/download/plugins/credentials/1415.v831096eb_5534/credentials.hpi",
-    "sha256": "1462p5sq2kx76jann27vc1zkpl6wiiwzjapxai8l0gprpsjiv9m1"
+    "version": "1419.v2337d1ceceef",
+    "url": "https://updates.jenkins.io/download/plugins/credentials/1419.v2337d1ceceef/credentials.hpi",
+    "sha256": "0a4pja7mvf3f6009c0jwf6979rd5wadgbs8wa1lw49bnrad1y4m4"
   },
   {
     "name": "credentials-binding",
-    "version": "687.v619cb_15e923f",
-    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/687.v619cb_15e923f/credentials-binding.hpi",
-    "sha256": "03bxygj33xmishd2pbqkrgnwwijs7akfyq1g5xwy68gwgc39qn1s"
+    "version": "702.vfe613e537e88",
+    "url": "https://updates.jenkins.io/download/plugins/credentials-binding/702.vfe613e537e88/credentials-binding.hpi",
+    "sha256": "10c2zpz5944wqabi1hwjfnmh4cd9jaz66wg0xlzd7xkka3ma36l0"
   },
   {
     "name": "data-tables-api",
-    "version": "2.3.2-2",
-    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-2/data-tables-api.hpi",
-    "sha256": "1jgcznqj0zxyg6jwn0wyfbxij3dfxzi0nf1zq09rzqczj2df78h9"
+    "version": "2.3.2-3",
+    "url": "https://updates.jenkins.io/download/plugins/data-tables-api/2.3.2-3/data-tables-api.hpi",
+    "sha256": "0sqhxzcmyvwl1lsw5k8fl0pfb662656ciq9albikgmpi9rjcyjpn"
   },
   {
     "name": "display-url-api",
-    "version": "2.209.v582ed814ff2f",
-    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.209.v582ed814ff2f/display-url-api.hpi",
-    "sha256": "09b81rsyk27p2d96zwhay42h1wallh66ckaxi9q6jdxrbgwpac21"
+    "version": "2.217.va_6b_de84cc74b_",
+    "url": "https://updates.jenkins.io/download/plugins/display-url-api/2.217.va_6b_de84cc74b_/display-url-api.hpi",
+    "sha256": "1jn03bkxr8i2bfj0gfn788x4jv0war40p42n8zgblldl73ksmvh7"
   },
   {
     "name": "durable-task",
-    "version": "587.v84b_877235b_45",
-    "url": "https://updates.jenkins.io/download/plugins/durable-task/587.v84b_877235b_45/durable-task.hpi",
-    "sha256": "1d1rp7bf5iba88p1wkvqcilyfsm2bzzzgjb8gjrziyv7ay35sjpl"
+    "version": "595.ve87b_f1318d67",
+    "url": "https://updates.jenkins.io/download/plugins/durable-task/595.ve87b_f1318d67/durable-task.hpi",
+    "sha256": "1lf32pdwl9hx956a2yijna6l3qd18id6gxr6dps9kvlabm3nfw9m"
   },
   {
     "name": "echarts-api",
-    "version": "5.6.0-5",
-    "url": "https://updates.jenkins.io/download/plugins/echarts-api/5.6.0-5/echarts-api.hpi",
-    "sha256": "0mhimldjv57fmirhwj74wq8rld6pjxwx4svglyj2b7gy3dxiaznl"
+    "version": "6.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/echarts-api/6.0.0-1/echarts-api.hpi",
+    "sha256": "15f3pwa84ih2prk0q1yyslyap6vpjyij0q8zirg8z5p2qcvs98bp"
   },
   {
     "name": "eddsa-api",
@@ -193,9 +193,9 @@
   },
   {
     "name": "email-ext",
-    "version": "1911.v19b_8e86f9815",
-    "url": "https://updates.jenkins.io/download/plugins/email-ext/1911.v19b_8e86f9815/email-ext.hpi",
-    "sha256": "0pidv9lv5s4l9ixxrlnzkyk22za7z47v0jh96fd2vjrqiqslgj35"
+    "version": "1925.v1598902b_58dd",
+    "url": "https://updates.jenkins.io/download/plugins/email-ext/1925.v1598902b_58dd/email-ext.hpi",
+    "sha256": "0qgkyyibij27aisrq129fw8n61lxmpf770lry4sx9cfgfzr8bdis"
   },
   {
     "name": "favorite",
@@ -205,9 +205,9 @@
   },
   {
     "name": "font-awesome-api",
-    "version": "6.7.2-1",
-    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/6.7.2-1/font-awesome-api.hpi",
-    "sha256": "0gyx355sv5c82bqkqh2yi4rnbm68qg2vv6kmwxbc4p7lc5n6g703"
+    "version": "7.0.0-1",
+    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/7.0.0-1/font-awesome-api.hpi",
+    "sha256": "0hcwg70x1lyikdhfyfbzq8pgwy4n0dww7klkgfj9l0r6vkmcdwnk"
   },
   {
     "name": "git",
@@ -217,9 +217,9 @@
   },
   {
     "name": "git-client",
-    "version": "6.2.0",
-    "url": "https://updates.jenkins.io/download/plugins/git-client/6.2.0/git-client.hpi",
-    "sha256": "0ybjvxk3ivpg202jb6nw7xdcmfbjpidz99byiyy66wgsq3cr6qam"
+    "version": "6.3.0",
+    "url": "https://updates.jenkins.io/download/plugins/git-client/6.3.0/git-client.hpi",
+    "sha256": "0bbd14pjsp9bp20s2raqc7fd4vrj32gbmrxchcmxr0n746papwgm"
   },
   {
     "name": "git-server",
@@ -229,9 +229,9 @@
   },
   {
     "name": "github",
-    "version": "1.43.0",
-    "url": "https://updates.jenkins.io/download/plugins/github/1.43.0/github.hpi",
-    "sha256": "0i8dn80xx7x0p79y6ifnl0kdaq86b2di5m3jirwgc69gc4f5g0xj"
+    "version": "1.44.0",
+    "url": "https://updates.jenkins.io/download/plugins/github/1.44.0/github.hpi",
+    "sha256": "1xppsq1aaywn337agpy5wy88aygr6q1vxhzzfy0pacs12zgkw89h"
   },
   {
     "name": "github-api",
@@ -241,9 +241,9 @@
   },
   {
     "name": "github-branch-source",
-    "version": "1824.v046257273408",
-    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1824.v046257273408/github-branch-source.hpi",
-    "sha256": "08a53njlfphyyfkpx288bp7acvhwfvnjhqfp56d0fkwxzjhixmcx"
+    "version": "1834.v857721ea_74c6",
+    "url": "https://updates.jenkins.io/download/plugins/github-branch-source/1834.v857721ea_74c6/github-branch-source.hpi",
+    "sha256": "1qsm5a6m0ljafanq1vxbppnvki0w5rypl0v3fm6b392c93l493v9"
   },
   {
     "name": "github-pullrequest",
@@ -253,9 +253,9 @@
   },
   {
     "name": "gson-api",
-    "version": "2.13.1-139.v4569c2ef303f",
-    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-139.v4569c2ef303f/gson-api.hpi",
-    "sha256": "0rz4a2kym62c9gf1p0ir1akdc8q09j394v0n314z49isf2n30hrj"
+    "version": "2.13.1-153.vb_3d0c48a_a_b_4a_",
+    "url": "https://updates.jenkins.io/download/plugins/gson-api/2.13.1-153.vb_3d0c48a_a_b_4a_/gson-api.hpi",
+    "sha256": "1xn6ydnqaj2v4j5nhk710gb5cyrar14cvg5bbywi3266yii4148a"
   },
   {
     "name": "instance-identity",
@@ -265,15 +265,15 @@
   },
   {
     "name": "ionicons-api",
-    "version": "88.va_4187cb_eddf1",
-    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/88.va_4187cb_eddf1/ionicons-api.hpi",
-    "sha256": "0vzs1m251knzbjk3qpxk29pycs04dh50y1b0pw6vswkmb05a8vid"
+    "version": "94.vcc3065403257",
+    "url": "https://updates.jenkins.io/download/plugins/ionicons-api/94.vcc3065403257/ionicons-api.hpi",
+    "sha256": "0gxcfglxhn1ry61wcbg43qk318h6aqnz7kaw8a3xha6nfm1m1wwm"
   },
   {
     "name": "jackson2-api",
-    "version": "2.19.0-404.vb_b_0fd2fea_e10",
-    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.0-404.vb_b_0fd2fea_e10/jackson2-api.hpi",
-    "sha256": "1pp8sa78mi33v0hhxsa0msr9vrg2h2lxc14liq1v962hj62253gy"
+    "version": "2.19.2-408.v18248a_324cfe",
+    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.19.2-408.v18248a_324cfe/jackson2-api.hpi",
+    "sha256": "158fz044pldpyqaagq9d54y7xba6id93xd8bhyrsgvnd5vmkjwiz"
   },
   {
     "name": "jakarta-activation-api",
@@ -289,9 +289,9 @@
   },
   {
     "name": "javadoc",
-    "version": "327.vdfe586651ee0",
-    "url": "https://updates.jenkins.io/download/plugins/javadoc/327.vdfe586651ee0/javadoc.hpi",
-    "sha256": "1nf6bi37m4j54jf20c2gljngazf5ngipsgmh3qpgg1i44pp583v9"
+    "version": "354.vee1a_660b_4990",
+    "url": "https://updates.jenkins.io/download/plugins/javadoc/354.vee1a_660b_4990/javadoc.hpi",
+    "sha256": "05dvpnn2587r0qwfngylwf33qb7s9nrwr1xqgv4jj99z85957h3d"
   },
   {
     "name": "javax-activation-api",
@@ -325,15 +325,15 @@
   },
   {
     "name": "joda-time-api",
-    "version": "2.14.0-127.v7d9da_295a_d51",
-    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-127.v7d9da_295a_d51/joda-time-api.hpi",
-    "sha256": "0p5hakxs02c445dm3vzzm0vyrcqiv49ppqxnwx1kg897ns7qjwy2"
+    "version": "2.14.0-149.v1c3ce991d1b_9",
+    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.0-149.v1c3ce991d1b_9/joda-time-api.hpi",
+    "sha256": "08wa03insvaybkybzn120gc9dxvd15qhq9y9ghckfgfalla042y5"
   },
   {
     "name": "jquery3-api",
-    "version": "3.7.1-3",
-    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-3/jquery3-api.hpi",
-    "sha256": "0d1awnb0m5k9dg37333nmlma2s1991jm55zsmmsqqfq1jllg68qq"
+    "version": "3.7.1-583.vda_6ca_102270d",
+    "url": "https://updates.jenkins.io/download/plugins/jquery3-api/3.7.1-583.vda_6ca_102270d/jquery3-api.hpi",
+    "sha256": "0yk8zain5inr2vllr0pikywbiryc2294cqzxl99asdi1yycdvr04"
   },
   {
     "name": "jsch",
@@ -343,21 +343,21 @@
   },
   {
     "name": "json-api",
-    "version": "20250517-153.vc8a_a_d87c0ce3",
-    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-153.vc8a_a_d87c0ce3/json-api.hpi",
-    "sha256": "0v6i0i1vp5q17b10r4vnn92kv4b1lw0wa79sm8bbx0410p6pk6v2"
+    "version": "20250517-163.v1c5da_e99c775",
+    "url": "https://updates.jenkins.io/download/plugins/json-api/20250517-163.v1c5da_e99c775/json-api.hpi",
+    "sha256": "18pfvp9pxl1gfmszbgipgl8vy4smbhq0afgn6gy7rzmsixg7w3f6"
   },
   {
     "name": "json-path-api",
-    "version": "2.9.0-148.v22a_7ffe323ce",
-    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-148.v22a_7ffe323ce/json-path-api.hpi",
-    "sha256": "14arnnsz9w23mmv9j2m66ynvf3jy9l4mzr2s8vy2sabcdgsc3z4k"
+    "version": "2.9.0-178.vca_b_c71881321",
+    "url": "https://updates.jenkins.io/download/plugins/json-path-api/2.9.0-178.vca_b_c71881321/json-path-api.hpi",
+    "sha256": "1bbn7aldzms9n4kz78nhvrr1qgyzvaqrqyqczyp0xzq14srk3hwg"
   },
   {
     "name": "jsoup",
-    "version": "1.21.1-52.v96e4041b_60fd",
-    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-52.v96e4041b_60fd/jsoup.hpi",
-    "sha256": "057rdrlxp98f0yhdp901p1w75j87hdp76jsnq9f3brfg89kgax6j"
+    "version": "1.21.1-58.vfc578e6e2610",
+    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.21.1-58.vfc578e6e2610/jsoup.hpi",
+    "sha256": "0n37y54ch7g7iw16srkyni8p8dijf4p3vnq7lrf0ivjahyk8cz5n"
   },
   {
     "name": "jucies",
@@ -373,15 +373,15 @@
   },
   {
     "name": "lockable-resources",
-    "version": "1349.v8b_ccb_c5487f7",
-    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1349.v8b_ccb_c5487f7/lockable-resources.hpi",
-    "sha256": "11fj40llz4diq93wqc9zaz3w4lsfb8fkrq09vw8lmjhri41qk5r8"
+    "version": "1412.v3f305a_fb_a_117",
+    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1412.v3f305a_fb_a_117/lockable-resources.hpi",
+    "sha256": "18j8k6lk00qgy43kavlxrwc8w5in96pvd36wjdy2iszv0w2rkwrm"
   },
   {
     "name": "mailer",
-    "version": "509.vc54d23fc427e",
-    "url": "https://updates.jenkins.io/download/plugins/mailer/509.vc54d23fc427e/mailer.hpi",
-    "sha256": "1vpypmkpl2li54ajyy3xd04dcngsh3qcz6nzn4jjp41m6cfnzpgg"
+    "version": "515.vd788654779b_1",
+    "url": "https://updates.jenkins.io/download/plugins/mailer/515.vd788654779b_1/mailer.hpi",
+    "sha256": "0c6f10kby3r38cj6s3wh8w69qhbf4k4vx30wfx4vkbqalsam9rzv"
   },
   {
     "name": "mapdb-api",
@@ -391,27 +391,27 @@
   },
   {
     "name": "matrix-auth",
-    "version": "3.2.6",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.6/matrix-auth.hpi",
-    "sha256": "1g3ij9f8ad6yhciyliwchv5dv7rlml7vghs64kmgrb9fff7pqgkj"
+    "version": "3.2.7",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.7/matrix-auth.hpi",
+    "sha256": "0j7d2ca1p0glda5vwxwh63pbas4v0w724wdls8nxaq5sj7x3mcb6"
   },
   {
     "name": "matrix-project",
-    "version": "849.v0cd64ed7e531",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-project/849.v0cd64ed7e531/matrix-project.hpi",
-    "sha256": "0rl2syrpi6dc6vylhqmsmr2y5mg7l73g2viv3cyrkgllj1gg3ixq"
+    "version": "856.v4c352b_3a_b_23e",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-project/856.v4c352b_3a_b_23e/matrix-project.hpi",
+    "sha256": "1mvchdmqm0qwqipc35mam0lkk1j9vcbni1qywp6llrbx6kdlmpwf"
   },
   {
     "name": "maven-plugin",
-    "version": "3.26",
-    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.26/maven-plugin.hpi",
-    "sha256": "1cdxpxr7yfm5fazdj26zmw8aqla95nmmj1qymypv7w2yg8ahs49f"
+    "version": "3.27",
+    "url": "https://updates.jenkins.io/download/plugins/maven-plugin/3.27/maven-plugin.hpi",
+    "sha256": "1zh5anab4w251x3p7k7znhns5hvhflvw7428sgvfn68vmms9zmk4"
   },
   {
     "name": "metrics",
-    "version": "4.2.32-476.v5042e1c1edd7",
-    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-476.v5042e1c1edd7/metrics.hpi",
-    "sha256": "1kz7sqm2wbss4x3s3g8bdxa898nbzkhaypx823j83ijhcyqkqkac"
+    "version": "4.2.32-481.v75f035fdc894",
+    "url": "https://updates.jenkins.io/download/plugins/metrics/4.2.32-481.v75f035fdc894/metrics.hpi",
+    "sha256": "1gda878bnkwx1635znqw7p5q3inx1xkg0l9f132ggz56b5rvxy1l"
   },
   {
     "name": "mina-sshd-api-common",
@@ -439,15 +439,15 @@
   },
   {
     "name": "oss-symbols-api",
-    "version": "356.v2da_d59a_3742b_",
-    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/356.v2da_d59a_3742b_/oss-symbols-api.hpi",
-    "sha256": "07x91ap75cchgqx175lshs706pb4n3wd2p5alcsg639xcvgwza62"
+    "version": "392.v27a_482d90083",
+    "url": "https://updates.jenkins.io/download/plugins/oss-symbols-api/392.v27a_482d90083/oss-symbols-api.hpi",
+    "sha256": "0dilvhwi7hafr1dc322ngp1r0lk8bplpk0lj8gwg7fh8f4b2q0ig"
   },
   {
     "name": "parameterized-trigger",
-    "version": "859.vb_e3907a_07a_16",
-    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/859.vb_e3907a_07a_16/parameterized-trigger.hpi",
-    "sha256": "1wyky5if74f490wwc1r375dsq0hl08059888qsw1kw6si4wbqi1q"
+    "version": "873.v8b_e37dd8418f",
+    "url": "https://updates.jenkins.io/download/plugins/parameterized-trigger/873.v8b_e37dd8418f/parameterized-trigger.hpi",
+    "sha256": "0r6vzwgfvrkgwcc9mk3pnlhr9z60hg02l7v55f8a9cxbh336k1fc"
   },
   {
     "name": "pipeline-build-step",
@@ -463,9 +463,9 @@
   },
   {
     "name": "pipeline-graph-view",
-    "version": "590.v06d574696250",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/590.v06d574696250/pipeline-graph-view.hpi",
-    "sha256": "0k61xy9yfmjysz6q1ym2jvh0ky3i8raddjpf8qc4hr0vww4fk61k"
+    "version": "619.v92f3fcdc39db_",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/619.v92f3fcdc39db_/pipeline-graph-view.hpi",
+    "sha256": "0sk51dzirw8bqrx8rbwlr8xk5mjbl2xyf3qg0if77l54w04d18a8"
   },
   {
     "name": "pipeline-groovy-lib",
@@ -475,9 +475,9 @@
   },
   {
     "name": "pipeline-input-step",
-    "version": "527.vd61b_1d3c5078",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/527.vd61b_1d3c5078/pipeline-input-step.hpi",
-    "sha256": "1309wfacpy1wjsb6paa6lxgsmhfgykd86pcbsbz2pl6qqb3i4bzq"
+    "version": "534.v352f0a_e98918",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-input-step/534.v352f0a_e98918/pipeline-input-step.hpi",
+    "sha256": "1vkyiw4384j8vqq91zv4wpsf1r25nzbd77gr48alkv84ikza55vs"
   },
   {
     "name": "pipeline-milestone-step",
@@ -487,21 +487,21 @@
   },
   {
     "name": "pipeline-model-api",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2255.v56a_15e805f12/pipeline-model-api.hpi",
-    "sha256": "16z4hjwh2nsrl3krs6ik5gi7wvsjz7y34glh99m9c5q5mf3d7whx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-api/2.2265.v140e610fe9d5/pipeline-model-api.hpi",
+    "sha256": "0m8x4nkcl2v5mw6rv29d1sgwx6gqjszp28m3ippv1m5hr66nv7m3"
   },
   {
     "name": "pipeline-model-definition",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2255.v56a_15e805f12/pipeline-model-definition.hpi",
-    "sha256": "17rnjhy3yr2v1xrxglvdlzmkv8ixj7lkgi0mb39szk4101yj55sx"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-definition/2.2265.v140e610fe9d5/pipeline-model-definition.hpi",
+    "sha256": "0bxv1534203dsgqjyg311r0ks92rbgi26brl28wp90dnipcdl852"
   },
   {
     "name": "pipeline-model-extensions",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2255.v56a_15e805f12/pipeline-model-extensions.hpi",
-    "sha256": "1qw1ikkdxdpgdm3il1hpmc0bcjcf1p2gxczhmypy6w1pdhkginrc"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-model-extensions/2.2265.v140e610fe9d5/pipeline-model-extensions.hpi",
+    "sha256": "1zls5vz1znwp9fcniqkgv6hmhfcb17g3fw6x0kd01581zc6xr36f"
   },
   {
     "name": "pipeline-rest-api",
@@ -517,9 +517,9 @@
   },
   {
     "name": "pipeline-stage-tags-metadata",
-    "version": "2.2255.v56a_15e805f12",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2255.v56a_15e805f12/pipeline-stage-tags-metadata.hpi",
-    "sha256": "0v2mcjc0kxl8nzdipjn6sak4y0l4k86rn9i3x2nlc61c9narl8cq"
+    "version": "2.2265.v140e610fe9d5",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-stage-tags-metadata/2.2265.v140e610fe9d5/pipeline-stage-tags-metadata.hpi",
+    "sha256": "02jld8bhjrn2k4hgd8gbhs00bv78sfkvm4ala39xk8c3my4szppq"
   },
   {
     "name": "pipeline-stage-view",
@@ -565,9 +565,9 @@
   },
   {
     "name": "reverse-proxy-auth-plugin",
-    "version": "238.v82ceca_8417a_6",
-    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/238.v82ceca_8417a_6/reverse-proxy-auth-plugin.hpi",
-    "sha256": "18dakdm8p7x1zw8fibvnbiyjrp6l7dzg5w2z44zva7s19may86aj"
+    "version": "245.v93f25b_b_b_3102",
+    "url": "https://updates.jenkins.io/download/plugins/reverse-proxy-auth-plugin/245.v93f25b_b_b_3102/reverse-proxy-auth-plugin.hpi",
+    "sha256": "0hvhnmy6zvd4m20xvqaln8dl0912jfhaw1v6j2y685yl1z1216m0"
   },
   {
     "name": "robot",
@@ -583,21 +583,21 @@
   },
   {
     "name": "scm-api",
-    "version": "704.v3ce5c542825a_",
-    "url": "https://updates.jenkins.io/download/plugins/scm-api/704.v3ce5c542825a_/scm-api.hpi",
-    "sha256": "1j8hv8hl4mcmybmzzvjhvvn6133i4bym1pck3x1zh4dhd98j6wpf"
+    "version": "707.v749f968369d4",
+    "url": "https://updates.jenkins.io/download/plugins/scm-api/707.v749f968369d4/scm-api.hpi",
+    "sha256": "15154mwr8bibxyb0jgdma799k6ahjl3jjagvjiiw1pzcyivxbiw7"
   },
   {
     "name": "script-security",
-    "version": "1373.vb_b_4a_a_c26fa_00",
-    "url": "https://updates.jenkins.io/download/plugins/script-security/1373.vb_b_4a_a_c26fa_00/script-security.hpi",
-    "sha256": "09y4xysz3xjdyjmgspak78llhgac7zzcl6rkjmjpf5ab29igx6bi"
+    "version": "1378.vf25626395f49",
+    "url": "https://updates.jenkins.io/download/plugins/script-security/1378.vf25626395f49/script-security.hpi",
+    "sha256": "1qlrpwqydl598zqljp4204j2hgb25vkd1rma4723j0r9gkbfmn1d"
   },
   {
     "name": "scriptler",
-    "version": "397.vc46f19cb_3c18",
-    "url": "https://updates.jenkins.io/download/plugins/scriptler/397.vc46f19cb_3c18/scriptler.hpi",
-    "sha256": "1sj4sbz7yfrb35l0mgis12y3a23y811wfznbzx2cw7alvsi8ykr2"
+    "version": "425.v09a_dc03401b_0",
+    "url": "https://updates.jenkins.io/download/plugins/scriptler/425.v09a_dc03401b_0/scriptler.hpi",
+    "sha256": "0ynkwlw06nsp0k3xg989nlai3jnni2nvl1l6q4y5lpnnsaa33zvk"
   },
   {
     "name": "snakeyaml-api",
@@ -607,39 +607,39 @@
   },
   {
     "name": "ssh-credentials",
-    "version": "359.v2191c4cf635f",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/359.v2191c4cf635f/ssh-credentials.hpi",
-    "sha256": "0idq2yfjh3bmrlyi3lbi599zahjmpbvx6v9qfqlfcjik5y863c20"
+    "version": "361.vb_f6760818e8c",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-credentials/361.vb_f6760818e8c/ssh-credentials.hpi",
+    "sha256": "0nilaf2ds1favqi3l4xi3qlclyip9v23di0spgh9gq7xzxacg00y"
   },
   {
     "name": "ssh-slaves",
-    "version": "3.1031.v72c6b_883b_869",
-    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1031.v72c6b_883b_869/ssh-slaves.hpi",
-    "sha256": "0z7hn30wd3wd5h098pachjral0si15rp96q28c63mpqqbgqm1gwl"
+    "version": "3.1071.v0d059c7b_c555",
+    "url": "https://updates.jenkins.io/download/plugins/ssh-slaves/3.1071.v0d059c7b_c555/ssh-slaves.hpi",
+    "sha256": "0mdbbf1ffiyi3q866rayxd0zs8q1593c0qibh3qllksw99ir8zb8"
   },
   {
     "name": "sshd",
-    "version": "3.372.v5d04a_e92d8cf",
-    "url": "https://updates.jenkins.io/download/plugins/sshd/3.372.v5d04a_e92d8cf/sshd.hpi",
-    "sha256": "0gmwss6csr8ssmvjad7p91hcxya9k1kfpp4wpgnhsgfhrnggxfw1"
+    "version": "3.374.v19b_d59ce6610",
+    "url": "https://updates.jenkins.io/download/plugins/sshd/3.374.v19b_d59ce6610/sshd.hpi",
+    "sha256": "0ix0x0rxj730gsglvny7dp734qphs7pyny77k03vjqz2zm4c9p3k"
   },
   {
     "name": "structs",
-    "version": "350.v3b_30f09f2363",
-    "url": "https://updates.jenkins.io/download/plugins/structs/350.v3b_30f09f2363/structs.hpi",
-    "sha256": "16g71kczi0p298g4lsswvjy8n1ariby1ng9krl6srq2cdsqfhhg3"
+    "version": "353.v261ea_40a_80fb_",
+    "url": "https://updates.jenkins.io/download/plugins/structs/353.v261ea_40a_80fb_/structs.hpi",
+    "sha256": "0bkkgbvxg0632ybrw8aip0xsl832dq0009pqcbazzxkbfpqws8cy"
   },
   {
     "name": "subversion",
-    "version": "1287.vd2d507146906",
-    "url": "https://updates.jenkins.io/download/plugins/subversion/1287.vd2d507146906/subversion.hpi",
-    "sha256": "11sv1xy2klbf9l09n7lry06xg448x5z5qbllja3kafib597183l2"
+    "version": "1292.ve8cf25770ee3",
+    "url": "https://updates.jenkins.io/download/plugins/subversion/1292.ve8cf25770ee3/subversion.hpi",
+    "sha256": "178sbcvzggda8f1m4ya99hvkd1vfrsrczhh2lk6lrrij7wsj3i1h"
   },
   {
     "name": "support-core",
-    "version": "1739.v0d10c0a_57cb_e",
-    "url": "https://updates.jenkins.io/download/plugins/support-core/1739.v0d10c0a_57cb_e/support-core.hpi",
-    "sha256": "0bml1pfv0w3979fqyda26r5286c8rlsrz3v23rf8y3ym4byn9svh"
+    "version": "1758.v87f0f880c067",
+    "url": "https://updates.jenkins.io/download/plugins/support-core/1758.v87f0f880c067/support-core.hpi",
+    "sha256": "0clz81fhcnd55rg0wdj399s2lrsp1csi7bxl2vqd23v8p0qrl8h7"
   },
   {
     "name": "timestamper",
@@ -649,9 +649,9 @@
   },
   {
     "name": "token-macro",
-    "version": "444.v52de7e9c573d",
-    "url": "https://updates.jenkins.io/download/plugins/token-macro/444.v52de7e9c573d/token-macro.hpi",
-    "sha256": "0slyazvqi63g4d57lm6jkmmnkcw1kkqfycnwvq1qlddmpqa9n3qv"
+    "version": "477.vd4f0dc3cb_cf1",
+    "url": "https://updates.jenkins.io/download/plugins/token-macro/477.vd4f0dc3cb_cf1/token-macro.hpi",
+    "sha256": "0axlnsvnj1r58k7x9x9hwbpvl0qi1p2f3b15i6bffwbm8rxy967g"
   },
   {
     "name": "trilead-api",
@@ -685,9 +685,9 @@
   },
   {
     "name": "workflow-api",
-    "version": "1373.v7b_813f10efa_b_",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1373.v7b_813f10efa_b_/workflow-api.hpi",
-    "sha256": "1c161pxxl15ydp1pzf7vd7gv9si8vlz55n528is6vgjbwv774rzm"
+    "version": "1384.vdc05a_48f535f",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-api/1384.vdc05a_48f535f/workflow-api.hpi",
+    "sha256": "10hfhzzfhh2nmhj9qy13d4q9bcw0rg034iy1kjlha2kwg5dqg1yj"
   },
   {
     "name": "workflow-basic-steps",
@@ -697,15 +697,15 @@
   },
   {
     "name": "workflow-cps",
-    "version": "4150.ve20ca_b_a_a_2815",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4150.ve20ca_b_a_a_2815/workflow-cps.hpi",
-    "sha256": "0b26r675s2h8n3dnd3r3k79a5vjs18wk5j9r6qdyzphv3rn8m652"
+    "version": "4183.v94b_6fd39da_c1",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4183.v94b_6fd39da_c1/workflow-cps.hpi",
+    "sha256": "1malwfi5cj2ha3d1xgbkrkw746cwmk1b0j1yqvfkm5i3yi434zsn"
   },
   {
     "name": "workflow-durable-task-step",
-    "version": "1434.v1b_595c29ddd7",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1434.v1b_595c29ddd7/workflow-durable-task-step.hpi",
-    "sha256": "1k34ymais9xacs1nakdhiv09p1mvd3a5nsp97967cxyvg0gvm85i"
+    "version": "1452.v0ee719c104a_7",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-durable-task-step/1452.v0ee719c104a_7/workflow-durable-task-step.hpi",
+    "sha256": "0asfz07plmaghh8kky1ffmfwfhb3qw5wk0ydnr3m8632k607n2fb"
   },
   {
     "name": "workflow-job",
@@ -715,9 +715,9 @@
   },
   {
     "name": "workflow-multibranch",
-    "version": "806.vb_b_688f609ee9",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/806.vb_b_688f609ee9/workflow-multibranch.hpi",
-    "sha256": "1gim0q59x8yzfdkhmk5svi4ns4v84m767wyq76jjik7xsb6mhw34"
+    "version": "811.vcd33d074c2a_0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/811.vcd33d074c2a_0/workflow-multibranch.hpi",
+    "sha256": "0mm10a3wfbi8qizmixkipgf07jl1yhvyw7nmwwwkgv6nvzxvzjhi"
   },
   {
     "name": "workflow-scm-step",
@@ -727,14 +727,14 @@
   },
   {
     "name": "workflow-step-api",
-    "version": "700.v6e45cb_a_5a_a_21",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/700.v6e45cb_a_5a_a_21/workflow-step-api.hpi",
-    "sha256": "0j3y00idx8qm7lj6kl0c3rx5sgszfc7lzwpah3z8pf86jzv307i0"
+    "version": "706.v518c5dcb_24c0",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-step-api/706.v518c5dcb_24c0/workflow-step-api.hpi",
+    "sha256": "1q0vsc4xjqzqnzjs5wn72pkjq7kgzq15zj7p8pw7w8mr1k08wpb8"
   },
   {
     "name": "workflow-support",
-    "version": "968.v8f17397e87b_8",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-support/968.v8f17397e87b_8/workflow-support.hpi",
-    "sha256": "0i1412z0ap79y4zix941z2l8i24inssfmirm7p7nkvgpa76mnlaz"
+    "version": "976.vb_d9493c2eb_09",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-support/976.vb_d9493c2eb_09/workflow-support.hpi",
+    "sha256": "0s9px2czgyqankln5sb5arv61pb30i0byks49c82vgwd9hqf0v0w"
   }
 ]

--- a/hosts/hetzci/vm/plugins.txt
+++ b/hosts/hetzci/vm/plugins.txt
@@ -16,3 +16,4 @@ robot
 timestamper
 uno-choice
 workflow-aggregator
+dark-theme


### PR DESCRIPTION
Updated Jenkins plugins and added `dark-theme` plugin. Now Jenkins follows your system's dark mode setting.