### PR TITLE
hetzci: Change oauth2-proxy restart config

### DIFF
--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -363,6 +363,14 @@ in
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };
+  systemd.services.oauth2-proxy.serviceConfig = {
+    # Try re-start at 10 seconds intervals.
+    # If there are more than 3 restart attempts in a 60 second interval,
+    # wait for the 60 second interval to pass before another re-try.
+    RestartSec = 10;
+    StartLimitBurst = 3;
+    StartLimitInterval = 60;
+  };
 
   systemd.services.jenkins-purge-artifacts = {
     after = [ "jenkins.service" ];

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -360,6 +360,14 @@ in
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };
+  systemd.services.oauth2-proxy.serviceConfig = {
+    # Try re-start at 10 seconds intervals.
+    # If there are more than 3 restart attempts in a 60 second interval,
+    # wait for the 60 second interval to pass before another re-try.
+    RestartSec = 10;
+    StartLimitBurst = 3;
+    StartLimitInterval = 60;
+  };
 
   systemd.services.jenkins-purge-artifacts = {
     after = [ "jenkins.service" ];

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -371,6 +371,14 @@ in
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };
+  systemd.services.oauth2-proxy.serviceConfig = {
+    # Try re-start at 10 seconds intervals.
+    # If there are more than 3 restart attempts in a 60 second interval,
+    # wait for the 60 second interval to pass before another re-try.
+    RestartSec = 10;
+    StartLimitBurst = 3;
+    StartLimitInterval = 60;
+  };
 
   systemd.services.jenkins-purge-artifacts = {
     after = [ "jenkins.service" ];

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -289,6 +289,14 @@ in
     };
     keyFile = config.sops.templates.oauth2_proxy_env.path;
   };
+  systemd.services.oauth2-proxy.serviceConfig = {
+    # Try re-start at 10 seconds intervals.
+    # If there are more than 3 restart attempts in a 60 second interval,
+    # wait for the 60 second interval to pass before another re-try.
+    RestartSec = 10;
+    StartLimitBurst = 3;
+    StartLimitInterval = 60;
+  };
 
   systemd.services.jenkins-purge-artifacts = {
     after = [ "jenkins.service" ];


### PR DESCRIPTION
I notice oauth2-proxy occasionally fails after new installation, which I've been testing on release environment lately.
This PR changes the oauth2-proxy service restart config so it doens't fail on fresh installations.