### PR TITLE
Keep more jenkins logs

### DIFF
--- a/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-main.groovy
@@ -52,7 +52,7 @@ pipeline {
     githubPush()
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     // githubPush() trigger requires checkout to be done at least once to

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-manual.groovy
@@ -26,7 +26,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -37,7 +37,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-poweroff.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly-poweroff.groovy
@@ -30,7 +30,7 @@ pipeline {
     cron('0 19 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-nightly.groovy
@@ -70,7 +70,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge-manual.groovy
@@ -48,7 +48,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/ghaf-pre-merge.groovy
@@ -62,7 +62,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/dev/casc/pipelines/modules/utils.groovy
@@ -24,7 +24,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
-  def jenkins_build_dir = "/var/lib/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -42,8 +41,7 @@ def create_pipeline(List<Map> targets) {
         sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
         sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
-        sh "cp -P ${it.target} ${jenkins_build_dir}/"
-        sh "nix-store --add-root ${jenkins_build_dir}/${it.target} -r ${jenkins_build_dir}/${it.target}"
+        sh "nix-store --add-root ${artifacts_local_dir}/${it.target} -r ${artifacts_local_dir}/${it.target}"
       }
       // Provenance
       stage("Provenance ${shortname}") {

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -136,7 +136,7 @@ in
     systemd.timers.jenkins-purge-artifacts = {
       wantedBy = [ "timers.target" ];
       timerConfig = {
-        OnCalendar = "hourly";
+        OnCalendar = "minutely";
       };
     };
 

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-main.groovy
@@ -52,7 +52,7 @@ pipeline {
     githubPush()
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     // githubPush() trigger requires checkout to be done at least once to

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-manual.groovy
@@ -26,7 +26,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -40,7 +40,7 @@ pipeline {
     cron('0 0 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-nightly.groovy
@@ -73,7 +73,7 @@ pipeline {
     cron('0 20 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge-manual.groovy
@@ -48,7 +48,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/ghaf-pre-merge.groovy
@@ -62,7 +62,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -36,7 +36,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
-  def jenkins_build_dir = "/var/lib/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -54,8 +53,7 @@ def create_pipeline(List<Map> targets) {
         sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
         sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
-        sh "cp -P ${it.target} ${jenkins_build_dir}/"
-        sh "nix-store --add-root ${jenkins_build_dir}/${it.target} -r ${jenkins_build_dir}/${it.target}"
+        sh "nix-store --add-root ${artifacts_local_dir}/${it.target} -r ${artifacts_local_dir}/${it.target}"
       }
       // Provenance
       stage("Provenance ${shortname}") {

--- a/hosts/hetzci/purge-jenkins-artifacts.sh
+++ b/hosts/hetzci/purge-jenkins-artifacts.sh
@@ -3,16 +3,29 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-set -eEuo pipefail
+set -e # exit immediately if a command fails
+set -E # exit immediately if a command fails (subshells)
+set -u # treat unset variables as an error and exit
 
-# Find anything exactly two paths deep from the artifacts directory, i.e.:
-# /var/lib/jenkins/artifacts/*/*/. If the matching path directly contains
-# only broken symlinks or directories, the path is removed.
+# Expected arguments and their defaults if not passed in environment variables
+# Always keep at least this many build artifacts for each pipeline
+PURGE_KEEP_BUILDS="${PURGE_KEEP_BUILDS:=3}"
+# Skip purge if nix store disk usage is less than PURGE_DU_PCT percent
+PURGE_DU_PCT="${PURGE_DU_PCT:=90}"
+
+nix_store_du_pct=$( (df /nix/store --output=pcent || df /nix --output=pcent || df / --output=pcent) | tr -dc '0-9' )
+echo "nix store disk usage: $nix_store_du_pct%"
+if (( nix_store_du_pct < PURGE_DU_PCT )); then
+  exit 0
+fi
+
+echo "Purge artifacts; removing all but the last $PURGE_KEEP_BUILDS builds on each pipeline"
+# Outer loop finds the directories directly under /var/lib/jenkins/artifacts/,
+# that is, the per-pipeline artifacts directories.
+# Inner loop removes all but the latest PURGE_KEEP_BUILDS builds on each pipeline
 while IFS= read -r path; do
-    if find "$path" -maxdepth 1 -mindepth 1 -not -xtype l -not -type d | read -r;
-    then
-        continue
-    fi
-    echo "Removing: '$path'"
-    rm -fr "$path"
-done < <(find /var/lib/jenkins/artifacts -maxdepth 2 -mindepth 2)
+  find "$path" -maxdepth 0 -exec ls -rt {} + | head -n -"$PURGE_KEEP_BUILDS" | while read -r x; do
+    echo "Removing '$path/$x'"
+    rm -fr "${path:?}/${x:?}"
+  done
+done < <(find /var/lib/jenkins/artifacts -maxdepth 1 -mindepth 1 -type d)

--- a/hosts/hetzci/release/casc/pipelines/ghaf-release.groovy
+++ b/hosts/hetzci/release/casc/pipelines/ghaf-release.groovy
@@ -51,7 +51,7 @@ pipeline {
     githubPush()
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/release/casc/pipelines/modules/utils.groovy
@@ -24,7 +24,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
-  def jenkins_build_dir = "/var/lib/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -42,8 +41,7 @@ def create_pipeline(List<Map> targets) {
         sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
         sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
-        sh "cp -P ${it.target} ${jenkins_build_dir}/"
-        sh "nix-store --add-root ${jenkins_build_dir}/${it.target} -r ${jenkins_build_dir}/${it.target}"
+        sh "nix-store --add-root ${artifacts_local_dir}/${it.target} -r ${artifacts_local_dir}/${it.target}"
       }
       // Provenance
       stage("Provenance ${shortname}") {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-main.groovy
@@ -52,7 +52,7 @@ pipeline {
     githubPush()
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     // githubPush() trigger requires checkout to be done at least once to

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-manual.groovy
@@ -26,7 +26,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-perftest.groovy
@@ -40,7 +40,7 @@ pipeline {
     cron('0 0 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-poweroff.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly-poweroff.groovy
@@ -30,7 +30,7 @@ pipeline {
     cron('0 19 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-nightly.groovy
@@ -73,7 +73,7 @@ pipeline {
     cron('0 20 * * *')
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge-manual.groovy
@@ -48,7 +48,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '3'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-pre-merge.groovy
@@ -62,7 +62,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5'))
+    buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/ghaf-release.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/ghaf-release.groovy
@@ -51,7 +51,7 @@ pipeline {
     githubPush()
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5'))
+    buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -36,7 +36,6 @@ def create_pipeline(List<Map> targets) {
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
-  def jenkins_build_dir = "/var/lib/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
@@ -54,8 +53,7 @@ def create_pipeline(List<Map> targets) {
         sh "nix build --fallback -v .#${it.target} --out-link ${it.target}"
         build_end = run_cmd('date +%s')
         sh "mkdir -v -p ${artifacts_local_dir} && cp -P ${it.target} ${artifacts_local_dir}/"
-        sh "cp -P ${it.target} ${jenkins_build_dir}/"
-        sh "nix-store --add-root ${jenkins_build_dir}/${it.target} -r ${jenkins_build_dir}/${it.target}"
+        sh "nix-store --add-root ${artifacts_local_dir}/${it.target} -r ${artifacts_local_dir}/${it.target}"
       }
       // Provenance
       stage("Provenance ${shortname}") {


### PR DESCRIPTION
- Revert the [change](https://github.com/tiiuae/ghaf-infra/commit/4a37d6c796988173b9c2d89ab9a7afc4b98c907e) that reduced the number of builds as outlined in [PR#635](https://github.com/tiiuae/ghaf-infra/pull/635)
- Change `purge-jenkins-artifacts.sh`:
  - Make it run once a minute
  - Do nothing if nix store disk is less than 90% full
  - Otherwise, remove old artifacts keeping only the artifacts from latest 3 builds on each pipeline to free-up disk space for nix GC.

Tested locally in a `vm` environment. Also, deployed to [`dev`](https://ci-dev.vedenemo.dev/).