### PR TITLE
Update ci-yubi flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "sbsigntools": "sbsigntools"
       },
       "locked": {
-        "lastModified": 1757523657,
-        "narHash": "sha256-4NB0tIs3cpWiOuuUHY4dZpfpTVD2bu6w1tnokczvCa0=",
+        "lastModified": 1758610559,
+        "narHash": "sha256-+M96U8cIKm0Zz0wsnT+tZv94zITqpGlBoI3/yO0x1os=",
         "owner": "tiiuae",
         "repo": "ci-yubi",
-        "rev": "d05c974b8a73ac4e4bfa4d0311c5aca8dac25ad2",
+        "rev": "0d64b4fa273ef5a05fdf24aa56a31c07649f7388",
         "type": "github"
       },
       "original": {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -18,7 +18,7 @@ def TARGETS = [
     testset: '_relayboot_gui_regression_',
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release",
-    testset: null, uefisign: true
+    testset: null, uefisign: true,
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-release-installer",
     testset: null,
@@ -60,7 +60,7 @@ def TARGETS = [
     testset: null,
   ],
   [ target: "packages.x86_64-linux.system76-darp11-b-debug",
-    testset: '_relayboot_gui_regression_',
+    testset: '_relayboot_gui_regression_', uefisign: true,
   ],
 ]
 


### PR DESCRIPTION
- Update ci-yubi input to include changes from https://github.com/tiiuae/ci-yubi/pull/29
- Copy the recent `prod` nightly pipeline changes to `vm`

Tested in `vm` by running the nightly pipeline and confirming the `uefisign` now works on x1 and darp11 targets. 