### PR TITLE
Move zramswap configuration to nix module

### DIFF
--- a/hosts/azure-common.nix
+++ b/hosts/azure-common.nix
@@ -8,7 +8,10 @@ let
   asGB = size: toString (size * 1024 * 1024 * 1024);
 in
 {
-  imports = [ "${modulesPath}/virtualisation/azure-config.nix" ];
+  imports = [
+    ./zramswap.nix
+    "${modulesPath}/virtualisation/azure-config.nix"
+  ];
 
   nix = {
     settings = {
@@ -65,17 +68,4 @@ in
     tree
   ];
 
-  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-    memoryPercent = 100;
-  };
-  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
-  boot.kernel.sysctl = {
-    "vm.swappiness" = 180;
-    "vm.watermark_boost_factor" = 0;
-    "vm.watermark_scale_factor" = 125;
-    "vm.page-cluster" = 0;
-  };
 }

--- a/hosts/builders/hetz86-rel-1/configuration.nix
+++ b/hosts/builders/hetz86-rel-1/configuration.nix
@@ -14,6 +14,7 @@
       ../cross-compilation.nix
       ../cachix-push.nix
       ../../hetzner-cloud.nix
+      ../../zramswap.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
     ]
@@ -42,20 +43,6 @@
   services.monitoring = {
     metrics.enable = true;
     logs.enable = true;
-  };
-
-  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-    memoryPercent = 150;
-  };
-  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
-  boot.kernel.sysctl = {
-    "vm.swappiness" = 180;
-    "vm.watermark_boost_factor" = 0;
-    "vm.watermark_scale_factor" = 125;
-    "vm.page-cluster" = 0;
   };
 
   # Ensure only the nixos.org and ghaf-release cachix cache are trusted

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -14,6 +14,7 @@
       ../builders-common.nix
       ../cachix-push.nix
       ../../hetzner-cloud.nix
+      ../../zramswap.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
     ]
@@ -41,20 +42,6 @@
   services.monitoring = {
     metrics.enable = true;
     logs.enable = true;
-  };
-
-  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-    memoryPercent = 150;
-  };
-  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
-  boot.kernel.sysctl = {
-    "vm.swappiness" = 180;
-    "vm.watermark_boost_factor" = 0;
-    "vm.watermark_scale_factor" = 125;
-    "vm.page-cluster" = 0;
   };
 
   # Nixos-anywhere kexec switch fails on hetzner cloud arm VMs without this

--- a/hosts/hetzci/common.nix
+++ b/hosts/hetzci/common.nix
@@ -10,6 +10,7 @@
 {
   imports =
     [
+      ../zramswap.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
     ]
@@ -26,20 +27,6 @@
     screen
     tmux
   ];
-
-  # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
-  zramSwap = {
-    enable = true;
-    algorithm = "zstd";
-    memoryPercent = 100;
-  };
-  # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
-  boot.kernel.sysctl = {
-    "vm.swappiness" = 180;
-    "vm.watermark_boost_factor" = 0;
-    "vm.watermark_scale_factor" = 125;
-    "vm.page-cluster" = 0;
-  };
 
   # Increase the maximum number of open files user limit, see ulimit -n
   security.pam.loginLimits = [

--- a/hosts/zramswap.nix
+++ b/hosts/zramswap.nix
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  config,
+  ...
+}:
+{
+  config = {
+    # Enable zramSwap: https://search.nixos.org/options?show=zramSwap.enable
+    zramSwap = {
+      enable = true;
+      algorithm = "zstd";
+      # Increasing the zramSwap size up to 150% should be fine.
+      # Ref: https://github.com/NixOS/nixpkgs/issues/103106
+      memoryPercent = lib.mkDefault 150;
+    };
+    # https://wiki.archlinux.org/title/Zram#Optimizing_swap_on_zram:
+    boot.kernel.sysctl = {
+      "vm.swappiness" = 180;
+      "vm.watermark_boost_factor" = 0;
+      "vm.watermark_scale_factor" = 125;
+      "vm.page-cluster" = 0;
+    };
+  };
+}


### PR DESCRIPTION
Move zramSwap configuration to separate module and start using the module on hosts that enable zramSwap.
This also increases the default memoryPercent to 150% which works fine in testing (ref: https://github.com/NixOS/nixpkgs/issues/103106)

