### PR TITLE
Initial version of cachix-push.nix

### DIFF
--- a/hosts/builders/cachix-push.nix
+++ b/hosts/builders/cachix-push.nix
@@ -26,6 +26,13 @@ in
       ];
       serviceConfig = {
         Type = "simple";
+        Restart = "always";
+        # Try re-start at 30 seconds intervals.
+        # If there are more than 3 restart attempts in a 240 second interval,
+        # wait for the 240 second interval to pass before another re-try.
+        RestartSec = 30;
+        StartLimitBurst = 3;
+        StartLimitInterval = 240;
       };
       script = builtins.readFile ./cachix-push.sh;
       environment = {

--- a/hosts/builders/cachix-push.nix
+++ b/hosts/builders/cachix-push.nix
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.cachix-push;
+in
+{
+  options.cachix-push = {
+    cacheName = lib.mkOption {
+      type = lib.types.str;
+      description = "Cachix cache name";
+    };
+  };
+  config = {
+    systemd.services.cachix-push = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        cachix
+        diffutils
+      ];
+      serviceConfig = {
+        Type = "simple";
+      };
+      script = builtins.readFile ./cachix-push.sh;
+      environment = {
+        CACHIX_AUTH_TOKEN_FILE = "${config.sops.secrets.cachix-auth-token.path}";
+        CACHIX_CACHE_NAME = cfg.cacheName;
+      };
+    };
+  };
+}

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -12,6 +12,7 @@
       ./disk-config.nix
       ../builders-common.nix
       ../cross-compilation.nix
+      ../cachix-push.nix
       ../../hetzner-cloud.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
@@ -26,13 +27,17 @@
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       loki_password.owner = "promtail";
+      cachix-auth-token.owner = "root";
     };
   };
 
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetz86-rel-1";
-
   boot.kernelModules = [ "kvm-amd" ];
+
+  cachix-push = {
+    cacheName = "ghaf-release";
+  };
 
   services.monitoring = {
     metrics.enable = true;

--- a/hosts/builders/hetz86-rel-1/secrets.yaml
+++ b/hosts/builders/hetz86-rel-1/secrets.yaml
@@ -1,5 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:ywBRot+VHFYeRLYGBQrjfYTj7gSmHPDPwBPZ3kDYteW6imzriHga2582C3YHmc0F52C8jk0P5IEOw1+xAUNIN//TJZJstCoNW07d21QXKt3Pem9rK80i9j1pQSA10XXBy4CGHfHiOzQ40ew2mP+vXwruADDolfa/h7A6mzAhIu1HMy3ij+DwoAOs8upSy9GFcKtM5c/oeauKiRjcEbOh07IAcX+vymFNWdubER9spOKt+qM+/nEDn+oaze4Gm9b8p7akeTEyXKSQ0EPRJZRMeAFuh8QBAeuJyZYeBgboowi6sO0t40y78h5/OirQm7tl6n6RulGZS+G+brwheI4YDecCzBdkDaqeeLPhewfiL6L29Kzqi8nWSVMXpGFYZ8p2Dl0FfllUL5Lpi31+8t+48ZSQ419/UBhxfJYHZoQJV4RRvvAyqzuadM7QNSBYXTXkuU6jYP9fa3pEUSfwmMg5Su+bZg36K7YLhHwnVyTThDAey9GrliQ53n9BzCqcdNXxS+fR+glXFsduE5q3lGCL,iv:UfRlT1wJSXC1ejXX8HAjDJqjuL7Op0p2WClzBixKOE8=,tag:knp0m8WufmvqieOhpkVsWw==,type:str]
 loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:TDrteHXXF8vusyOBF6X3KbrZF1NmhDY6MmhE0K5N48+IPUNOe3NTz9Hgq/RRuhzZgy2w53np8t1KA8ox/lLs6d0eFOkjgEZ5+cg/p9/5rwlO6KWfV0YZ8EWT9kPB0j0mpUXuuwZ221kmMDktVlf6iBP7aYd6f23URuK3KFrLzZrgWE3evhTarLB/MyR0tQH1dWDhytF1,iv:j9DJZ37LDkhvqOSZfG5IN1mg6yWY5Xgp/hQE5Oz5+4Q=,tag:PeYmDn7HnWqyRuMdJ8q1eg==,type:str]
 sops:
     age:
         - recipient: age1a6qza2a4j459m7r04pgs8fajmve00r5a25rlagr6c63s3pskevkqd7zps6
@@ -38,7 +39,7 @@ sops:
             c0FlOFRuOWdaWmdyQnFHMVpPQU9jTEkKV1EOWI1RDUsNIpvvm1yIzwBh47xKZlWX
             2nXuZljXQehSzs+sGNBN0wYQ/+MhS7icMf3vq2ElXKEexLqSghnBZg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-09-11T05:41:22Z"
