### PR TITLE
ci-release: Add hetzner release builders

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -22,6 +22,7 @@ keys:
   - &build3 age1q7c2wlrpj0dvthdg7v9j4jmee0kzda8ggtp4nq8jay9u4catee3sn9pa0w
   - &build4 age146j4dfg9974kxe8hegjrdq5ywaldxw5j3fnkghxc6jkrrf0tndpsjjs0x3
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
+  - &hetzarm-rel-1 age1nws8wlvsdmrkskepx76ygcklqcrx4x9nk05czpgx9jdc7uyryepqda2sfs
   - &hetz86-1 age1zy44vwv4t97fhaupczfu835t6lfssxhzd6sfu7vlmel5gfrg4gxq6j5egr
   - &hetz86-builder age13p9uu27kv9qchcxy6dd8s602fep5zk3xqe8pwhe7yqaa5hyj697qhax6g8
   - &hetz86-rel-1 age1a6qza2a4j459m7r04pgs8fajmve00r5a25rlagr6c63s3pskevkqd7zps6
@@ -106,6 +107,13 @@ creation_rules:
     key_groups:
     - age:
       - *hetzarm
+      - *jrautiola
+      - *hrosten
+      - *fayad
+  - path_regex: hosts/builders/hetzarm-rel-1/secrets.yaml$
+    key_groups:
+    - age:
+      - *hetzarm-rel-1
       - *jrautiola
       - *hrosten
       - *fayad

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -24,6 +24,7 @@ keys:
   - &hetzarm age1ppunea05ue028qezt9rvhp59dgcskkleetyjpqtxzea7vtp4ppfqh7ltuy
   - &hetz86-1 age1zy44vwv4t97fhaupczfu835t6lfssxhzd6sfu7vlmel5gfrg4gxq6j5egr
   - &hetz86-builder age13p9uu27kv9qchcxy6dd8s602fep5zk3xqe8pwhe7yqaa5hyj697qhax6g8
+  - &hetz86-rel-1 age1a6qza2a4j459m7r04pgs8fajmve00r5a25rlagr6c63s3pskevkqd7zps6
   - &hetzci-release age19kx56nu8rlwtyaap83vyg940ylv9hpf7dprgdpcctqqv8k8ecqhsnxtfs4
   - &hetzci-prod age1av993eefvndhv2apa4x7tpc7ezyhuj3jz9866vtulnrdwmjqe5hqrjc2z8
   - &hetzci-dev age10xhyyjrhackyac2f042t3z8yqld3sh39ul3mukwkt6gyr7gn9upq8n30gm
@@ -119,6 +120,13 @@ creation_rules:
     key_groups:
     - age:
       - *hetz86-builder
+      - *jrautiola
+      - *hrosten
+      - *fayad
+  - path_regex: hosts/builders/hetz86-rel-1/secrets.yaml$
+    key_groups:
+    - age:
+      - *hetz86-rel-1
       - *jrautiola
       - *hrosten
       - *fayad

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -19,7 +19,6 @@
       common
       service-openssh
       team-devenv
-      user-remote-build
     ]);
 
   sops = {
@@ -48,4 +47,16 @@
     cacheName = "ghaf-dev";
     cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
+
+  # hetzci-release can use this as remote builder
+  users.users.hetzci-release = {
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIO9k4r3MqFXlatxzDwZash9U8R8dRhlxyHI050hsCFy"
+    ];
+  };
+  nix.settings.trusted-users = [
+    "@wheel"
+    "hetzci-release"
+  ];
 }

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  inputs,
+  config,
+  ...
+}:
+{
+  imports =
+    [
+      ./disk-config.nix
+      ../builders-common.nix
+      ../../hetzner-cloud.nix
+      inputs.sops-nix.nixosModules.sops
+      inputs.disko.nixosModules.disko
+    ]
+    ++ (with self.nixosModules; [
+      common
+      service-openssh
+      team-devenv
+      user-remote-build
+    ]);
+
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets = {
+      cachix-auth-token.owner = "root";
+      loki_password.owner = "promtail";
+    };
+  };
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "hetz86-rel-1";
+
+  boot.kernelModules = [ "kvm-amd" ];
+
+  services.monitoring = {
+    metrics.enable = true;
+    logs.enable = true;
+  };
+
+  # Disable cachix push for now, until we setup an own
+  # cache for release builds
+  services.cachix-watch-store = {
+    enable = false;
+    verbose = true;
+    cacheName = "ghaf-dev";
+    cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
+  };
+}

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
+  lib,
   self,
   inputs,
   config,
