### PR TITLE
hetzci: nix build with fallback on jenkins pipelines

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -38,7 +38,7 @@ def create_pipeline(List<Map> targets) {
       // Build
       stage("Build ${shortname}") {
         build_beg = run_cmd('date +%s')
-        sh "nix build -v .#${it.target} --out-link ${it.target}"
+        sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
       }
       // Provenance

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -38,7 +38,7 @@ def create_pipeline(List<Map> targets) {
       // Build
       stage("Build ${shortname}") {
         build_beg = run_cmd('date +%s')
-        sh "nix build -v .#${it.target} --out-link ${it.target}"
+        sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
       }
       // Provenance

--- a/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
@@ -38,7 +38,7 @@ def create_pipeline(List<Map> targets) {
       // Build
       stage("Build ${shortname}") {
         build_beg = run_cmd('date +%s')
-        sh "nix build -v .#${it.target} --out-link ${it.target}"
+        sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
       }
       // Provenance

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -38,7 +38,7 @@ def create_pipeline(List<Map> targets) {
       // Build
       stage("Build ${shortname}") {
         build_beg = run_cmd('date +%s')
-        sh "nix build -v .#${it.target} --out-link ${it.target}"
+        sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
       }
       // Provenance


### PR DESCRIPTION
Add nix build option `--fallback` to fall back on building the derivation locally (on the confgured remote builders in hetzci config) if realizing the output paths through the substitutes fails. This is a workaround to recent cachix 'Cannot serve NAR' [issue that occurs on some paths](https://ci-prod.vedenemo.dev/job/ghaf-pre-merge/220/pipeline-overview/log?nodeId=110).