### PR TITLE
Add SoftHSM capabilities to nethsm-gateway

### DIFF
--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -342,7 +342,7 @@ in
   # Workaround for prometheus to store data outside of /var/lib
   # https://discourse.nixos.org/t/custom-prometheus-data-directory/50741/5
   systemd.tmpfiles.rules = [
-    "D ${volumeMount}/prometheus 0751 prometheus prometheus - -"
+    "d ${volumeMount}/prometheus 0751 prometheus prometheus - -"
     "L+ /var/lib/${config.services.prometheus.stateDir}/data - - - - ${volumeMount}/prometheus"
   ];
 

--- a/hosts/nethsm-gateway/README.md
+++ b/hosts/nethsm-gateway/README.md
@@ -1,0 +1,125 @@
+<!--
+SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Nethsm Gateway
+
+## Softhsm usage
+
+Manual steps of how the softhsm is used. This can be automated with scripts in
+the future.
+
+### Creating softhsm signing keys
+
+> Prerequisite of key creation is that you are in the `softhsm` group.
+
+First define the pins as variables:
+
+```sh
+export PIN=1234
+export SO_PIN=123456
+export TOKEN=testkey
+```
+
+Init new softhsm token slot:
+
+```sh
+softhsm2-util --init-token --free --label $TOKEN --so-pin $SO_PIN --pin $PIN
+
+# or populate the SLOT automatically
+export SLOT=$(
+    softhsm2-util --init-token --free --label $TOKEN \
+    --so-pin $SO_PIN --pin $PIN | grep "to slot " | awk '{print $NF}'
+) && echo $SLOT
+```
+
+It will print the slot number to use in following commands. Save this to a
+variable as well:
+
+```sh
+export SLOT=391264627 # replace with the randomly assigned slot you got back
+```
+
+```sh
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --keypairgen --key-type rsa:4096 --label "PK-key" --id 01
+
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --keypairgen --key-type rsa:4096 --label "KEK-key" --id 02
+
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --keypairgen --key-type rsa:4096 --label "DB-key" --id 03
+```
+
+Verify keys are there. You should see 3 public keys and 3 private keys.
+
+```sh
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT --list-objects
+```
+
+### Creating certificates
+
+> `$KEYDIR` is defined in the system configuration.
+
+Now you can use the created private keys to generate x509 certificates:
+
+```sh
+# PK
+openssl req -new -x509 -sha256 -days 365 \
+        -key "pkcs11:token=$TOKEN;object=PK-key;type=private;pin-value=$PIN" \
+        -config $OPENSSL_EXTRA_CONF/create_PK_cert.ini \
+        -out $KEYDIR/pk.crt
+# KEK
+openssl req -new -x509 -sha256 -days 365 \
+        -key "pkcs11:token=$TOKEN;object=KEK-key;type=private;pin-value=$PIN" \
+        -config $OPENSSL_EXTRA_CONF/create_KEK_cert.ini \
+        -out $KEYDIR/kek.crt
+# DB
+openssl req -new -x509 -sha256 -days 365 \
+        -key "pkcs11:token=$TOKEN;object=DB-key;type=private;pin-value=$PIN" \
+        -config $OPENSSL_EXTRA_CONF/create_DB_cert.ini \
+        -out $KEYDIR/db.crt
+```
+
+You can import these certificates into the softhsm:
+
+```sh
+pkcs11-tool --module $SOFTHSM2_MODULE -p 1234 --slot $SLOT \
+            --write-object $KEYDIR/pk.crt --type cert --label PK-cert
+
+pkcs11-tool --module $SOFTHSM2_MODULE -p 1234 --slot $SLOT \
+            --write-object $KEYDIR/kek.crt --type cert --label KEK-cert
+
+pkcs11-tool --module $SOFTHSM2_MODULE -p 1234 --slot $SLOT \
+            --write-object $KEYDIR/db.crt --type cert --label DB-cert
+```
+
+### Exporting public keys
+
+The public keys can be exported for enrollment to UEFI if needed.
+
+```sh
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --read-object --type pubkey --label PK-key -o $KEYDIR/pk.der
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --read-object --type pubkey --label KEK-key -o $KEYDIR/kek.der
+pkcs11-tool --module $SOFTHSM2_MODULE -p $PIN --slot $SLOT \
+            --read-object --type pubkey --label DB-key -o $KEYDIR/db.der
+```
+
+### Signing EFI file using sbsign
+
+Sign your EFI bootloader using private key and certificate stored on the
+softhsm. `systemd-sbsign` can use the openssl pkcs11 provider to pull those
+objects.
+
+```sh
+systemd-sbsign sign \
+    --private-key-source provider:pkcs11 \
+    --private-key "pkcs11:token=$TOKEN;object=DB-key;type=private;pin-value=$PIN" \
+    --certificate-source provider:pkcs11 \
+    --certificate "pkcs11:token=$TOKEN;object=DB-cert;type=cert;pin-value=$PIN" \
+    --output SIGNED_BOOT.EFI \
+    YOUR_BOOT.EFI
+```