@@ -47,6 +48,15 @@
     cacheName = "ghaf-dev";
     cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
+
+  # Ensure only the nixos.org cache is trusted
+  nix.settings.trusted-public-keys = lib.mkForce [
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+  ];
+  nix.settings.substituters = lib.mkForce [ "https://cache.nixos.org/" ];
+  nix.settings.extra-trusted-public-keys = lib.mkForce [ "" ];
+  nix.settings.extra-substituters = lib.mkForce [ "" ];
+  nix.settings.trusted-substituters = lib.mkForce [ "" ];
 
   # hetzci-release can use this as remote builder
   users.users.hetzci-release = {

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -12,6 +12,7 @@
     [
       ./disk-config.nix
       ../builders-common.nix
+      ../cross-compilation.nix
       ../../hetzner-cloud.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -40,6 +40,20 @@
     logs.enable = true;
   };
 
+  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 150;
+  };
+  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 180;
+    "vm.watermark_boost_factor" = 0;
+    "vm.watermark_scale_factor" = 125;
+    "vm.page-cluster" = 0;
+  };
+
   # Disable cachix push for now, until we setup an own
   # cache for release builds
   services.cachix-watch-store = {

--- a/hosts/builders/hetz86-rel-1/disk-config.nix
+++ b/hosts/builders/hetz86-rel-1/disk-config.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_102943721";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "256M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/builders/hetz86-rel-1/secrets.yaml
+++ b/hosts/builders/hetz86-rel-1/secrets.yaml
@@ -1,0 +1,45 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:ywBRot+VHFYeRLYGBQrjfYTj7gSmHPDPwBPZ3kDYteW6imzriHga2582C3YHmc0F52C8jk0P5IEOw1+xAUNIN//TJZJstCoNW07d21QXKt3Pem9rK80i9j1pQSA10XXBy4CGHfHiOzQ40ew2mP+vXwruADDolfa/h7A6mzAhIu1HMy3ij+DwoAOs8upSy9GFcKtM5c/oeauKiRjcEbOh07IAcX+vymFNWdubER9spOKt+qM+/nEDn+oaze4Gm9b8p7akeTEyXKSQ0EPRJZRMeAFuh8QBAeuJyZYeBgboowi6sO0t40y78h5/OirQm7tl6n6RulGZS+G+brwheI4YDecCzBdkDaqeeLPhewfiL6L29Kzqi8nWSVMXpGFYZ8p2Dl0FfllUL5Lpi31+8t+48ZSQ419/UBhxfJYHZoQJV4RRvvAyqzuadM7QNSBYXTXkuU6jYP9fa3pEUSfwmMg5Su+bZg36K7YLhHwnVyTThDAey9GrliQ53n9BzCqcdNXxS+fR+glXFsduE5q3lGCL,iv:UfRlT1wJSXC1ejXX8HAjDJqjuL7Op0p2WClzBixKOE8=,tag:knp0m8WufmvqieOhpkVsWw==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:BOt4ZRd0BF8sKrn/dzYMYr+5OGmieKd3SbioIyU+Ix6jJU54KZw+5psq/zsfF9NdQKxHpxsvKg2jCYlVuDdJZthi8xDXTjb7ORLnNCtDDoFlz9AT2zTZICDsF7DRQFOP/Eip0Rb8U+JxC6NdbdOG/g2ekxxLpFF64T15Er+kg+hh2Rde3wcMZ8Cn40sOmH3iFvZ8dYH7,iv:FwN5wIjndncQDGWbSPznWEh4OdLNQWXzQFmuUa1363w=,tag:gHig7eBSwRTCsgAgsYWLyw==,type:str]
+loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
+sops:
+    age:
+        - recipient: age1a6qza2a4j459m7r04pgs8fajmve00r5a25rlagr6c63s3pskevkqd7zps6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6RGhLS2U0SC82eEhLWEJz
+            cTB5STd2QlJUeUlySWdlMFBuU3VaamNFZ3lBCmU5ZVcveTZaWmVDcTRLTUk0VEFZ
+            Njl6bnlTWENDSnQ2T2FMR3lRTjRnWFUKLS0tIGdvaXEyTU11Z0Ria0dSNU1rRERx
+            WW9IQ3lkd05DZnRrWG4vUzlnSjlzZG8KdlJHyUD6gok73E02yCp84BunDkKmlXYN
+            dOJ28mVjWEnfTmQEjlXAiGk6qSbwUi3ZvWZArHKefSpdd+PNCuSc8g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQNGhoSzQ5aWcwQXJiOHBs
+            YXpWc1EyR1RadWZJRkRUMlI2SStiMHVVd2lFCnczNVA2UW1laFhkVEZSU1UrbFVW
+            NmUybm44RDM5dGpPNG9yTnB6UHE2elEKLS0tIHFXL3F5UUhrcXhtOXlRdXkyazk0
+            a25EQTY4NXlsbzZNZTNsVWFSTUNVaTAKp8urWgchHwjCZEvvgyoH0h5aitDqjAc8
+            dSlqPOs9MDlEPHUCB9p1Zc8p1Bzlm5sQHFxaWPgNbjxkXItnZ6UgFg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkcUtKejU4YXhyaWNzZXR1
+            VDJtckMzN3BqbHR6Y1o0NW0xRVFveTI3Q0FzCnEwK0thaG4xaURlNFdJeURpbndY
+            dDVpcVlJdEk0OStBR3VxbnRFd2pzT28KLS0tIHE0OEs1c28xQlFXZVdxZkhoeDIy
+            djhjbnlLd0VEVGhkbVM5QzAxbVBaSWcK5Sx0tmWd6SoUwA4irAy+dMTnPohOfKY7
+            2wI+YGQg4Kz5ffxtKFY8Q2cmjBnrfZKs97P0Y+Ann13DZXVTZP8zsw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtM05EKzRsWE4rN1dhSzJD
+            UkhHY2JabGZxMWhqU2RaL29qYnpBbHd4YVdZCjdTS3ZIbms1ZnNWa2RQZjJGT0pl
+            UTBFTVdmTU1xVUNnZ0tDcmtaTkFoVTgKLS0tIGYzM1gwZCttcmlVdXRwK3pXTkFo
+            c0FlOFRuOWdaWmdyQnFHMVpPQU9jTEkKV1EOWI1RDUsNIpvvm1yIzwBh47xKZlWX
+            2nXuZljXQehSzs+sGNBN0wYQ/+MhS7icMf3vq2ElXKEexLqSghnBZg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-03T07:05:48Z"
+    mac: ENC[AES256_GCM,data:KPpAiqMa25q5O4ALvexUhTOk9r2f4wDvsIoFTuoRUwaDUlFFXB6n5C77DOcq0sjqifH2lXgbN+sw6s4P9o1K+2eCadXxaSHdftV0V2xdcUQXyb2lKfXjKfDF4NnSjpk7gcLXIJWy2Fx8L9TT2LbLpgYDJUS2K/OeuepVUYjzfZg=,iv:2BuwqUk+STGCgGuopDo/LaT+qp5RxvCcxUMPMhWakrU=,tag:mo7SWC8+T95fwkOGyXSyPA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/hosts/builders/hetz86-rel-1/secrets.yaml
+++ b/hosts/builders/hetz86-rel-1/secrets.yaml
@@ -39,7 +39,7 @@ sops:
             c0FlOFRuOWdaWmdyQnFHMVpPQU9jTEkKV1EOWI1RDUsNIpvvm1yIzwBh47xKZlWX
             2nXuZljXQehSzs+sGNBN0wYQ/+MhS7icMf3vq2ElXKEexLqSghnBZg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-09-03T07:05:48Z"
-    mac: ENC[AES256_GCM,data:KPpAiqMa25q5O4ALvexUhTOk9r2f4wDvsIoFTuoRUwaDUlFFXB6n5C77DOcq0sjqifH2lXgbN+sw6s4P9o1K+2eCadXxaSHdftV0V2xdcUQXyb2lKfXjKfDF4NnSjpk7gcLXIJWy2Fx8L9TT2LbLpgYDJUS2K/OeuepVUYjzfZg=,iv:2BuwqUk+STGCgGuopDo/LaT+qp5RxvCcxUMPMhWakrU=,tag:mo7SWC8+T95fwkOGyXSyPA==,type:str]
+    lastmodified: "2025-09-03T15:49:44Z"
+    mac: ENC[AES256_GCM,data:JDVgTVekftY8fBwbc4HdDtVkYhCNrKERCRL3jCw2eRM3wBDacOCbGyBtsl5ZUtfAjbs/e2pqrkxO2m3QqnsAateqdltNfnplRhzbDMG8553CteSegwpzhnLuktgn+niGxQpvWHi9QqqUnB3JXi4SMJA9Vz/qSnjbkR9i58Pp/g4=,iv:JmehITNxA4tv70BoEtPtIHLucSUIZE9sn8KnSG0yfoQ=,tag:3LhdJtV0DI2KHJphfXNM/g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -45,4 +45,16 @@
     cacheName = "ghaf-dev";
     cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
+
+  # hetzci-release can use this as remote builder
+  users.users.hetzci-release = {
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIO9k4r3MqFXlatxzDwZash9U8R8dRhlxyHI050hsCFy"
+    ];
+  };
+  nix.settings.trusted-users = [
+    "@wheel"
+    "hetzci-release"
+  ];
 }

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   lib,
+  pkgs,
   self,
   inputs,
   config,
@@ -51,6 +52,9 @@
     "vm.watermark_scale_factor" = 125;
     "vm.page-cluster" = 0;
   };
