### PR TITLE
Fix monitoring of release builders

### DIFF
--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -74,13 +74,10 @@ in
     wantedBy = [ "multi-user.target" ];
     after = [ "network.target" ];
     description = "Run the sshified http-to-ssh proxy";
-    path = [
-      self.packages.${pkgs.system}.sshified
-    ];
     serviceConfig = {
       User = "sshified";
       ExecStart = ''
-        sshified \
+        ${lib.getExe self.packages.${pkgs.system}.sshified} \
         --proxy.listen-addr 127.0.0.1:8888 \
         --ssh.user sshified \
         --ssh.key-file ${config.sops.secrets.sshified_private_key.path} \

--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -14,14 +14,13 @@ let
   domain = "monitoring.vedenemo.dev";
   volumeMount = config.disko.devices.disk.data.content.mountpoint;
 
+  # these hosts will be monitored through ssh tunnel
   # populates known hosts as well as grafana scrape targets
-  sshMonitoredHosts = {
+  hetznerRobotHosts = {
     inherit (machines)
       hetzarm
-      hetzarm-rel-1
       hetz86-1
       hetz86-builder
-      hetz86-rel-1
       ;
   };
 in
@@ -97,7 +96,7 @@ in
   services.openssh.knownHosts = lib.mapAttrs (_: host: {
     hostNames = [ host.ip ];
     inherit (host) publicKey;
-  }) sshMonitoredHosts;
+  }) hetznerRobotHosts;
 
   # monitors also itself
   services.monitoring = {
@@ -379,6 +378,8 @@ in
                 hetzci-dev
                 hetzci-prod
                 hetzci-release
+                hetz86-rel-1
+                hetzarm-rel-1
                 ;
             };
       }
@@ -391,7 +392,7 @@ in
           labels = {
             machine_name = name;
           };
-        }) sshMonitoredHosts;
+        }) hetznerRobotHosts;
       }
       {
         job_name = "office";

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -45,6 +45,7 @@
 
   hetzarm-rel-1 = {
     ip = "46.62.196.166";
+    internal_ip = "10.0.0.12";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/4rUvG9LPsYGuPFIwjJLoip/DOa6NTWUPGQ20fxXFy";
   };
 
@@ -60,6 +61,7 @@
 
   hetz86-rel-1 = {
     ip = "46.62.194.110";
+    internal_ip = "10.0.0.11";
     publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGg4+l1ln0HycoqkN0vbwvU+fZBniozhLq0Z8hGsGfjx";
   };
 

--- a/pkgs/sshified/default.nix
+++ b/pkgs/sshified/default.nix
@@ -21,4 +21,6 @@ buildGoModule rec {
   ];
 
   subPackages = [ "." ];
+
+  meta.mainProgram = pname;
 }


### PR DESCRIPTION
release builders were mistakenly set to be monitored through ssh instead of using hetzner internal network. The `hetzner-cloud.nix` module defaults to sending logs through internal ip. Added a nix evaluation warning to catch this in the future.

Also fixes sshified service as it was not using the binary from path properly.