### PR TITLE
Stop evaluating every host on deploy

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -85,7 +85,7 @@ class Targets:
                 )
                 for name, node in json.loads(
                     subprocess.check_output(
-                        ["nix", "eval", "--json", f"{ROOT}#deploy.targets"]
+                        ["nix", "eval", "--json", f"{ROOT}#installationTargets"]
                     )
                 ).items()
             }
@@ -103,7 +103,7 @@ class Targets:
 
         node = json.loads(
             subprocess.check_output(
-                ["nix", "eval", "--json", f"{ROOT}#deploy.targets.{alias}"]
+                ["nix", "eval", "--json", f"{ROOT}#installationTargets.{alias}"]
             )
         )
         return TargetHost(


### PR DESCRIPTION
Everything under `flake.deploy` gets evaluated during deploy, even though `deploy.targets` was only there for `tasks.py` to use. Because `deploy.targets` checks for the presence of secrets, it has to evaluate the host's config.

Moved targets out of deploy and added a new top-level flake output `.#installationTargets`. Now only the host that is being deployed gets evaluated when you run `deploy`, speeding up the process significantly.