--- a/hosts/nethsm-gateway/configuration.nix
+++ b/hosts/nethsm-gateway/configuration.nix
@@ -18,6 +18,7 @@ in
       ./disk-config.nix
       inputs.sops-nix.nixosModules.sops
       inputs.disko.nixosModules.disko
+      ./softhsm.nix
     ]
     ++ (with self.nixosModules; [
       common
@@ -36,8 +37,6 @@ in
       nethsm-credentials.owner = "root";
     };
   };
-
-  environment.systemPackages = with pkgs; [ pynitrokey ];
 
   nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "nethsm-gateway";

--- a/hosts/nethsm-gateway/softhsm.nix
+++ b/hosts/nethsm-gateway/softhsm.nix
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  pkgs,
+  inputs,
+  lib,
+  ...
+}:
+let
+  stateDir = "/var/lib/softhsm";
+  keyDir = stateDir + "/keys";
+  tokenDir = stateDir + "/tokens";
+  softhsmModule = "${softhsm2}/lib/softhsm/libsofthsm2.so";
+
+  # patch in the 1.1 update.
+  # can be removed when we update from 25.05
+  # https://github.com/NixOS/nixpkgs/pull/444707
+  pkcs11-provider = pkgs.pkcs11-provider.overrideAttrs rec {
+    version = "1.1";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "latchset";
+      repo = "pkcs11-provider";
+      tag = "v${version}";
+      fetchSubmodules = true;
+      hash = "sha256-QXEwDl6pk8G5ba8lD4uYw2QuD3qS/sgd1od8crHct2s=";
+    };
+  };
+
+  # nixpkgs provides 2.6.1, which is from 2020.
+  # softhsm2 has not had a new release or tag in over 5 years.
+  # Using the latest from git is better than using an outdated release.
+  softhsm2 = pkgs.stdenv.mkDerivation {
+    pname = "softhsm2";
+    version = "develop";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "softhsm";
+      repo = "SoftHSMv2";
+      # head of develop branch
+      rev = "25b94d4752739fc5954e7eb3a404810db5d632fa";
+      sha256 = "sha256-yjcS8Jm7XAEqa1DrE0FcbccvubcRl+UlUeNp56NUVi8=";
+    };
+
+    nativeBuildInputs = with pkgs; [
+      autoreconfHook
+      openssl
+      sqlite
+    ];
+
+    # use openssl backend instead of botan
+    # https://github.com/openssl/openssl/issues/22508#issuecomment-2646121200
+    configureFlags = [
+      "--with-crypto-backend=openssl"
+      "--with-openssl=${lib.getDev pkgs.openssl}"
+      "--with-objectstore-backend-db"
+      "--sysconfdir=$out/etc"
+      "--localstatedir=$out/var"
+    ];
+
+    postInstall = "rm -rf $out/var";
+  };
+
+  # systemd-sbsign is in the package but not exposed in PATH
+  # https://github.com/NixOS/nixpkgs/issues/447999
+  # Create a wrapper derivation that just adds it to $out/bin
+  systemd-sbsign = pkgs.stdenv.mkDerivation {
+    name = "systemd-sbsign";
+    # noop unpackPhase as there is no $src
+    unpackPhase = "true";
+    buildInputs = [ pkgs.systemd ];
+    installPhase = ''
+      mkdir -p $out/bin
+      ln -s ${pkgs.systemd}/lib/systemd/systemd-sbsign $out/bin/systemd-sbsign
+    '';
+  };
+in
+{
+  environment.systemPackages =
+    (with pkgs; [
+      openssl
+      pynitrokey # nitropy
+      opensc # pkcs11-tool
+    ])
+    ++ [
+      systemd-sbsign
+      softhsm2
+    ];
+
+  users.groups.softhsm = { };
+
+  systemd.tmpfiles.rules = [
+    "d ${tokenDir} 0770 root softhsm - -"
+    "d ${keyDir} 0770 root softhsm - -"
+  ];
+
+  environment.variables = {
+    KEYDIR = keyDir;
+    SOFTHSM2_MODULE = softhsmModule;
+
+    SOFTHSM2_CONF = toString (
+      pkgs.writeText "softhsm2.conf" ''
+        directories.tokendir = ${tokenDir}
+        objectstore.backend = file
+        log.level = INFO
+        slots.removable = false
+        slots.mechanisms = ALL
+        library.reset_on_fork = false
+      ''
+    );
+
+    # Using a modern OpenSSL 3 provider for pkcs11 instead of legacy engine
+    # https://github.com/latchset/pkcs11-provider/blob/main/HOWTO.md
+    OPENSSL_CONF = toString (
+      pkgs.writeText "openssl.cnf" # ini
+        ''
+          openssl_conf = openssl_init
+
+          [openssl_init]
+          providers = provider_sect
+
+          [provider_sect]
+          pkcs11 = pkcs11_sect
+
+          [pkcs11_sect]
+          activate = 1
+          module = "${pkcs11-provider}/lib/ossl-modules/pkcs11.so"
+          pkcs11-module-path = ${softhsmModule}
+          # quirks for softhsm2 to avoid segfault
+          # see https://github.com/latchset/pkcs11-provider/blob/663dea335c80bec7fd96d544ff875af08d6461a9/tests/softhsm-init.sh#L64
+          # and https://github.com/openssl/openssl/issues/22508#issuecomment-1780033252
+          pkcs11-module-quirks = no-deinit no-operation-state
+        ''
+    );
+
+    # Extra cert creation config can be loaded from ci-yubi repo
+    OPENSSL_EXTRA_CONF = "${inputs.ci-yubi}/secboot/conf";
+  };
+}