+
+  # Nixos-anywhere kexec switch fails on hetzner cloud arm VMs without this
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # Disable cachix push for now, until we setup an own
   # cache for release builds

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -38,6 +38,20 @@
     logs.enable = true;
   };
 
+  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 150;
+  };
+  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 180;
+    "vm.watermark_boost_factor" = 0;
+    "vm.watermark_scale_factor" = 125;
+    "vm.page-cluster" = 0;
+  };
+
   # Disable cachix push for now, until we setup an own
   # cache for release builds
   services.cachix-watch-store = {

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
+  lib,
   self,
   inputs,
   config,
@@ -45,6 +46,15 @@
     cacheName = "ghaf-dev";
     cachixTokenFile = config.sops.secrets.cachix-auth-token.path;
   };
+
+  # Ensure only the nixos.org cache is trusted
+  nix.settings.trusted-public-keys = lib.mkForce [
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+  ];
+  nix.settings.substituters = lib.mkForce [ "https://cache.nixos.org/" ];
+  nix.settings.extra-trusted-public-keys = lib.mkForce [ "" ];
+  nix.settings.extra-substituters = lib.mkForce [ "" ];
+  nix.settings.trusted-substituters = lib.mkForce [ "" ];
 
   # hetzci-release can use this as remote builder
   users.users.hetzci-release = {

--- a/hosts/builders/hetzarm-rel-1/disk-config.nix
+++ b/hosts/builders/hetzarm-rel-1/disk-config.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_102943746";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "256M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/builders/hetzarm-rel-1/secrets.yaml
+++ b/hosts/builders/hetzarm-rel-1/secrets.yaml
@@ -1,0 +1,45 @@
+ssh_host_ed25519_key: ENC[AES256_GCM,data:75dhbwPp1keDClhzDz/MT+fNxn/L2H9UR++MAndaRT55FBYLHzrt4OcnIAfa3mXHitn6ERDz7s5V4MPJBTnMKat5vZhiIhVhurdpyyoDv/S4JH98N6MTj3thpjKv6en4tloSTXZd+CU1NMaFs5t3O6L78GS77a/2SG/ES1juz7anD4TTTLwCcRCePQ1YPITpwyT/F/3yQStb5oJEss7wYxbDKu7Gp3BF/AI5VvKEbbkT3VHEcfcqwwe2+gSrY7IwxZJHDwNhFg/FXWJz9HJjW/+vn09oGkCwW4kHF7EwIFzNg3hmFmBvxTOrk/VIdNw+/J+bwHmeuxG744pWOBF31HRyYYLRFWKj7KtnNzJGHuARpRYEVEsImd0xXzA/mEOX0hjNpL1v6J5GAebkMyMR/FCAcrJ6OhyzMTsuJYIJby8L5KQhrkPqWf0g5OERxVjohugRhnVZUZCXlh/l0pyg6ub3A+e3cNtezNObbmON6WkRt4uxDJN2U39ZFhBquAEf98vtEzSnJ45Qmfj1ChKPQ+/f+i/7QloQoGL0,iv:oR7JevIdKPQiDizp9tUhCVyRWkMDDvfTXvd9YTVe2VQ=,tag:x9P2GgK19CwfREpRRhfU/g==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:BOt4ZRd0BF8sKrn/dzYMYr+5OGmieKd3SbioIyU+Ix6jJU54KZw+5psq/zsfF9NdQKxHpxsvKg2jCYlVuDdJZthi8xDXTjb7ORLnNCtDDoFlz9AT2zTZICDsF7DRQFOP/Eip0Rb8U+JxC6NdbdOG/g2ekxxLpFF64T15Er+kg+hh2Rde3wcMZ8Cn40sOmH3iFvZ8dYH7,iv:FwN5wIjndncQDGWbSPznWEh4OdLNQWXzQFmuUa1363w=,tag:gHig7eBSwRTCsgAgsYWLyw==,type:str]
+loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
+sops:
+    age:
+        - recipient: age1nws8wlvsdmrkskepx76ygcklqcrx4x9nk05czpgx9jdc7uyryepqda2sfs
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBscm5UOHhCcEFCaUpReEpl
+            K1V1TGhrcFh6WUtZR09lbXc0RlZsdm1mVG5vClZyOXl3azhZTExjdDBBN2ptUWda
+            dlV6NFFuYjJSN0ozWUJhMFUxUTFnQWcKLS0tIDNQNEtwd2dQQnYyNENtK0lOYzJR
+            M2V0TFhoZy9CRFNlMytxQm9Pc1d5WDQKOzBxEH6BA91Zt6N6co/uOs8CMvpQtGM8
+            hRTHzzCWUlrt7EpeqD/SutKUb790Ci4oTjnpVo00gfbja0vy4VqSjQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0N2NaVE5UZTMwVGt6aVBC
+            U3Y5djFZL1JoMXlnMkdWRkZaa2xGRDc2Wnc0CkV1T1lwTUNES3o4a1pqK3V0NEo5
+            VDFyRUJ0TmYvTFFHMnZ1bzRBQ2t2RzQKLS0tIGg3Qzd6dmFFMkJCdUpjZzhtM0o4
+            azM0d24xcXhaNGhtS1hibittcmx1OFkKc67gSC7Gomc0kejYS+Q1mvIl0Q3VYX+q
+            Ofmhkh5NLld0oM6DHGxeeK6+/VVkDXT/TKLNAg/kt3YShMBUdihJuA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxWlMwZWo4UUtyUFM3c3Uv
+            aHRtQitVSEFEU3QybWNSOE5RcmYzZ0l6clFJCnptNmd0aloxZUhkOGdEdmNMSnhp
+            MS84a2V4SlhjMFJCTCtyZkFRb3FETk0KLS0tIEJLWDhVclNCcFVtN3lRc0hFQkRK
+            UHpYS0g0dFVQZEJPbS9uSXl0OEQ2QkEK3jRv7eqCbLiHuyppwXiLioM/7+Nnekb4
+            RSxiOseL246sq7V0RPStbWwm4f1c2wid0voKqIYL/Ph3cqUaOHMnsg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6ZmI4QThLVkMzcmtlOVgx
+            YUVuWHM5My9ndFRld00zaWZhb0lOWm15YmpNCjJKVkJzMERsa2JRQk1LMVhxdkFu
+            dTU1RzZLcThCcThBRzlLN2VPSHF0UXcKLS0tIGFXUTVWaDF2VnQ4cFJVbG5EemRu
+            b0hoRFFNL0RhZ1ZKZ21VeHJ3bjlzS1kKg1QlW1cEbArIvLtYbogrGPUuHr2pklU9
+            p7LrRn+lc8/jpSrJz4fxmWw9R+ts+WGoRRR3s8OXQra+dtIP2GiKRA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-04T06:32:41Z"
+    mac: ENC[AES256_GCM,data:BKyfALTiONXNJwMUnE+p5TZGQGKxGyaQxthBM/FOX1o0g6p98oh5C0HewokifoDzbqzaAZCCFTssPbPT7Kf3dlPCI5sm5eyukaGGgab6wVWw0cneGylsmjqhGPHYd7ehwPQ2f7xS+YzcmAwZxzSYUt5IT94ABirRdOTDs+Ro7Pg=,iv:MchIFhAE5wCJmIPVcVFwuDFV7oG0mXXfgEW7OkhiyZ0=,tag:XqO1ytE9ZIYqjlbX59oHhw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -52,6 +52,7 @@ in
     nixos-build3 = ./builders/build3/configuration.nix;
     nixos-build4 = ./builders/build4/configuration.nix;
     nixos-hetzarm = ./builders/hetzarm/configuration.nix;
+    nixos-hetzarm-rel-1 = ./builders/hetzarm-rel-1/configuration.nix;
     nixos-monitoring = ./monitoring/configuration.nix;
     nixos-testagent-prod = ./testagent/prod/configuration.nix;
     nixos-testagent-dev = ./testagent/dev/configuration.nix;
@@ -97,6 +98,7 @@ in
           "build3"
           "build4"
           "hetzarm"
+          "hetzarm-rel-1"
           "monitoring"
           "testagent-prod"
           "testagent-dev"

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -70,6 +70,7 @@ in
     nixos-hetzci-vm = ./hetzci/vm/configuration.nix;
     nixos-hetz86-1 = ./builders/hetz86-1/configuration.nix;
     nixos-hetz86-builder = ./builders/hetz86-builder/configuration.nix;
+    nixos-hetz86-rel-1 = ./builders/hetz86-rel-1/configuration.nix;
   };
 
   # Expose as flake.lib.mkNixOS.
@@ -113,6 +114,7 @@ in
           "hetzci-release"
           "hetz86-1"
           "hetz86-builder"
+          "hetz86-rel-1"
         ]
     ))
     // {

