### PR TITLE
hetzci-release: Move caddy state to persistent volume

### DIFF
--- a/hosts/ghaf-monitoring/provision/alert-rules.yaml
+++ b/hosts/ghaf-monitoring/provision/alert-rules.yaml
@@ -17,13 +17,12 @@ groups:
               model:
                 editorMode: code
                 expr: |-
-                    floor(
-                      min by(device, machine_name) (
-                        (node_filesystem_free_bytes{fstype="ext4"})
-                        / 1024 / 1024 / 1024
-                        and ignoring(device, machine_name)
-                        node_filesystem_size_bytes{fstype="ext4"} > 1 * 1024 * 1024 * 1024
-                      )
+                    round(
+                      max by(device, machine_name) (
+                        100 - ((node_filesystem_avail_bytes{fstype="ext4"} * 100)
+                        / node_filesystem_size_bytes{fstype="ext4"}))
+                      ,
+                      0.01
                     )
                 instant: true
                 intervalMs: 1000
@@ -37,8 +36,8 @@ groups:
                 conditions:
                     - evaluator:
                         params:
-                            - 20
-                        type: lt
+                            - 98
+                        type: gt
                       operator:
                         type: and
                       query:
@@ -62,7 +61,7 @@ groups:
           execErrState: Error
           for: 1m
           annotations:
-            summary: '{{ $labels.device }} on {{ $labels.machine_name }} has {{ (index $values "A").Value }} GB of free space left'
+            summary: '{{ $labels.device }} on {{ $labels.machine_name }} disk usage is {{ (index $values "A").Value }}%'
           isPaused: false
         - uid: feuvsf9f7dla8c
           title: Low disk space /boot

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -31,6 +31,16 @@ in
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetzci-release";
 
+  # Configure /var/lib/caddy in /etc/fstab.
+  fileSystems."/var/lib/caddy" = {
+    device = "/dev/disk/by-id/scsi-0HC_Volume_103219547";
+    fsType = "ext4";
+    options = [
+      "x-systemd.makefs"
+      "x-systemd.growfs"
+    ];
+  };
+
   environment.systemPackages = with pkgs; [
     screen
     tmux


### PR DESCRIPTION
- ci-release: Move caddy state to peristent volume so we don't hit the Let's Encrypt TLS rate limits when ci-release Jenkins controller host gets re-installed for ephemeral builds.
- ghaf-monitoring: Improve disk space alert to fire if disk usage on an ext4 disk is greater than 98%. This is needed to not fire on small disks (such as caddy state) based on absolute GB limit.

Tested and currently deployed to [monitoring.vedenemo.dev](https://monitoring.vedenemo.dev/alerting/grafana/beuvsalzfeigwe/view) and https://ci-release.vedenemo.dev/