### PR TITLE
hetzci: Add mp4 support

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test-manual.groovy
@@ -112,7 +112,7 @@ def ghaf_robot_test(String tags) {
   env.ROBOT_EXECUTED = 'true'
   env.INCLUDE_TEST_TAGS = "${tags}"
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     try {
       // Pass variables as environment variables to shell.
       // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
@@ -133,7 +133,7 @@ def ghaf_robot_test(String tags) {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $tags; mkdir -p $tags
-        mv -f *.txt *.png output.xml report.html log.html $tags/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $tags/ || true
       """
     }
   }
@@ -276,6 +276,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-hw-test.groovy
@@ -114,7 +114,7 @@ def ghaf_robot_test(String testname='relayboot') {
     env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
   }
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     // On failure, continue the pipeline execution
     env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
     try {
@@ -139,7 +139,7 @@ def ghaf_robot_test(String testname='relayboot') {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $testname; mkdir -p $testname
-        mv -f *.txt *.png output.xml report.html log.html $testname/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $testname/ || true
       """
     }
   }
@@ -348,6 +348,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test-manual.groovy
@@ -112,7 +112,7 @@ def ghaf_robot_test(String tags) {
   env.ROBOT_EXECUTED = 'true'
   env.INCLUDE_TEST_TAGS = "${tags}"
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     try {
       // Pass variables as environment variables to shell.
       // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
@@ -133,7 +133,7 @@ def ghaf_robot_test(String tags) {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $tags; mkdir -p $tags
-        mv -f *.txt *.png output.xml report.html log.html $tags/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $tags/ || true
       """
     }
   }
@@ -276,6 +276,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-hw-test.groovy
@@ -114,7 +114,7 @@ def ghaf_robot_test(String testname='relayboot') {
     env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
   }
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     // On failure, continue the pipeline execution
     env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
     try {
@@ -139,7 +139,7 @@ def ghaf_robot_test(String testname='relayboot') {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $testname; mkdir -p $testname
-        mv -f *.txt *.png output.xml report.html log.html $testname/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $testname/ || true
       """
     }
   }
@@ -348,6 +348,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/release/casc/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/release/casc/pipelines/ghaf-hw-test-manual.groovy
@@ -112,7 +112,7 @@ def ghaf_robot_test(String tags) {
   env.ROBOT_EXECUTED = 'true'
   env.INCLUDE_TEST_TAGS = "${tags}"
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     try {
       // Pass variables as environment variables to shell.
       // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
@@ -133,7 +133,7 @@ def ghaf_robot_test(String tags) {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $tags; mkdir -p $tags
-        mv -f *.txt *.png output.xml report.html log.html $tags/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $tags/ || true
       """
     }
   }
@@ -276,6 +276,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/release/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/release/casc/pipelines/ghaf-hw-test.groovy
@@ -114,7 +114,7 @@ def ghaf_robot_test(String testname='relayboot') {
     env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
   }
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     // On failure, continue the pipeline execution
     env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
     try {
@@ -139,7 +139,7 @@ def ghaf_robot_test(String testname='relayboot') {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $testname; mkdir -p $testname
-        mv -f *.txt *.png output.xml report.html log.html $testname/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $testname/ || true
       """
     }
   }
@@ -348,6 +348,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test-manual.groovy
@@ -112,7 +112,7 @@ def ghaf_robot_test(String tags) {
   env.ROBOT_EXECUTED = 'true'
   env.INCLUDE_TEST_TAGS = "${tags}"
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     try {
       // Pass variables as environment variables to shell.
       // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
@@ -133,7 +133,7 @@ def ghaf_robot_test(String tags) {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $tags; mkdir -p $tags
-        mv -f *.txt *.png output.xml report.html log.html $tags/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $tags/ || true
       """
     }
   }
@@ -276,6 +276,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-hw-test.groovy
@@ -114,7 +114,7 @@ def ghaf_robot_test(String testname='relayboot') {
     env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
   }
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.txt *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png *.mp4 output.xml report.html log.html'
     // On failure, continue the pipeline execution
     env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
     try {
@@ -139,7 +139,7 @@ def ghaf_robot_test(String testname='relayboot') {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $testname; mkdir -p $testname
-        mv -f *.txt *.png output.xml report.html log.html $testname/ || true
+        mv -f *.txt *.png *.mp4 output.xml report.html log.html $testname/ || true
       """
     }
   }
@@ -348,6 +348,7 @@ pipeline {
             'Robot-Framework/test-suites/**/*.html, ' +
             'Robot-Framework/test-suites/**/*.xml, ' +
             'Robot-Framework/test-suites/**/*.png, ' +
+            'Robot-Framework/test-suites/**/*.mp4, ' +
             'Robot-Framework/test-suites/**/*.txt'
           archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
         }


### PR DESCRIPTION
Copy mp4 files from the agent. Testrun in [dev](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/743/). 

Jenkins sometimes shows an error `No video with supported format and MIME type found` when trying to play the video. Refreshing the page may fix it, or the file can be downloaded and viewed locally.