--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -19,8 +19,10 @@ let
   sshMonitoredHosts = {
     inherit (machines)
       hetzarm
+      hetzarm-rel-1
       hetz86-1
       hetz86-builder
+      hetz86-rel-1
       ;
   };
 in

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -48,6 +48,15 @@
     ];
   };
 
+  # Ensure only the nixos.org cache is trusted
+  nix.settings.trusted-public-keys = lib.mkForce [
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+  ];
+  nix.settings.substituters = lib.mkForce [ "https://cache.nixos.org/" ];
+  nix.settings.extra-trusted-public-keys = lib.mkForce [ "" ];
+  nix.settings.extra-substituters = lib.mkForce [ "" ];
+  nix.settings.trusted-substituters = lib.mkForce [ "" ];
+
   # Configure (release) remote builders
   nix = {
     distributedBuilds = true;

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -1,19 +1,29 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ lib, ... }:
+{
+  lib,
+  config,
+  machines,
+  ...
+}:
 {
   imports = [
     ./disk-config.nix
     ../common.nix
     ../jenkins.nix
-    ../remote-builders.nix
     ../cloud.nix
     ../auth.nix
   ];
 
   system.stateVersion = lib.mkForce "25.05";
   networking.hostName = "hetzci-release";
-  sops.defaultSopsFile = ./secrets.yaml;
+
+  sops = {
+    defaultSopsFile = ./secrets.yaml;
+    secrets = {
+      ssh_private_key.owner = "root";
+    };
+  };
 
   hetzci = {
     jenkins = {
@@ -36,5 +46,48 @@
       "x-systemd.makefs"
       "x-systemd.growfs"
     ];
+  };
+
+  # Configure (release) remote builders
+  nix = {
+    distributedBuilds = true;
+    buildMachines =
+      let
+        commonOptions = {
+          maxJobs = 16;
+          speedFactor = 10;
+          supportedFeatures = [
+            "kvm"
+            "nixos-test"
+            "benchmark"
+            "big-parallel"
+          ];
+          sshUser = "hetzci-release";
+          sshKey = config.sops.secrets.ssh_private_key.path;
+        };
+      in
+      [
+        (
+          {
+            hostName = "hetz86-rel-1";
+            system = "x86_64-linux";
+          }
+          // commonOptions
+        )
+      ];
+  };
+
+  programs.ssh = {
+    # Known builder host public keys, these go to /root/.ssh/known_hosts
+    knownHosts = {
+      "hetz86-rel-1".publicKey = machines.hetz86-rel-1.publicKey;
+      "${machines.hetz86-rel-1.ip}".publicKey = machines.hetz86-rel-1.publicKey;
+    };
+
+    # Custom options to /etc/ssh/ssh_config
+    extraConfig = lib.mkAfter ''
+      Host hetz86-rel-1
+      Hostname ${machines.hetz86-rel-1.ip}
+    '';
   };
 }

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -74,6 +74,13 @@
           }
           // commonOptions
         )