--- a/users/alextserepov.nix
+++ b/users/alextserepov.nix
@@ -11,6 +11,7 @@
       extraGroups = [
         "wheel"
         "networkmanager"
+        "softhsm"
       ];
     };
   };

--- a/users/cazfi.nix
+++ b/users/cazfi.nix
@@ -12,6 +12,7 @@
         "wheel"
         "networkmanager"
         "docker"
+        "softhsm"
       ];
     };
   };

--- a/users/hrosten.nix
+++ b/users/hrosten.nix
@@ -11,6 +11,7 @@
       extraGroups = [
         "wheel"
         "networkmanager"
+        "softhsm"
       ];
     };
   };

--- a/users/jrautiola.nix
+++ b/users/jrautiola.nix
@@ -13,6 +13,7 @@
       extraGroups = [
         "wheel"
         "networkmanager"
+        "softhsm"
       ];
     };
   };


### PR DESCRIPTION
Added softhsm to nethsm-gateway and instructions how to use it. We can interact with the softhsm by using a softhsm module with pkcs11, and openssl can interact with pkcs11 using pkcs11-provider. This is a new openssl 3.X provider.

I was able to remove the usage of legacy openssl features throughout the whole signing process by using `systemd-sbsign` instead of the old `sbsign` from sbsigntools. `systemd-sbsign` can use openssl 3.X providers to access key objects straight from the softhsm.