### PR TITLE
Run darp11 tests also in ghaf-manual pipeline

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
@@ -89,7 +89,7 @@ pipeline {
             }
             if (params.system76_darp11_b_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: params.TESTSET  ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
@@ -89,7 +89,7 @@ pipeline {
             }
             if (params.system76_darp11_b_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: params.TESTSET  ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
@@ -89,7 +89,7 @@ pipeline {
             }
             if (params.system76_darp11_b_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: null ])
+                [ target: "packages.x86_64-linux.system76-darp11-b-debug", testset: params.TESTSET  ])
             }
             MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             PIPELINE = MODULES.utils.create_pipeline(TARGETS)


### PR DESCRIPTION
Run darp11 tests also in ghaf-manual pipeline. It seems this was left out from the recent PR to add darp11 config: https://github.com/tiiuae/ghaf-infra/pull/602