+        (
+          {
+            hostName = "hetzarm-rel-1";
+            system = "aarch64-linux";
+          }
+          // commonOptions
+        )
       ];
   };
 
@@ -82,12 +89,16 @@
     knownHosts = {
       "hetz86-rel-1".publicKey = machines.hetz86-rel-1.publicKey;
       "${machines.hetz86-rel-1.ip}".publicKey = machines.hetz86-rel-1.publicKey;
+      "hetzarm-rel-1".publicKey = machines.hetzarm-rel-1.publicKey;
+      "${machines.hetzarm-rel-1.ip}".publicKey = machines.hetzarm-rel-1.publicKey;
     };
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''
       Host hetz86-rel-1
       Hostname ${machines.hetz86-rel-1.ip}
+      Host hetzarm-rel-1
+      Hostname ${machines.hetzarm-rel-1.ip}
     '';
   };
 }

--- a/hosts/hetzci/release/secrets.yaml
+++ b/hosts/hetzci/release/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:tKQS1ShTc3ziDqOHebhKaxD+WEYIld/j+SIZVuuDgTCumjsg5pT3mQQS4c+BEAjMGdgJpitDQkxI9yX5wJhz54P9ed1NsMkzrneFP58+7YggoeaIDssYyn8dNquf6qsO2U31j0G3qtjo/VOuUFoa6dX8HqGZkkgwYkb820x32R0rc36oIUMXLzJaNq39Z3kiPtu+6KX2M3jWuFqcfLMtnBfKw2crI6G3xERv3nOYdeEFNfjZvs6KHALaimLwHI6NkgqQcWGXuC9PFhxTH58AW7sQfqKi+LB39886SvDunvIpMJHPXUL4mP+PdCrZQ+KpM7vokxQWR2C89Rfh6zfSWmb1q2owrmSXhvslR4hi9GK9RxcOzJjowm/KmD/Xcwzq0Bk2TnOi75OCzuF6zwa/UBZzi9lkizD9K4HVPjmfXZKEpVUMvUwWZgu3/uIL/1qSCb/16yYumL2Bqv+vm+Pns+AM7hJPQYv9N40mtWvz5dt5ivPPCEqQD91BJl6uLpS/MEuhH+UpUm9effoz5OJvyeovuhN/t4sHvX8R,iv:zzfM4oFqo9GRgRFWDvAHLAmbMMJg5IvsnEWUYwwwBQY=,tag:UMjUoqQo0RGxjhYYS6JDKQ==,type:str]
+ssh_private_key: ENC[AES256_GCM,data:l9H705vCG1uKgjO3iiun+R2ak9TUKBc85V5a8kZZjMyvePuAtvYnDtc2s40ruEHNptgOryeAScLKizRgOWtYXuR/8qRNdcqhPggIWDJCRzhImLSvSU7G9de1/itCrkwC6uk7cF0QwTyoIJBrrCVz67IkAPAtsxaJaH/Rs7RRjcL11LckG7TkM+/mWzUWE33Ky7x+ZeW/WOKL2jeRZbmGolUO18DEp1bAXgsiZPi2/DZfTdtEMvLj16prmRHvOjYrPJ2YtYMLz3ZBurJ2n0TuxD5sV0HAtblss7YYt4HctPoftJBrkq9Ce/jAdwP6O/iwS3hl0obZob4/Dwj5MlzMN1RNFIY/ZVi6EHtGTEy8CNDiPWyhcdcwuJHUJTrlhx5afKuXO8ULkpOFqyuITArIRt3Dtr1j2r8QYuSCezTCtDhpOiN7MX5rf1fc1hbNuaWcnZG/Ar6bCuJ1HWASOraAPxphD9bnLMTIb6tT+/Z8b5ASMr0NIzRQlJiY2+mu+251A4uV,iv:Y7rfo2Y/9yZiLvtvHRb72yQWKH/WOu9t2H4lWrRVzNY=,tag:NrRXYt0KOg1p/As/nVlwWw==,type:str]
 oauth2_proxy_client_secret: ENC[AES256_GCM,data:ww3anrvRVkYknkeezrGqEA07i0Xf4yGPSSvFBa4XAWg=,iv:UF/W2HbtgWeuedM4wTRkiRb4eprDOto3Q3StLDuoYXg=,tag:52mPWiMcbcieGcfkv8Rv/A==,type:str]
 oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:2peVU6TWd+OZ1AcD6+Cnsof6pYzkX5nQYHqbUKFVSveVt9F/msXksjeWrg==,iv:vegMu1MSwENdruSr3RI1iBQIBnJ0Cwf3YZnK1j8FZhc=,tag:BITxYtU9P/BfDoS17Xy8qg==,type:str]
 jenkins_api_token: ENC[AES256_GCM,data:paXifH4nATF+6FqSv+ReDRGbsbEXbQ+SOKqaV9VFgNABLA==,iv:8dd7FvRhuW1VDaElgqaSQL1SxFHl+OugqIIRBGJ+Ls8=,tag:htfuumutvgGuy2gzcAq28A==,type:str]
