### PR TITLE
Publish jenkins artifacts into OCI registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ result-*
 .pre-commit-config.yaml
 /*.qcow2
 ca.key
+**/__pycache__/*

--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -39,13 +39,24 @@ let
       };
       accessControl = {
         repositories = {
-          "**" = {
-            defaultPolicy = [
-              "read"
-              "create"
-              "update"
-              "delete"
+          "ghaf/**" = {
+            policies = [
+              {
+                users = [ "jenkins" ];
+                actions = [
+                  "read"
+                  "create"
+                  "update"
+                  "delete"
+                ];
+              }
             ];
+            defaultPolicy = [ "read" ];
+            anonymousPolicy = [ "read" ];
+          };
+          "**" = {
+            defaultPolicy = [ "read" ];
+            anonymousPolicy = [ "read" ];
           };
         };
       };

--- a/hosts/hetzci/casc/registryPublish.yaml
+++ b/hosts/hetzci/casc/registryPublish.yaml
@@ -1,0 +1,9 @@
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - string:
+              scope: GLOBAL
+              id: "oci_registry_password"
+              secret: "${file:/run/secrets/oci_registry_password}"
+              description: "OCI registry writer password"

--- a/hosts/hetzci/dev/configuration.nix
+++ b/hosts/hetzci/dev/configuration.nix
@@ -37,6 +37,7 @@ in
         "ghaf-pre-merge-manual"
         "ghaf-pre-merge"
       ];
+      withRegistryPublish = true;
     };
     auth = {
       clientID = "hetzci-dev";

--- a/hosts/hetzci/dev/secrets.yaml
+++ b/hosts/hetzci/dev/secrets.yaml
@@ -10,6 +10,7 @@ nebula-cert: ENC[AES256_GCM,data:VZksUfhPFqIkOB/3yBFwUI5mJusJVaJ1wW7Me4/2WmXyXZe
 nebula-key: ENC[AES256_GCM,data:LgC6h8oHtEXyr35vGLJDdKmPbusLiTnZa0uuL/zTaUg3py6g/yyGjTDeMbJF7QA4cbGJ7P17k6zIADHNvikvYcWrE7NK7cJ9Pkl0LOGpgAOrQ5+Mn8NNRrKM6+rHsqVZHxUhHPmBrh4+zmm9aha/S+Je0OLWigczh3vH4m3tpg==,iv:+w1Nal8bolAdLoy8YIj3PPD7zlZZJlPWnudjkQVsboU=,tag:+IHeaoq6rtbYYnmJAuxy5Q==,type:str]
 tls-pks-file: ENC[AES256_GCM,data:DwNSgXN2DbnhgssvcMXw9fHnvsxDhvBl5kziwzkKoxcFQLXvRnhcxqvTvbBILCdyXN4heCGi+jfTkJiVdc2oJ2KoVV6uPBbpGY4hTg==,iv:rWivHAh0PDUZflxv8egP+GkZGxRpdL4XGy5Aevn0Dvw=,tag:HW2865uTycwOUzJWZyZk8A==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:W6pshKT+V/1TOmnT,iv:sz5T/8WAzhA445X77oHi/mBhVTF0ddOW09pqGxgyrLI=,tag:k5goNR7XfDXPipVQP03NEA==,type:str]
+oci_registry_password: ENC[AES256_GCM,data:e48R8j3Gi/Q7H2MsuHoL,iv:6jK1vlT3mvy1LlbtVSABsk/CI8xmfGQAaSYhut2bNcc=,tag:EYwkQs+OZvv7tXxCQxC5Gg==,type:str]
 sops:
     age:
         - recipient: age10xhyyjrhackyac2f042t3z8yqld3sh39ul3mukwkt6gyr7gn9upq8n30gm
@@ -39,7 +40,7 @@ sops:
             TDRuK3Vhb1lMZ2owdjJLUjRGS0VMa3cKF+7Q7xRFyYd6U8apfqlpWEiJ7xsF//xJ
             zpc1bxl7gLKs9EH3kdv8ATYZzGXC/UCd9ccpmy9TYDogTcIqOGZYtQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-16T10:22:23Z"
-    mac: ENC[AES256_GCM,data:zov08p+hrHTsHHVl5WSxgL2apT5Yd5z5fSzNOY7wSm6vQE3WZFgAYDqvIz55IseCNlCHFojgv7QyiMlxH+eeF8MTuYIz8J8cH3aiV+K+08AiAf7Kvei5d6ERPrQgUmlGt8dWis25Jru9ks8Z3BJh04nevpdclNtkJG1HIQ8ueZk=,iv:JReVAdq0n3kowPawjp++SSHJMWip6Y/h1Fwc+kN0nTM=,tag:4YugcIGWVyICtK8LzIiyZg==,type:str]
+    lastmodified: "2026-03-28T16:15:27Z"
+    mac: ENC[AES256_GCM,data:j74ORqD2yZvzW2UXQ9c6SL/vIO3HeN/xz5uROuZE+wiSmwIm+qyYvPy+BLfdznMghPE/Xhn4BYWTMScCFHRGPncAuvUFNqwyQsGcTx/v847aTDNNTIRqDP9chBfIhRN2jvngCT32ftL0k+tcB7NUkVEO1WfYu9SY5unaz3RqfYw=,iv:2hGne3KF5PPO1nUcfhnVIt6nSD3u4FzI7fam8ixGRD4=,tag:wdyWMFAv34ZJWw2ozjxiZA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -123,6 +123,11 @@ in
       description = "Add capability to archive artifacts to permanent storage";
       default = false;
     };
+    withRegistryPublish = lib.mkOption {
+      type = lib.types.bool;
+      description = "Add capability to publish build artifacts to the OCI registry";
+      default = false;
+    };
   };
   config = {
     sops = {
@@ -139,6 +144,9 @@ in
         (lib.mkIf cfg.withArchiveArtifacts {
           jenkins_archive_access_key.owner = "jenkins";
           jenkins_archive_secret_key.owner = "jenkins";
+        })
+        (lib.mkIf cfg.withRegistryPublish {
+          oci_registry_password.owner = "jenkins";
         })
       ];
     };
@@ -174,6 +182,10 @@ in
         ++ lib.optionals cfg.withArchiveArtifacts [
           pkgs.tree
           self.packages.${pkgs.stdenv.hostPlatform.system}.archive-ghaf-release
+        ]
+        ++ lib.optionals cfg.withRegistryPublish [
+          pkgs.oras
+          self.packages.${pkgs.stdenv.hostPlatform.system}.oci-publish
         ];
 
       environment = {
@@ -246,6 +258,9 @@ in
       })
       (lib.mkIf cfg.withArchiveArtifacts {
         "jenkins/casc/archiveArtifacts.yaml".source = ./casc/archiveArtifacts.yaml;
+      })
+      (lib.mkIf cfg.withRegistryPublish {
+        "jenkins/casc/registryPublish.yaml".source = ./casc/registryPublish.yaml;
       })
     ];
 

--- a/hosts/hetzci/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/pipelines/modules/utils.groovy
@@ -14,6 +14,14 @@ def path_basename(String path) {
   return idx >= 0 ? path.substring(idx + 1) : path
 }
 
+def image_role(String path) {
+  def basename = path_basename(path)
+  if (basename == null) {
+    return null
+  }
+  return basename.endsWith(".iso") ? "installer" : "disk"
+}
+
 def append_to_build_description(String text) {
   lock('build-description') {
     if(!currentBuild.description) {
@@ -48,6 +56,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
   def artifacts = "artifacts/${env.JOB_BASE_NAME}/${stamp}-commit_${target_commit}"
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
+  def immutable_tag = "${env.CI_ENV}-${stamp}-${target_commit}"
   def signingToken = "YubiHSM"
   def signing_possible = env.CI_ENV != 'vm'
 
@@ -62,42 +71,51 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
     def output = "${artifacts_local_dir}/${it.target}"
 
     def manifest = [
+      ci_env: env.CI_ENV,
+      job: [
+        name: env.JOB_NAME,
+        build_id: env.BUILD_ID,
+        build_url: env.BUILD_URL,
+      ],
+      source: [
+        repository: target_repo,
+        ref: target_commit,
+        revision: target_commit,
+      ],
       target: it.target,
       build: [
         ts_begin: null,
         ts_finished: null,
       ],
-      image: null,
+      image: [
+        path: null,
+        role: null,
+        signature: [
+          path: null,
+          signing_key: null,
+        ],
+      ],
       uefi: [
         signed: false,
         reason: null,
         signing_key: null,
       ],
       attestations: [
-        sbom: [
-          csv: null,
-          cdx: null,
-          spdx: null,
-        ],
         provenance: [
-          nix_build: null,
-          secureboot: null,
-        ],
-      ],
-      signatures: [
-        image: [
           path: null,
-          signing_key: null,
+          signature: [
+            path: null,
+            signing_key: null,
+          ],
         ],
-        provenance: [
-          nix_build: [
-            path: null,
-            signing_key: null,
-          ],
-          secureboot: [
-            path: null,
-            signing_key: null,
-          ],
+        sbom_csv: [
+          path: null,
+        ],
+        sbom_cyclonedx: [
+          path: null,
+        ],
+        sbom_spdx: [
+          path: null,
         ],
       ],
     ]
@@ -159,7 +177,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
               done
               echo "provenance attempt=\$attempt passed"
             """
-            manifest.attestations.provenance.nix_build = "attestations/provenance.json"
+            manifest.attestations.provenance.path = "attestations/provenance.json"
           }
         }
       }
@@ -187,9 +205,9 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
               --cdx ${outdir}/sbom.cdx.json \
               --spdx ${outdir}/sbom.spdx.json
           """
-          manifest.attestations.sbom.csv = "attestations/sbom.csv"
-          manifest.attestations.sbom.cdx = "attestations/sbom.cdx.json"
-          manifest.attestations.sbom.spdx = "attestations/sbom.spdx.json"
+          manifest.attestations.sbom_csv.path = "attestations/sbom.csv"
+          manifest.attestations.sbom_cyclonedx.path = "attestations/sbom.cdx.json"
+          manifest.attestations.sbom_spdx.path = "attestations/sbom.spdx.json"
         }
       }
       // Signing stages
@@ -204,8 +222,8 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
                 -in ${output}/attestations/provenance.json
             """
           }
-          manifest.signatures.provenance.nix_build.path = "attestations/provenance.json.sig"
-          manifest.signatures.provenance.nix_build.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignProv"
+          manifest.attestations.provenance.signature.path = "attestations/provenance.json.sig"
+          manifest.attestations.provenance.signature.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignProv"
         }
       }
       if (!it.no_image) {
@@ -214,13 +232,14 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           if (!img_path) {
             error("No image found!")
           }
-          manifest.image = img_path - "${output}/"
+          manifest.image.path = img_path - "${output}/"
+          manifest.image.role = image_role(manifest.image.path)
         }
         if (signing_possible) {
           if (it.get('uefisign', false) || it.get('uefisigniso', false)) {
             stage("Sign (UEFI) ${shortname}") {
               def tmpdir = run_cmd("mktemp -d")
-              def img_name = path_basename(manifest.image)
+              def img_name = path_basename(manifest.image.path)
 
               def signer = "uefisign"
               if (it.target.contains("nvidia-jetson-orin")) {
@@ -231,14 +250,14 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
                 sh """
                   ${signer} /etc/jenkins/keys/secboot/DB.pem \
                     'pkcs11:token=${signingToken};object=uefi-ghaf-db' \
-                    ${output}/${manifest.image} \
+                    ${output}/${manifest.image.path} \
                     ${tmpdir}
                 """
               }
 
               sh "mv ${tmpdir}/signed_${img_name} ${output}/${img_name}"
               // replace original image with uefisigned one
-              manifest.image = img_name
+              manifest.image.path = img_name
               manifest.uefi.signed = true;
               manifest.uefi.reason = null
               manifest.uefi.signing_key = "pkcs11:token=${signingToken};object=uefi-ghaf-db"
@@ -246,27 +265,27 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           }
           stage("Sign (SLSA) image ${shortname}") {
             lock('signing') {
-              def img_name = path_basename(manifest.image)
+              def img_name = path_basename(manifest.image.path)
               // sign the current main image be it unsigned or uefisigned
               sh """
                 openssl dgst -sha256 -sign \
                   'pkcs11:token=${signingToken};object=GhafInfraSignECP256' \
                   -out ${output}/${img_name}.sig \
-                  ${output}/${manifest.image}
+                  ${output}/${manifest.image.path}
               """
             }
-            manifest.signatures.image.path = "${path_basename(manifest.image)}.sig"
-            manifest.signatures.image.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignECP256"
+            manifest.image.signature.path = "${path_basename(manifest.image.path)}.sig"
+            manifest.image.signature.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignECP256"
           }
         }
       }
       // Link artifacts
       stage("Link artifacts ${shortname}") {
-        if (manifest.image && !manifest.uefi.signed) {
-          def img_name = path_basename(manifest.image)
+        if (manifest.image.path && !manifest.uefi.signed) {
+          def img_name = path_basename(manifest.image.path)
           // make symlink from output root to original image if not using uefisigned
-          sh "ln -s ${output}/${manifest.image} ${output}/${img_name}"
-          manifest.image = img_name
+          sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
+          manifest.image.path = img_name
         }
 
         writeFile(
@@ -278,10 +297,34 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           append_to_build_description(artifacts_href)
         }
       }
+      if (!it.no_image) {
+        stage("Publish OCI ${shortname}") {
+          if (sh(
+            script: 'command -v oci-publish >/dev/null 2>&1',
+            returnStatus: true
+          ) != 0) {
+            println("Skipping OCI publish ${shortname}: oci-publish is not installed")
+          } else {
+            withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
+              def job_name = env.JOB_BASE_NAME.replaceFirst('^ghaf-', '')
+              def target_name = it.target.replaceFirst('^packages\\.', '')
+              def oci_repository = "ghaf/${job_name}/${target_name}"
+              def oci_result_json = "${output}/oci-result.json"
+              sh """
+                oci-publish target \
+                  -d '${output}' \
+                  -r '${oci_repository}' \
+                  -t '${immutable_tag}' \
+                  -o '${oci_result_json}'
+              """
+            }
+          }
+        }
+      }
       // Test
       if (it.testset != null && !it.testset.isEmpty()) {
         stage("Test ${shortname}") {
-          def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image}"
+          def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image.path}"
           def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
           def test_params = [
               string(name: "IMG_URL", value: img_url),
@@ -316,7 +359,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         // regular test run cannot be replaced with a secure boot-only run.
         if (it.test_secboot && manifest.uefi.signed && env.CI_ENV == "prod") {
           stage("Test SB ${shortname}") {
-            def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image}"
+            def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image.path}"
             def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
             def test_params = [
               string(name: "IMG_URL", value: img_url),

--- a/hosts/hetzci/prod/configuration.nix
+++ b/hosts/hetzci/prod/configuration.nix
@@ -37,6 +37,7 @@ in
         "ghaf-pre-merge"
       ];
       withCachix = false;
+      withRegistryPublish = true;
     };
     auth = {
       clientID = "hetzci-prod";

--- a/hosts/hetzci/prod/secrets.yaml
+++ b/hosts/hetzci/prod/secrets.yaml
@@ -9,6 +9,7 @@ nebula-cert: ENC[AES256_GCM,data:zjrXlQMTJMIrrFuLkic8iTp3+X46D5DBGU7Wxr7OegFNZB/
 nebula-key: ENC[AES256_GCM,data:0IicUXHJarz+Kzfyg+sW7NwoPwchZNkX1twKW5FOtbAG0bqaGzshD8bEfqLP++7FDJKXs+Rt48fKejHe9t7/+MdZlV1CNit0izeisV4ncu7qG+TNJb7XtcM51Ug2bVq3FFMZHcO34s76lvdNEwjyPkgXF8qBIEpujqCMPsSfpw==,iv:8P48LDGkso2F5iwRXB+Y+/CoaOu4L9VpD0N7r5KnSjE=,tag:ahB9NUY8jw+w/2z4w5nUtg==,type:str]
 tls-pks-file: ENC[AES256_GCM,data:a2CstI1wydpMmKWEkBymo47l+nKsN6WDhYK2RnzGJa19pvq4yC82+9Ef6PJaalNMXmKamUS1yiPQNbSpcXnHgQOKUMYgK0nuZ/uqq/s=,iv:WqItzw+PeiHdHlHCo9swC3RzPni3TH9Q2hbDl9VLxXg=,tag:8LL0PdI/aI1poEw1SbfLBw==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:Op7oKIA2vLGJrGaM,iv:LXjIft1qjRTAGnomNIEfWjIh3GV1pVwEFxeNO/vSQlQ=,tag:XD1ZGg4/4BetQnUVvSGRlw==,type:str]
+oci_registry_password: ENC[AES256_GCM,data:rgzU+R5lyVPxtey9d2kC,iv:pxxT7/rb4mWDx8Tp/lu2p0l3k0whD39GMSYK0Pr8ASQ=,tag:N+peFNfDUsaLKWcWgr7WPQ==,type:str]
 sops:
     age:
         - recipient: age1av993eefvndhv2apa4x7tpc7ezyhuj3jz9866vtulnrdwmjqe5hqrjc2z8
@@ -38,7 +39,7 @@ sops:
             MVd4MzZZcjlPTGptL0cyZnY2NldWRFkKgGSHqIHOfYPGxfBTwp97qqCWNTc489Jb
             jpA6QIU1VSNsg//J3BqQvNDMZbUrq+EK6RFDYyVDguv/sYSZqkeEOg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-16T11:21:05Z"
-    mac: ENC[AES256_GCM,data:Qc6NGV4cPyX2AxQ3PWUZYUBTGx3ga82uJA3dC1ThuZZFqouTVWF8b3rMB7cbMs2XBfnq616gm0Ag0NbvznHwGzX5cIQKxpoqSbb4vDpUFLQ8IDhHhaIXYiZT/xuK32YTJmBLUTjS9z0PLHZK6jqP+qarHvrTusRSE8tZgnTkU5M=,iv:mfq9g93sILve0MsTHRaEWu2RGWs4bmHTD3hjGqs1niI=,tag:y1Yf/y/e1EqB9UI4GQmJhg==,type:str]
+    lastmodified: "2026-03-28T16:15:34Z"
+    mac: ENC[AES256_GCM,data:sPaFwnF1WArHGok53M6HGSv+1VCa0MU573Ee413TgJH5ULzdJet/7RZZmA61vPZY3OzVaww4E8IcaiLSmPHiBVSsLUOK5P5I7e772oHW4hD7R0xyLDgFzGBimApl4AwjW+4ZTUK2mLXyVctSavSlZMjzWuXBMxpGrxGYKm2IlqE=,iv:TxM+/FjG3wrZM8cz1fE44WISlhNcr8f6q8ZBNOCBYc0=,tag:Pk3H/Q2c5YoKPUhEAEsULQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -63,6 +63,7 @@ in
       withGithubStatus = false;
       withGithubWebhook = false;
       withArchiveArtifacts = true;
+      withRegistryPublish = true;
     };
     auth = {
       clientID = "hetzci-release";

--- a/hosts/hetzci/release/secrets.yaml
+++ b/hosts/hetzci/release/secrets.yaml
@@ -11,6 +11,7 @@ tls-pks-file: ENC[AES256_GCM,data:g54YacvUEohwc7E/TICnwNteTJ9ofFL1G8aXqU5Bcndd5o
 jenkins_archive_access_key: ENC[AES256_GCM,data:cpSIQV77NfaDlH3NIwXFOHaBZbA=,iv:6rM+EzEN58YK3ntq4eKBfpdBFqJLy00opKfGwv5dUPc=,tag:vhegWlQxUXvbuws2RQJwBA==,type:str]
 jenkins_archive_secret_key: ENC[AES256_GCM,data:3PkZ6MnXGqMTUDp5V6upsDnbc8Vv3v1zDBLkN/+eqnfahtOyBVK6Jg==,iv:I5rs4uGrFGvRuU4M3208GI/FI7qjpK0hMYGkhyDCQRY=,tag:Io7BFJEWaeE/2Bjx3YCYNw==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:EGATxt84EgU0CZEn,iv:jRnw5PiUbn6OjGukNeD0gRBoEDwmZVu9U+ray73YwbM=,tag:T3HqRAf4/CzltSMHEgJATw==,type:str]
+oci_registry_password: ENC[AES256_GCM,data:M3hzz4h9FrpV8I934GGb,iv:Q2kha2fuFq5boT6/v0lOH3rTQQ9K2idod9BgY+hEPEk=,tag:5C+waAAUh7hBUxgSTsNFHA==,type:str]
 sops:
     age:
         - recipient: age19kx56nu8rlwtyaap83vyg940ylv9hpf7dprgdpcctqqv8k8ecqhsnxtfs4
@@ -67,7 +68,7 @@ sops:
             T01wcWtXdCszNFNReTZ6VEI2RGl4d1kKrsh3nVC5+8EzIUIUB7SvsKl/La317JEw
             igvMrZxxfI3bjIaqpDzVWrm3JTfbSgCr9SuVOd4Jmq8NestA9CTWag==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-16T11:21:23Z"
-    mac: ENC[AES256_GCM,data:drlEkY6tk9SmIRzd/E1ZEkTaLyqemuk6gcDW/h5vxJjuc1YZxPn7+QJQ3dpTmA/fI/1SVM+EYzI+KVxUpZGqgptptQWN2YLLLgKSUoSb5oT8ZVt7W+7mciiMQx/j8hFaGQ4DwPRVdhVa4Jtk1hXyPNeOGMQnmIBzKcPc2+sgfkg=,iv:331ZtUTLpDw36MheIsGhQpQ8GLaIDuFZd00Nt2kqJfQ=,tag:esSIi2Fvg6i5dkGFgwvoxA==,type:str]
+    lastmodified: "2026-03-16T15:14:08Z"
+    mac: ENC[AES256_GCM,data:MYJC2en+eb9ocSczxqle3ILSsBy2GCUG2G8dGxOB86qYRSsUYlUPRj1YPuEwBSkWF0io0KfQbC0jZVzIqyIEQj389AFCuMrAjs/R5laOwkA9MiC2enTuhvCufci/K/ad58OOMaDhRBLVMJbZDhOUuI86eRcZD5k8sKKMYmYnt6k=,iv:XcaHx3nkM9lEyu5WKTckVaiuawpQelHHvJ7GLgWo2F4=,tag:2iYUmlEfguPdATMV9I32Ig==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -64,6 +64,7 @@
             gnutls
             minio-client
             tree
+            oras
           ])
           ++ (with inputs'; [
             deploy-rs.packages.default

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -13,6 +13,7 @@
           selfPkgs = self'.packages;
         };
         nethsm-exporter = pkgs.callPackage ../pkgs/nethsm-exporter { };
+        oci-publish = pkgs.callPackage ../pkgs/oci-publish { };
         pkcs11-proxy = pkgs.callPackage ../pkgs/pkcs11-proxy { };
         systemd-sbsign = pkgs.callPackage ../pkgs/systemd-sbsign { };
         nethsm-pkcs11 = pkgs.callPackage ../pkgs/nethsm-pkcs11 { };

--- a/pkgs/oci-publish/default.nix
+++ b/pkgs/oci-publish/default.nix
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  lib,
+  makeWrapper,
+  oras,
+  python3Packages,
+  ...
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "oci-publish";
+  version = "0.1.0";
+  format = "other";
+
+  src = ./src;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    install -Dm755 oci_publish.py "$out/bin/${pname}"
+    patchShebangs "$out/bin/${pname}"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/${pname}" \
+      --prefix PATH : "${lib.makeBinPath [ oras ]}"
+  '';
+
+  meta.mainProgram = pname;
+}

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=too-many-locals, too-many-arguments
+
+"""Publish Ghaf OCI target artifacts."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, NoReturn
+
+
+DETACHED_SIGNATURE_MEDIA_TYPE = "application/vnd.ghaf.signature.v1"
+TARGET_ARTIFACT_TYPE = "application/vnd.ghaf.image.v1"
+TARGET_CONFIG_MEDIA_TYPE = "application/vnd.ghaf.manifest.v1+json"
+REFERRER_MEDIA_TYPES = {
+    "provenance": "application/vnd.in-toto+json",
+    "sbom_cyclonedx": "application/vnd.cyclonedx+json",
+    "sbom_spdx": "application/spdx+json",
+    "sbom_csv": "text/csv",
+}
+REPOSITORY_COMPONENT_PATTERN = re.compile(r"^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$")
+
+
+def fail(message: str) -> NoReturn:
+    """Exit with an error message."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_json(path: Path) -> Any:
+    """Load JSON from disk."""
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, data: Any) -> None:
+    """Write JSON with stable formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+
+
+def run_command(
+    args: list[str], *, cwd: Path | None = None, stdin_text: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and return the completed process."""
+    try:
+        return subprocess.run(
+            args,
+            check=True,
+            text=True,
+            cwd=cwd,
+            input=stdin_text,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        message = error.stderr.strip() or error.stdout.strip() or str(error)
+        fail(message)
+    except FileNotFoundError:
+        fail(f"command '{args[0]}' is not installed")
+
+
+def run_oras(args: list[str], *, cwd: Path | None = None) -> dict[str, Any]:
+    """Run an ORAS command that returns JSON."""
+    result = run_command(["oras", *args, "--format", "json"], cwd=cwd)
+    return json.loads(result.stdout)
+
+
+def annotation_args(annotations: dict[str, str]) -> list[str]:
+    """Render annotation CLI arguments."""
+    return [
+        f"--annotation={key}={value}" for key, value in annotations.items() if value
+    ]
+
+
+def normalize_repository(repository: str) -> str:
+    """Normalize and validate an OCI repository path."""
+    normalized = repository.strip().lower()
+    if not normalized:
+        fail("repository must not be empty")
+
+    for component in normalized.split("/"):
+        if not REPOSITORY_COMPONENT_PATTERN.fullmatch(component):
+            fail(
+                f"invalid repository '{repository}': "
+                f"component '{component}' does not match OCI naming rules"
+            )
+
+    return normalized
+
+
+def publish_referrer(
+    *,
+    common_args: list[str],
+    subject_reference: str,
+    target_dir: Path,
+    role: str,
+    relpath: str,
+    signature_relpath: str | None = None,
+) -> dict[str, str]:
+    """Attach one referrer artifact."""
+    media_type = REFERRER_MEDIA_TYPES[role]
+    path = target_dir / relpath
+
+    files = [f"{relpath}:{media_type}"]
+    if signature_relpath:
+        files.append(f"{signature_relpath}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
+
+    annotations = {
+        "org.opencontainers.image.description": path.name,
+    }
+    output = run_oras(
+        [
+            "attach",
+            *common_args,
+            *annotation_args(annotations),
+            "--disable-path-validation",
+            "--artifact-type",
+            media_type,
+            subject_reference,
+            *files,
+        ],
+        cwd=target_dir,
+    )
+
+    result = {
+        "path": relpath,
+        "artifact_type": media_type,
+        "digest": output["digest"],
+    }
+
+    return result
+
+
+def publish_target_artifacts(
+    *,
+    manifest: dict[str, Any],
+    target_dir: Path,
+    result_json: Path,
+    repository: str,
+    common_args: list[str],
+    primary_reference: str,
+    immutable_tag: str,
+    mutable_tags: list[str],
+    subject_uses_digest: bool,
+) -> int:
+    """Publish the primary artifact, referrers, and result metadata."""
+    manifest_path = target_dir / "manifest.json"
+    result_reference_prefix = f"{primary_reference.rsplit(':', 1)[0]}@"
+    target = manifest["target"]
+    image = manifest["image"]
+    image_path = image["path"]
+    image_signature = image["signature"]["path"]
+
+    push_files = [f"{image_path}:application/octet-stream"]
+    if image_signature:
+        push_files.append(f"{image_signature}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
+
+    primary_output = run_oras(
+        [
+            "push",
+            *common_args,
+            *annotation_args({"org.opencontainers.image.title": target}),
+            "--disable-path-validation",
+            "--artifact-type",
+            TARGET_ARTIFACT_TYPE,
+            "--config",
+            f"{manifest_path}:{TARGET_CONFIG_MEDIA_TYPE}",
+            primary_reference,
+            *push_files,
+        ],
+        cwd=target_dir,
+    )
+    primary_digest = primary_output["digest"]
+
+    attestations = manifest["attestations"]
+
+    referrers: dict[str, Any] = {}
+    for role in REFERRER_MEDIA_TYPES:
+        relpath = attestations[role]["path"]
+        if not relpath:
+            continue
+
+        signature_relpath = None
+        signature = attestations[role].get("signature")
+        if signature:
+            signature_relpath = attestations[role]["signature"]["path"]
+
+        referrers[role] = publish_referrer(
+            common_args=common_args,
+            subject_reference=(
+                f"{result_reference_prefix}{primary_digest}"
+                if subject_uses_digest
+                else primary_reference
+            ),
+            target_dir=target_dir,
+            role=role,
+            relpath=relpath,
+            signature_relpath=signature_relpath,
+        )
+
+    if mutable_tags:
+        run_command(["oras", "tag", *common_args, primary_reference, *mutable_tags])
+
+    result = {
+        "target": target,
+        "repository": repository,
+        "immutable_tag": immutable_tag,
+        "primary": {
+            "artifact_type": TARGET_ARTIFACT_TYPE,
+            "media_type": primary_output["mediaType"],
+            "digest": primary_digest,
+            "reference": f"{result_reference_prefix}{primary_digest}",
+            "tag_reference": primary_reference,
+        },
+        "referrers": referrers,
+        "mutable_tags": mutable_tags,
+    }
+    write_json(result_json, result)
+
+    print(f"[+] Published {target} as {result_reference_prefix}{primary_digest}")
+    print(f"[+] Wrote publish result: {result_json}")
+    return 0
+
+
+def publish_target(args: argparse.Namespace) -> int:
+    """Publish one target artifact and its referrers."""
+    target_dir = Path(args.target_dir).expanduser().resolve()
+    manifest_path = target_dir / "manifest.json"
+    result_json = Path(args.result_json).expanduser().resolve()
+
+    if not target_dir.is_dir() or not manifest_path.is_file():
+        fail("target directory or manifest.json is missing")
+
+    manifest = read_json(manifest_path)
+    repository = normalize_repository(args.repository)
+
+    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
+    username = os.environ.get("OCI_USERNAME", "jenkins")
+    password = os.environ.get("OCI_PASSWORD", "")
+    layout_path = os.environ.get("OCI_LAYOUT_PATH", "")
+
+    if layout_path:
+        return publish_target_artifacts(
+            manifest=manifest,
+            target_dir=target_dir,
+            result_json=result_json,
+            repository=repository,
+            common_args=["--oci-layout-path", layout_path],
+            primary_reference=f"{repository}:{args.tag}",
+            immutable_tag=args.tag,
+            mutable_tags=list(args.mutable_tags),
+            subject_uses_digest=False,
+        )
+
+    if not password:
+        fail("OCI_PASSWORD is required when publishing to the registry")
+
+    with tempfile.TemporaryDirectory(prefix="oras-auth-") as registry_config_dir:
+        registry_config = Path(registry_config_dir) / "config.json"
+
+        # Use temp login session to avoid exposing OCI_PASSWORD in process arguments.
+        run_command(
+            [
+                "oras",
+                "login",
+                "-u",
+                username,
+                "--password-stdin",
+                "--registry-config",
+                str(registry_config),
+                registry,
+            ],
+            stdin_text=f"{password}\n",
+        )
+
+        return publish_target_artifacts(
+            manifest=manifest,
+            target_dir=target_dir,
+            result_json=result_json,
+            repository=repository,
+            common_args=["--registry-config", str(registry_config)],
+            primary_reference=f"{registry}/{repository}:{args.tag}",
+            immutable_tag=args.tag,
+            mutable_tags=list(args.mutable_tags),
+            subject_uses_digest=True,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description="Publish Ghaf OCI artifacts")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    target_parser = subparsers.add_parser("target", help="publish one target artifact")
+    target_parser.add_argument("-d", "--target-dir", required=True)
+    target_parser.add_argument("-r", "--repository", required=True)
+    target_parser.add_argument("-t", "--tag", required=True)
+    target_parser.add_argument("-o", "--result-json", required=True)
+    target_parser.add_argument(
+        "-m", "--mutable-tag", action="append", default=[], dest="mutable_tags"
+    )
+    target_parser.set_defaults(handler=publish_target)
+
+    return parser
+
+
+def main() -> int:
+    """CLI entrypoint."""
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -129,7 +129,7 @@ verify_signatures() {
     print_err "missing manifest: $dir"
     exit 1
   fi
-  if ! img_rel=$(jq -re '.image' "$manifest"); then
+  if ! img_rel=$(jq -re '.image.path' "$manifest"); then
     print_err "missing image entry in manifest: $manifest"
     exit 1
   fi
@@ -138,7 +138,7 @@ verify_signatures() {
     print_err "missing image: $dir"
     exit 1
   fi
-  if ! img_sig_rel=$(jq -re '.signatures.image.path' "$manifest"); then
+  if ! img_sig_rel=$(jq -re '.image.signature.path' "$manifest"); then
     print_err "missing image signature entry in manifest: $manifest"
     exit 1
   fi
@@ -147,8 +147,8 @@ verify_signatures() {
     print_err "missing image signature: $dir"
     exit 1
   fi
-  if ! prov_rel=$(jq -re '.attestations.provenance.nix_build' "$manifest"); then
-    print_err "missing nix_build provenance entry in manifest: $manifest"
+  if ! prov_rel=$(jq -re '.attestations.provenance.path' "$manifest"); then
+    print_err "missing provenance entry in manifest: $manifest"
     exit 1
   fi
   prov="$dir/$prov_rel"
@@ -156,8 +156,8 @@ verify_signatures() {
     print_err "missing nix_build provenance file: $dir"
     exit 1
   fi
-  if ! prov_sig_rel=$(jq -re '.signatures.provenance.nix_build.path' "$manifest"); then
-    print_err "missing nix_build provenance signature entry in manifest: $manifest"
+  if ! prov_sig_rel=$(jq -re '.attestations.provenance.signature.path' "$manifest"); then
+    print_err "missing provenance signature entry in manifest: $manifest"
     exit 1
   fi
   prov_sig="$dir/$prov_sig_rel"
@@ -208,11 +208,11 @@ prepare_artifacts() {
     mkdir -p "$TMPDIR/$target_name"
     ln -s "$manifest" "$TMPDIR/$target_name/manifest.json"
 
-    if ! image=$(jq -re '.image' "$manifest"); then
+    if ! image=$(jq -re '.image.path' "$manifest"); then
       print_err "missing image entry in manifest: $manifest"
       exit 1
     fi
-    if ! image_sig=$(jq -re '.signatures.image.path' "$manifest"); then
+    if ! image_sig=$(jq -re '.image.signature.path' "$manifest"); then
       print_err "missing image signature entry in manifest: $manifest"
       exit 1
     fi


### PR DESCRIPTION
Added `oci-publish` python CLI that publishes a target artifact directory containing `manifest.json` as an OCI artifact. 

In Jenkins, it is invoked for built targets and publishes them to https://registry.vedenemo.dev under `ghaf/<job>/<target>`. The script uses `manifest.json` as the artifact config blob and writes `oci-result.json` with the published digest and references.

It publishes the main image artifact with the image payload and its detached signature when present, and attaches provenance and SBOM outputs as separate referrer artifacts.