### PR TITLE
hetzci-prod: Trigger gc about 50GB earlier

### DIFF
--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -122,6 +122,8 @@ in
     trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
     substituters = https://ghaf-dev.cachix.org https://cache.nixos.org
     builders-use-substitutes = true
+    min-free =  75000000000
+    max-free = 300000000000
   '';
 
   programs.ssh = {


### PR DESCRIPTION
Define hetzci-prod min-free and max-free
separately from common.nix, triggering gc when
there's about 70GB free diskspace left.