@@ -38,7 +39,7 @@ sops:
             a1hkMDZhZWp3Q1hYbkt5VmQvOG9WV2sKfHtyW0taKWSL85hrZUFJUgjB+z/9vN/r
             6fklpuvN+m1iKuqLQPPluEN4MPqklkpEr0dbc6ahlf9PWT33KagoAQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-27T11:43:26Z"
-    mac: ENC[AES256_GCM,data:B98646R7RDpZ3qc0SNza/CRJxNsiscTov3texfbvBOG6dDBiJFKbQUfCaAtNffH2TriIQlHyeOvx/KXq2Jfn4BGqTcaYloMP/hqoCn37S4guKPX7Qy6TZRTQ5Eol7afPVrdctLjtLD4FfRMlM4ps3VBfQlrUhYZzxh18S4y4hOE=,iv:aFS+XL850GMs/93B1DtgF6h22rL7hkkzdzpy+1yhzZ0=,tag:04V6aT+BlypWveBOqhHsZw==,type:str]
+    lastmodified: "2025-09-03T15:50:33Z"
+    mac: ENC[AES256_GCM,data:960SkPzqA7aBdUMpfyzoKZADiNpxsuEzTuTJE5/IjoHm5gRPNtXPBg37SeynUID2itnUl4xv3n6kR89qVWnkUJ0kdqIFZck/L/faLWkayxL8XSt5k4ptknUZKFP1zwhpE8hHzvkeP8ogHeT4kh7JMmQSFQP03BAzK+mQWviBF+U=,iv:k3VgX6kSGdrNFYuO2QZBrlw092gOG4pxDzrTNELD0c0=,tag:nUK9Cc+RkPwJBAaZ+wPxLw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -53,6 +53,11 @@
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG68NdmOw3mhiBZwDv81dXitePoc1w//p/LpsHHA8QRp";
   };
 