-    mac: ENC[AES256_GCM,data:vvMWuksMM7Hkgdmg5vqp0K4k4vqYXRvf2qMl1HQIgTbpkESRLT6c8ybIPSlumc8swUIXqXfu2uCUZbEBQ2KoC+FN1YwOkcSWwykYJ/aDLRRMarBfbVXTxa4+xgw4rCzksEgf7uFjjqITIYh2HX7vTGGQ18a2sBfy1hTGSXl6PLg=,iv:Lg6SuFWli7yM6Ie68U77IitkSsXk8/Tf8NXJCQP+8aA=,tag:txL8xbtKLE7leaLZ/MF6eQ==,type:str]
+    lastmodified: "2025-09-15T09:20:57Z"
+    mac: ENC[AES256_GCM,data:v/jdv2910CnXYkPU3xQi8NlLxtmg40Ph2ffw3PhKOPYwirmFMXYWvWxiPC64AucoBm5bQlqKzSxZSaJKrWgAGe5gmFddKDodtlCXeRfNHj/S1AFbMZIF4rS/uygjEEP0AeICbuRNAfKYZH1o2NfMcc3rGQdrl3TwAq6h7xo72Wo=,iv:ldWVIWM2Er+2h+SYB2nFgAgkyCnpGE9KJrqG30+czWk=,tag:A1oy5XhzqS9ZEskeq+HgCA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -12,6 +12,7 @@
     [
       ./disk-config.nix
       ../builders-common.nix
+      ../cachix-push.nix
       ../../hetzner-cloud.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
@@ -26,11 +27,16 @@
     defaultSopsFile = ./secrets.yaml;
     secrets = {
       loki_password.owner = "promtail";
+      cachix-auth-token.owner = "root";
     };
   };
 
   nixpkgs.hostPlatform = "aarch64-linux";
   networking.hostName = "hetzarm-rel-1";
+
+  cachix-push = {
+    cacheName = "ghaf-release";
+  };
 
   services.monitoring = {
     metrics.enable = true;

--- a/hosts/builders/hetzarm-rel-1/secrets.yaml
+++ b/hosts/builders/hetzarm-rel-1/secrets.yaml
@@ -1,5 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:75dhbwPp1keDClhzDz/MT+fNxn/L2H9UR++MAndaRT55FBYLHzrt4OcnIAfa3mXHitn6ERDz7s5V4MPJBTnMKat5vZhiIhVhurdpyyoDv/S4JH98N6MTj3thpjKv6en4tloSTXZd+CU1NMaFs5t3O6L78GS77a/2SG/ES1juz7anD4TTTLwCcRCePQ1YPITpwyT/F/3yQStb5oJEss7wYxbDKu7Gp3BF/AI5VvKEbbkT3VHEcfcqwwe2+gSrY7IwxZJHDwNhFg/FXWJz9HJjW/+vn09oGkCwW4kHF7EwIFzNg3hmFmBvxTOrk/VIdNw+/J+bwHmeuxG744pWOBF31HRyYYLRFWKj7KtnNzJGHuARpRYEVEsImd0xXzA/mEOX0hjNpL1v6J5GAebkMyMR/FCAcrJ6OhyzMTsuJYIJby8L5KQhrkPqWf0g5OERxVjohugRhnVZUZCXlh/l0pyg6ub3A+e3cNtezNObbmON6WkRt4uxDJN2U39ZFhBquAEf98vtEzSnJ45Qmfj1ChKPQ+/f+i/7QloQoGL0,iv:oR7JevIdKPQiDizp9tUhCVyRWkMDDvfTXvd9YTVe2VQ=,tag:x9P2GgK19CwfREpRRhfU/g==,type:str]
 loki_password: ENC[AES256_GCM,data:bVecIUiiFo2Epa0/fo3Js8gHOg==,iv:c5XaFv9Elr+DBT+8X4YLbJvvRPVaq3oED7Jtpxngucg=,tag:ZewOdGXzpuTn99UukoP3eA==,type:str]
+cachix-auth-token: ENC[AES256_GCM,data:Cpubxe+i7fhJ6F1ateW4X7WgdZlzJCJ7WT8aIh0Wzcau2XN+XI1czPNsdAnlnE25XJ7A8y5hdcvVPgv/wh2ImgZpV3EFp4YcZXZGhdqmRDKwR9XgpXxzu8hC6H/yQ2+Kj+/k40DUSePXgqLTDhYqpK/OkeHtrhddSWY2RlhfDGbL1akm5+i3gUqZsp7Hou2Xf+FcXzm7,iv:goG0q1s/v5/ut4xY+3p738xc49QqPdzrvdVj3owa5GQ=,tag:UpmE6rxc3EOM1sfN6W8Cdw==,type:str]
 sops:
     age:
         - recipient: age1nws8wlvsdmrkskepx76ygcklqcrx4x9nk05czpgx9jdc7uyryepqda2sfs
@@ -38,7 +39,7 @@ sops:
             b0hoRFFNL0RhZ1ZKZ21VeHJ3bjlzS1kKg1QlW1cEbArIvLtYbogrGPUuHr2pklU9
             p7LrRn+lc8/jpSrJz4fxmWw9R+ts+WGoRRR3s8OXQra+dtIP2GiKRA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-09-11T05:41:33Z"
-    mac: ENC[AES256_GCM,data:1UcUJMm0UEBF8nfyWT2l4y17s2oF7f0A22KNl2vWauAOtqjDpa0bIklqkBealxq/ELjGfmqAQde7ia9XbtSsB8nUmlHf+A5ngDZXHO6UNAFrRUI1TgXfphv3N5hMeymbOlaCYig1jpd+QdPC6R1GQ9KNKj90LWX08TxF4AiMd0Q=,iv:x2ZzY9F9QqU850StAqErg+jHc8ol4kKQeHXESw2Bjww=,tag:6a3QpTBhvjlO+b/JQkuTvg==,type:str]
+    lastmodified: "2025-09-15T13:14:08Z"
+    mac: ENC[AES256_GCM,data:1MMjTz2P+W9hS3heKfN5pY3+Fb/ortec2A2bU2HlfMgIEva8GAh5dccJuqRwxzX4VDxIDicTfkhLkpv11IP8NWcy2TlNUZZoxzZbx6MS5OgKPuBjKQn7OYu0Jh7ZxUb+5cC13l92rl7W4Do95FNOKLjqVJN8aAsESyNJlrWyCdE=,iv:jw8+XJTrTMTgB0P/fK2kmhqa9bZQR5gjSWG5rqRTMbQ=,tag:0S3q8BCcNVOuLLmcKdXpPQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/hosts/hetzci/release/casc/pipelines/ghaf-release.groovy
+++ b/hosts/hetzci/release/casc/pipelines/ghaf-release.groovy
@@ -37,8 +37,6 @@ def RELEASE_TARGETS = [
 def OTA_TARGETS = [
   [ target: "lenovo-x1-carbon-gen11-debug" ],
   [ target: "system76-darp11-b-debug" ],
-  [ target: "nvidia-jetson-orin-nx-debug-from-x86_64" ],
-  [ target: "nvidia-jetson-orin-nx-debug" ],
 ]
 
 properties([


### PR DESCRIPTION
- Add `cachix-push.nix` nix module which implements a systemd service that is functionally-wise similar to [cachix-watch-store](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/system/cachix-watch-store.nix), but allows filtering the store paths pushed to cachix. This service can be used to replace the [cachix-watch-store](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/system/cachix-watch-store.nix) service (which we currently use e.g. in [hetzarm](https://github.com/tiiuae/ghaf-infra/blob/main/hosts/builders/hetzarm/configuration.nix#L44-L49) and [hetz86-1](https://github.com/tiiuae/ghaf-infra/blob/main/hosts/builders/hetz86-1/configuration.nix#L46-L51) builders).
- Start using `cachix-push.nix` in the release builders `hetz86-rel-1` and `hetzarm-rel-1`, pushing the build results to [ghaf-release](https://app.cachix.org/organization/tiiuae) cachix cache
- Remove OTA pins "nvidia-jetson-orin-nx-debug-from-x86_64" and "nvidia-jetson-orin-nx-debug" from the release pipeline that were added only to keep the release cache warm for cross-compiled builds that otherwise would take ages. This is now unnecessary, since we push all build results to ghaf-release cachix cache from the release builders.

A follow-up PR will disable [cachix-watch-store](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/system/cachix-watch-store.nix) service in [hetzarm](https://github.com/tiiuae/ghaf-infra/blob/main/hosts/builders/hetzarm/configuration.nix#L44-L49) and [hetz86-1](https://github.com/tiiuae/ghaf-infra/blob/main/hosts/builders/hetz86-1/configuration.nix#L46-L51) builders replacing it with `cachix-push.nix`.

Note about the cachix push [filtering](https://github.com/tiiuae/ghaf-infra/blob/78a79748b5c208f2812f73b826f14bd57f69a34f/hosts/builders/cachix-push.sh#L80-L81): we skip pushing the images, but otherwise push the full closure. This significantly reduces the cachix storage requirement. As an example, the current storage used on [ghaf-release](https://app.cachix.org/organization/tiiuae) cachix cache is  around 30GB - this is the amount of storage required from one full Ghaf release build (7 image targets + doc) after the changes from this PR.

This change has been tested in https://ci-release.vedenemo.dev/. 