### PR TITLE
Increase retry timeout on provenance failure

### DIFF
--- a/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/prod/casc/pipelines/modules/utils.groovy
@@ -84,15 +84,16 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              for i in {1..3}; do
-                if provenance ${it.target}/ --recursive --out ${it.target}.json; then
-                  echo "provenance attempt=\$i passed"
-                  break
-                else
-                  echo "provenance attempt=\$i failed"
-                  sleep 5
+              attempt=1; max_attempts=3;
+              while ! provenance ${it.target}/ --recursive --out ${it.target}.json; do
+                echo "provenance attempt=\$attempt failed"
+                if (( \$attempt >= \$max_attempts )); then
+                  exit 1
                 fi
+                attempt=\$(( \$attempt + 1 ))
+                sleep 30
               done
+              echo "provenance attempt=\$attempt passed"
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """

--- a/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/vm/casc/pipelines/modules/utils.groovy
@@ -84,15 +84,16 @@ def create_pipeline(List<Map> targets) {
         ]) {
           catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
             sh """
-              for i in {1..3}; do
-                if provenance ${it.target}/ --recursive --out ${it.target}.json; then
-                  echo "provenance attempt=\$i passed"
-                  break
-                else
-                  echo "provenance attempt=\$i failed"
-                  sleep 5
+              attempt=1; max_attempts=3;
+              while ! provenance ${it.target}/ --recursive --out ${it.target}.json; do
+                echo "provenance attempt=\$attempt failed"
+                if (( \$attempt >= \$max_attempts )); then
+                  exit 1
                 fi
+                attempt=\$(( \$attempt + 1 ))
+                sleep 30
               done
+              echo "provenance attempt=\$attempt passed"
               mkdir -v -p ${artifacts_local_dir}/scs/${it.target}
               cp ${it.target}.json ${artifacts_local_dir}/scs/${it.target}/provenance.json
             """


### PR DESCRIPTION
Builds over the weekend indicate that https://github.com/tiiuae/ghaf-infra/pull/645 helps with provenance failures (see: [ghaf-pre-merge/493](https://ci-prod.vedenemo.dev/job/ghaf-pre-merge/493/consoleText)), although it still fails occasionally (see: [ghaf-pre-merge/495](https://ci-prod.vedenemo.dev/job/ghaf-pre-merge/495/consoleText)). I'd like to see if increasing the retry timeout helps in the cases where it still fails.

Also, the change in this PR avoids sleeping after successfully running the provenance command.

Tested in dev: https://ci-dev.vedenemo.dev/job/ghaf-manual/115/