+  hetz86-rel-1 = {
+    ip = "46.62.194.110";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGg4+l1ln0HycoqkN0vbwvU+fZBniozhLq0Z8hGsGfjx";
+  };
+
   hetzci-dev = {
     ip = "157.180.119.138";
     internal_ip = "10.0.0.6";

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -43,6 +43,11 @@
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
   };
 
+  hetzarm-rel-1 = {
+    ip = "46.62.196.166";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/4rUvG9LPsYGuPFIwjJLoip/DOa6NTWUPGQ20fxXFy";
+  };
+
   hetz86-1 = {
     ip = "37.27.170.242";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -47,6 +47,7 @@ let
     hetzci-dev = mkDeployment "hetzci-dev" machines.hetzci-dev.ip;
     hetz86-1 = mkDeployment "hetz86-1" machines.hetz86-1.ip;
     hetz86-builder = mkDeployment "hetz86-builder" machines.hetz86-builder.ip;
+    hetz86-rel-1 = mkDeployment "hetz86-rel-1" machines.hetz86-rel-1.ip;
   };
 
   aarch64-nodes = {

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -52,6 +52,7 @@ let
 
   aarch64-nodes = {
     hetzarm = mkDeployment "hetzarm" machines.hetzarm.ip;
+    hetzarm-rel-1 = mkDeployment "hetzarm-rel-1" machines.hetzarm-rel-1.ip;
   };
 
   nodes = x86-nodes // aarch64-nodes;


### PR DESCRIPTION
- Add configuration for release builders `hetz86-rel-1` and `hetzarm-rel-1`
- Start using (only) the new builders in [ci-relese](https://ci-release.vedenemo.dev/)
- Use (only) nixos.org cache [ci-relese](https://ci-release.vedenemo.dev/)