### PR TITLE
hetzci: Add system76-darp11-b-debug targets

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
@@ -38,6 +38,9 @@ def TARGETS = [
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
     testset: '_relayboot_bat_',
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
@@ -19,7 +19,8 @@ properties([
     booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug'),
+    booleanParam(name: 'system76_darp11_b_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.system76-darp11-b-debug')
   ])
 ])
 pipeline {
@@ -85,6 +86,10 @@ pipeline {
             if (params.nvidia_jetson_orin_nx_debug) {
               TARGETS.push(
                 [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug", testset: params.TESTSET ])
+            }
+            if (params.system76_darp11_b_debug) {
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
@@ -59,6 +59,9 @@ def TARGETS = [
   [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
     testset: null,
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-main.groovy
@@ -38,6 +38,9 @@ def TARGETS = [
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
     testset: '_relayboot_bat_',
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
@@ -19,7 +19,8 @@ properties([
     booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug'),
+    booleanParam(name: 'system76_darp11_b_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.system76-darp11-b-debug')
   ])
 ])
 pipeline {
@@ -85,6 +86,10 @@ pipeline {
             if (params.nvidia_jetson_orin_nx_debug) {
               TARGETS.push(
                 [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug", testset: params.TESTSET ])
+            }
+            if (params.system76_darp11_b_debug) {
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
@@ -59,6 +59,9 @@ def TARGETS = [
   [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
     testset: null,
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-main.groovy
@@ -38,6 +38,9 @@ def TARGETS = [
   [ target: "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",
     testset: '_relayboot_bat_',
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
@@ -19,7 +19,8 @@ properties([
     booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_nx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'),
     booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
-    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
+    booleanParam(name: 'nvidia_jetson_orin_nx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-nx-debug'),
+    booleanParam(name: 'system76_darp11_b_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.system76-darp11-b-debug')
   ])
 ])
 pipeline {
@@ -85,6 +86,10 @@ pipeline {
             if (params.nvidia_jetson_orin_nx_debug) {
               TARGETS.push(
                 [ target: "packages.aarch64-linux.nvidia-jetson-orin-nx-debug", testset: params.TESTSET ])
+            }
+            if (params.system76_darp11_b_debug) {
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -59,6 +59,9 @@ def TARGETS = [
   [ target: "packages.aarch64-linux.nxp-imx8mp-evk-debug",
     testset: null,
   ],
+  [ target: "packages.x86_64-linux.system76-darp11-b-debug",
+    testset: null,
+  ],
 ]
 
 properties([


### PR DESCRIPTION
Add target `system76-darp11-b-debug` to vm, dev and prod pipelines: main, manual and nightly.

Tested [here](https://ci-dev.vedenemo.dev/job/ghaf-main/39/) and [here](https://ci-dev.vedenemo.dev/job/ghaf-manual/60/).