### PR TITLE
Trial provenance fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -231,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
         "type": "github"
       },
       "original": {
@@ -410,11 +410,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1757068644,
+        "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
         "type": "github"
       },
       "original": {
@@ -482,15 +482,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1756874151,
-        "narHash": "sha256-NB2CpoJGPYPW8UZb28fEWjxGgOVTaMfTcnZYVJnSj8k=",
+        "lastModified": 1758692892,
+        "narHash": "sha256-0Z7kEE5LjAGA1082wcwt6XYdfDxVWRmkCPjTdTwAgsQ=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "f32270b29e65711276d2d9ae705a80b5f1739a1c",
+        "rev": "7b3ac01558a122300d222e5bd01f4f81d2306d80",
         "type": "github"
       },
       "original": {
         "owner": "tiiuae",
+        "ref": "fix-provenance",
         "repo": "sbomnix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
     };
 
     sbomnix = {
-      url = "github:tiiuae/sbomnix";
+      url = "github:tiiuae/sbomnix/fix-provenance";
       inputs = {
         flake-parts.follows = "flake-parts";
         flake-compat.follows = "flake-compat";

--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -71,7 +71,7 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              provenance .#${it.target} --recursive --out ${it.target}.json
+              provenance ${it.target}/ --recursive --out ${it.target}.json
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -83,7 +83,7 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              provenance .#${it.target} --recursive --out ${it.target}.json
+              provenance ${it.target}/ --recursive --out ${it.target}.json
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """

--- a/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
@@ -71,7 +71,7 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              provenance .#${it.target} --recursive --out ${it.target}.json
+              provenance ${it.target}/ --recursive --out ${it.target}.json
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -83,7 +83,7 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              provenance .#${it.target} --recursive --out ${it.target}.json
+              provenance ${it.target}/ --recursive --out ${it.target}.json
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """


### PR DESCRIPTION
Trial a fix for the provenance generation issue, an example [here](https://ci-prod.vedenemo.dev/job/ghaf-nightly/117/pipeline-overview/?selected-node=593).

This PR includes two fixes:
- Use build out-path (instead of flake reference) as the provenance target. This should ensure the target is not re-evaluated, to make sure the provenance target is the same as the build output.
- Include a fix to provenance tool from the [sbomnix/fix-provenance](https://github.com/tiiuae/sbomnix/compare/main...fix-provenance) branch, which ensures the provenance subject is force-realised making sure the provenance target is always available in local nix store.

The issue is hard to reproduce, which is why I propose we merge and deploy this change, then monitor if we still see the issue. We could conclude the issue is fixed if it doesn't emerge after these changes have been deployed and running in prod for two weeks. If the fix is successful, we would merge the [sbomnix/fix-provenance](https://github.com/tiiuae/sbomnix/compare/main...fix-provenance) branch and move the ghaf-infra sbomnix input back to sbomnix main.