### PR TITLE
Fix cachix-push and auth service rate limits

### DIFF
--- a/hosts/builders/cachix-push.nix
+++ b/hosts/builders/cachix-push.nix
@@ -27,13 +27,11 @@ in
       serviceConfig = {
         Type = "simple";
         Restart = "always";
-        # Try re-start at 30 seconds intervals.
-        # If there are more than 3 restart attempts in a 240 second interval,
-        # wait for the 240 second interval to pass before another re-try.
+        # Try re-start at 30 second intervals.
         RestartSec = 30;
-        StartLimitBurst = 3;
-        StartLimitInterval = 240;
       };
+      # Allow unlimited restart attempts
+      unitConfig.StartLimitBurst = 0;
       script = builtins.readFile ./cachix-push.sh;
       environment = {
         CACHIX_AUTH_TOKEN_FILE = "${config.sops.secrets.cachix-auth-token.path}";

--- a/hosts/hetzci/auth.nix
+++ b/hosts/hetzci/auth.nix
@@ -59,13 +59,11 @@ in
       keyFile = config.sops.templates.oauth2_proxy_env.path;
     };
 
-    systemd.services.oauth2-proxy.serviceConfig = {
-      # Try re-start at 10 seconds intervals.
-      # If there are more than 3 restart attempts in a 60 second interval,
-      # wait for the 60 second interval to pass before another re-try.
-      RestartSec = 10;
-      StartLimitBurst = 3;
-      StartLimitInterval = 60;
+    systemd.services.oauth2-proxy = {
+      # Try re-start at 10 second intervals
+      serviceConfig.RestartSec = 10;
+      # Allow unlimited restart attempts
+      unitConfig.StartLimitBurst = 0;
     };
 
     services.caddy = {


### PR DESCRIPTION
Fix auth and cachix-push service restart rate limits, which did not work as explained in the earlier comments.

Also, fixes evaluation warnings from auth and cachix-push services, such as:
```
evaluation warning: Service 'oauth2-proxy.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786.
```