### PR TITLE
Unify host inventory

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -68,14 +68,20 @@ jobs:
       - name: Build ${{ matrix.arch }}
         shell: bash
         run: |
+          # Derive the per-arch host list from flake.lib.hostsBySystem so the
+          # filter stays in sync with the canonical inventory (no name-based
+          # heuristics).
+          HOSTS=$(nix eval --raw \
+            ".#lib.hostsBySystem.${{ matrix.arch }}" \
+            --apply 'names: builtins.concatStringsSep "|" names')
           if [ "${{ matrix.arch }}" == "x86_64-linux" ]; then
             BUILDER="${BUILDER_X86}"
-            # x86 targets: all nixosConfigurations except hetzarm, devShell, pre-commit checks
-            FILTER='(^nixosConfigurations\.((?!hetzarm).)*$|^devShells.x86_64-linux.*$|x86_64-linux\.pre-commit)'
+            # x86 targets: all x86_64-linux nixosConfigurations, devShell, pre-commit checks
+            FILTER="(^nixosConfigurations\\.(${HOSTS})\\.|^devShells\\.x86_64-linux\\..*$|x86_64-linux\\.pre-commit)"
           elif [ "${{ matrix.arch }}" == "aarch64-linux" ]; then
             BUILDER="${BUILDER_AARCH}"
-            # aarch64 targets: hetzarm nixosConfiguration
-            FILTER='^nixosConfigurations.*hetzarm.*'
+            # aarch64 targets: aarch64-linux nixosConfigurations
+            FILTER="^nixosConfigurations\\.(${HOSTS})\\."
           else
             echo "::error::Unknown architecture: '${{ matrix.arch }}'"
             exit 1

--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -10,6 +10,12 @@ on:
   pull_request_target:
     branches:
       - main
+  # Manual trigger. Lets maintainers run the workflow against any ref, which
+  # is useful for exercising workflow changes before merge (e.g. via
+  # `gh workflow run test-ghaf-infra.yml --ref <branch>`). GitHub only exposes
+  # workflow_dispatch once the trigger exists on the default branch, so this
+  # change itself must land on main before it can be used that way.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ghaf-infra
 │   ├── hetzci/         # Jenkins CI environments (see hetzci/README.md)
 │   ├── testagent/      # On-prem test agents
 │   ├── ghaf-*/         # Supporting services (monitoring, auth, registry, etc.)
-│   └── machines.nix    # Host inventory (IPs, keys, Nebula addresses)
+│   └── machines.nix    # Canonical host inventory (modules, systems, deploy metadata, IPs, keys)
 ├── nix/                # Flake plumbing (deployments, apps, git-hooks)
 ├── scripts/            # Operational scripts
 ├── services/           # Shared NixOS service modules

--- a/docs/adding-a-host.md
+++ b/docs/adding-a-host.md
@@ -45,7 +45,6 @@ service modules the host needs, and user modules:
   sops.defaultSopsFile = ./secrets.yaml;
 
   system.stateVersion = lib.mkForce "24.05";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-example";
 }
 ```
@@ -80,41 +79,28 @@ partitioning for the target disk. Identify the disk device ID on the server
 }
 ```
 
-### 3. Add entry to `hosts/machines.nix`
+### 3. Add the host to `hosts/machines.nix`
 
-Add the host's IP (and optionally `internal_ip`, `nebula_ip`, `publicKey`):
+Add a new inventory entry with the module path, target system, and machine
+metadata such as the host IP (and optionally `internal_ip`, `nebula_ip`,
+`publicKey`):
 
 ```nix
 ghaf-example = {
-  ip = "1.2.3.4";
+  module = ./ghaf-example/configuration.nix;
+  system = "x86_64-linux";
+  machine = {
+    ip = "1.2.3.4";
+  };
 };
 ```
 
-The `publicKey` field is populated after the first install (see
-[print-keys](./tasks.md#print-keys)).
-
-### 4. Register host in `hosts/default.nix`
-
-In `hosts/default.nix`, add the host to the `hostModules` attrset:
-
-```nix
-hostModules = {
-  # ...
-  ghaf-example = ./ghaf-example/configuration.nix;
-};
-```
-
-`flake.nixosModules.nixos-ghaf-example` and
-`flake.nixosConfigurations.ghaf-example` are generated from this entry
-automatically.
-
-### 5. Add deploy-rs node to `nix/deployments.nix`
-
-Add the host to the appropriate node set (`x86-nodes` or `aarch64-nodes`):
-
-```nix
-ghaf-example = mkDeployment "ghaf-example" machines.ghaf-example.ip;
-```
+This file drives `flake.nixosConfigurations.*` and `nix/deployments.nix`
+automatically. For normal hosts, `system` also drives `nixpkgs.hostPlatform`,
+so it does not need to be restated in the host config. VMs or other
+non-deploy-rs hosts can omit the `machine` attrset; VM-style outliers should
+also set `kind = "vm"`. The `publicKey` field is populated after the first
+install (see [print-keys](./tasks.md#print-keys)).
 
 ## Provisioning (first install)
 
@@ -138,7 +124,7 @@ After the first install the host has generated its SSH host key. The
 following steps retrieve that key, add it to sops, and redeploy so the
 host receives its encrypted secrets.
 
-### 6. Add host age key to `.sops.yaml`
+### 4. Add host age key to `.sops.yaml`
 
 Retrieve the host's SSH public key and convert it to an age key:
 
@@ -152,7 +138,7 @@ Add the resulting age key to the `keys` section of `.sops.yaml`:
 - &ghaf-example age1...
 ```
 
-### 7. Add creation rule in `.sops.yaml`
+### 5. Add creation rule in `.sops.yaml`
 
 Add a `creation_rules` entry so sops knows which keys can decrypt the
 host's secrets:
@@ -165,7 +151,7 @@ host's secrets:
     - *your-admin-anchor
 ```
 
-### 8. Create secrets file
+### 6. Create secrets file
 
 Copy the host's private SSH key from the remote host and store it as
 a sops secret:
@@ -183,7 +169,7 @@ rm /tmp/host-key
 
 At minimum, the secrets file must contain the `ssh_host_ed25519_key`.
 
-### 9. Run `inv update-sops-files`
+### 7. Run `inv update-sops-files`
 
 Re-encrypt all sops files to reflect the updated `.sops.yaml` rules:
 
@@ -191,7 +177,7 @@ Re-encrypt all sops files to reflect the updated `.sops.yaml` rules:
 inv update-sops-files
 ```
 
-### 10. Redeploy with secrets
+### 8. Redeploy with secrets
 
 Deploy the configuration again so the host receives its secrets
 (see [deploy-rs.md](./deploy-rs.md)):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,10 @@ at the end.
 
 ## Host Overview
 
-The full host inventory (IPs, SSH keys, Nebula addresses) lives in
-[`hosts/machines.nix`](../hosts/machines.nix). The sections below group hosts
-by role and describe how they relate to one another.
+The canonical host inventory lives in
+[`hosts/machines.nix`](../hosts/machines.nix). It records host modules, target
+systems, and machine metadata such as IPs, SSH keys, and Nebula addresses. The
+sections below group hosts by role and describe how they relate to one another.
 
 ### Jenkins Controllers
 
@@ -346,4 +347,4 @@ See [Monitoring](./monitoring.md) for development and debugging details.
 - [Jenkins authentication](./jenkins-authentication.md) — OIDC auth flow
 - [Jenkins test agents](./jenkins-testagents.md) — on-prem test agent setup
 - [Jenkins CI development](../hosts/hetzci/README.md) — CI environments and pipeline overview
-- [`hosts/machines.nix`](../hosts/machines.nix) — host inventory (IPs, keys, Nebula addresses)
+- [`hosts/machines.nix`](../hosts/machines.nix) — canonical host inventory (modules, systems, deploy metadata, IPs, keys, Nebula addresses)

--- a/docs/nebula.md
+++ b/docs/nebula.md
@@ -65,7 +65,7 @@ and run `nebula-cert sign` with the arguments you provide. After exiting, the te
 ### Example usage
 
 create new host certificate for `testagent-dev` and assign it the ip address `10.42.42.11` on the nebula network
-(Check hosts/machines.nix so you don't pick already occupied address).
+(Check `hosts/machines.nix` so you don't pick an already occupied address).
 This host will be part of the groups `testagent` and `office`.
 The groups can be anything and are used to define firewall rules between hosts.
 
@@ -131,7 +131,8 @@ host already exists in the infrastructure (see
 7. **Configure NixOS** — import the `service-nebula` module in the host's
    `configuration.nix` and enable it (see [Nix configuration](#nix-configuration)
    above).
-8. **Add `nebula_ip`** — set the `nebula_ip` field in `hosts/machines.nix`.
+8. **Add `nebula_ip`** — set the `nebula_ip` field in `hosts/machines.nix`
+   under the host's `machine` attrset.
 9. **Deploy** — deploy the host with `deploy .#<name>`.
 
 ## Firewall groups

--- a/hosts/builders/hetz86-1/configuration.nix
+++ b/hosts/builders/hetz86-1/configuration.nix
@@ -41,7 +41,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetz86-1";
   boot.kernelModules = [ "kvm-amd" ];
 

--- a/hosts/builders/hetz86-builder/configuration.nix
+++ b/hosts/builders/hetz86-builder/configuration.nix
@@ -31,7 +31,6 @@
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetz86-builder";
   boot.kernelModules = [ "kvm-amd" ];
 

--- a/hosts/builders/hetz86-dbg-1/configuration.nix
+++ b/hosts/builders/hetz86-dbg-1/configuration.nix
@@ -41,7 +41,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetz86-dbg-1";
   boot.kernelModules = [ "kvm-amd" ];
 

--- a/hosts/builders/hetz86-rel-2/configuration.nix
+++ b/hosts/builders/hetz86-rel-2/configuration.nix
@@ -44,7 +44,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "hetz86-rel-2";
   boot.kernelModules = [ "kvm-amd" ];
 

--- a/hosts/builders/hetzarm-dbg-1/configuration.nix
+++ b/hosts/builders/hetzarm-dbg-1/configuration.nix
@@ -41,7 +41,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "aarch64-linux";
   networking.hostName = "hetzarm-dbg-1";
 
   # Nixos-anywhere kexec switch fails on hetzner cloud arm VMs without this

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -45,7 +45,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "aarch64-linux";
   networking.hostName = "hetzarm-rel-1";
 
   cachix-push = {

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -40,7 +40,6 @@ in
     };
   };
 
-  nixpkgs.hostPlatform = "aarch64-linux";
   networking.hostName = "hetzarm";
 
   cachix-push = {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -14,6 +14,15 @@ let
   );
   isAutoConfiguredHost = _: host: (host.kind or "host") != "vm";
 
+  # Per-system grouping of nixosConfiguration names. Driven by the inventory's
+  # `system` field. Seeded with `hetzci-vm-no-host-nix-store`, which is an
+  # x86_64-linux VM variant exposed in `flake.nixosConfigurations` without its
+  # own inventory entry.
+  hostsBySystem = lib.foldlAttrs (
+    acc: name: host:
+    acc // { ${host.system} = (acc.${host.system} or [ ]) ++ [ name ]; }
+  ) { x86_64-linux = [ "hetzci-vm-no-host-nix-store" ]; } hostInventory;
+
   # make self and inputs available in nixos modules
   specialArgs = {
     inherit self inputs machines;
@@ -86,9 +95,8 @@ in
   }
   // nixosModulesFromHosts;
 
-  # Expose as flake.lib.mkNixOS.
   flake.lib = {
-    inherit mkNixOS;
+    inherit mkNixOS hostsBySystem;
   };
 
   flake.nixosConfigurations = nixosConfigurationsFromHosts // {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -28,9 +28,8 @@ let
     inherit self inputs machines;
   };
 
-  # Calls nixosSystem with a toplevel config
-  # (needs to be a "nixos-"-prefixed module in `self.nixosModules`),
-  # and optional extra configuration.
+  # Calls nixosSystem with a host configuration module from the inventory and
+  # optional extra configuration.
   mkNixOS =
     {
       systemName,
@@ -39,7 +38,7 @@ let
     lib.nixosSystem {
       inherit specialArgs;
       modules = [
-        self.nixosModules."nixos-${systemName}"
+        hostInventory.${systemName}.module
         {
           nixpkgs.hostPlatform = hostInventory.${systemName}.system;
         }
@@ -60,7 +59,7 @@ let
           ram_gb = 20;
           mount_host_nix_store = mountHostNixStore;
         })
-        self.nixosModules.nixos-hetzci-vm
+        hostInventory.hetzci-vm.module
         {
           nixpkgs.hostPlatform = hostInventory.hetzci-vm.system;
           # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/qemu-vm.nix
@@ -80,10 +79,6 @@ let
       ];
     };
 
-  nixosModulesFromHosts = lib.mapAttrs' (
-    name: host: lib.nameValuePair "nixos-${name}" host.module
-  ) hostInventory;
-
   nixosConfigurationsFromHosts = builtins.mapAttrs (name: _host: mkNixOS { systemName = name; }) (
     lib.filterAttrs isAutoConfiguredHost hostInventory
   );
@@ -92,8 +87,7 @@ in
   flake.nixosModules = {
     # shared modules
     common = import ./common.nix;
-  }
-  // nixosModulesFromHosts;
+  };
 
   flake.lib = {
     inherit mkNixOS hostsBySystem;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -8,7 +8,11 @@
   ...
 }:
 let
-  machines = import ./machines.nix;
+  hostInventory = import ./machines.nix;
+  machines = lib.mapAttrs (_: host: host.machine) (
+    lib.filterAttrs (_: host: host ? machine) hostInventory
+  );
+  isAutoConfiguredHost = _: host: (host.kind or "host") != "vm";
 
   # make self and inputs available in nixos modules
   specialArgs = {
@@ -27,6 +31,9 @@ let
       inherit specialArgs;
       modules = [
         self.nixosModules."nixos-${systemName}"
+        {
+          nixpkgs.hostPlatform = hostInventory.${systemName}.system;
+        }
       ]
       ++ lib.optional (extraConfig != null) extraConfig;
     };
@@ -46,7 +53,7 @@ let
         })
         self.nixosModules.nixos-hetzci-vm
         {
-          nixpkgs.hostPlatform = "x86_64-linux";
+          nixpkgs.hostPlatform = hostInventory.hetzci-vm.system;
           # https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/qemu-vm.nix
           virtualisation.vmVariant.virtualisation.forwardPorts = [
             {
@@ -64,48 +71,12 @@ let
       ];
     };
 
-  # All host module paths in one place.
-  # Most hosts can be instantiated with mkNixOS; hetzci-vm is created by mkHetzciVm.
-  hostModules = {
-    hetzarm = ./builders/hetzarm/configuration.nix;
-    hetzarm-dbg-1 = ./builders/hetzarm-dbg-1/configuration.nix;
-    hetzarm-rel-1 = ./builders/hetzarm-rel-1/configuration.nix;
-    testagent-dbg = ./testagent/dbg/configuration.nix;
-    testagent-prod = ./testagent/prod/configuration.nix;
-    testagent-dev = ./testagent/dev/configuration.nix;
-    testagent2-prod = ./testagent/prod2/configuration.nix;
-    testagent-release = ./testagent/release/configuration.nix;
-    nethsm-gateway = ./nethsm-gateway/configuration.nix;
-    ghaf-log = ./ghaf-log/configuration.nix;
-    ghaf-webserver = ./ghaf-webserver/configuration.nix;
-    ghaf-auth = ./ghaf-auth/configuration.nix;
-    ghaf-monitoring = ./ghaf-monitoring/configuration.nix;
-    ghaf-lighthouse = ./ghaf-lighthouse/configuration.nix;
-    ghaf-fleetdm = ./ghaf-fleetdm/configuration.nix;
-    ghaf-registry = ./ghaf-registry/configuration.nix;
-    hetzci-dbg = ./hetzci/dbg/configuration.nix;
-    hetzci-dev = ./hetzci/dev/configuration.nix;
-    hetzci-prod = ./hetzci/prod/configuration.nix;
-    hetzci-release = ./hetzci/release/configuration.nix;
-    hetzci-vm = ./hetzci/vm/configuration.nix;
-    hetz86-1 = ./builders/hetz86-1/configuration.nix;
-    hetz86-builder = ./builders/hetz86-builder/configuration.nix;
-    hetz86-dbg-1 = ./builders/hetz86-dbg-1/configuration.nix;
-    hetz86-rel-2 = ./builders/hetz86-rel-2/configuration.nix;
-    uae-lab-node1 = ./uae/lab/node1/configuration.nix;
-    uae-nethsm-gateway = ./uae/nethsm-gateway/configuration.nix;
-    uae-azureci-prod = ./uae/azureci/prod/configuration.nix;
-    uae-azureci-az86-1 = ./uae/azureci/builders/az86-1/configuration.nix;
-    uae-testagent-prod = ./uae/testagent/prod/configuration.nix;
-    uae-azureci-hetzarm-1 = ./uae/azureci/builders/hetzarm-1/configuration.nix;
-  };
-
   nixosModulesFromHosts = lib.mapAttrs' (
-    name: path: lib.nameValuePair "nixos-${name}" path
-  ) hostModules;
+    name: host: lib.nameValuePair "nixos-${name}" host.module
+  ) hostInventory;
 
-  nixosConfigurationsFromHosts = builtins.mapAttrs (name: _path: mkNixOS { systemName = name; }) (
-    lib.removeAttrs hostModules [ "hetzci-vm" ]
+  nixosConfigurationsFromHosts = builtins.mapAttrs (name: _host: mkNixOS { systemName = name; }) (
+    lib.filterAttrs isAutoConfiguredHost hostInventory
   );
 in
 {

--- a/hosts/ghaf-auth/configuration.nix
+++ b/hosts/ghaf-auth/configuration.nix
@@ -32,7 +32,6 @@ in
   };
 
   system.stateVersion = lib.mkForce "24.11";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-auth";
 
   services.monitoring = {

--- a/hosts/ghaf-fleetdm/configuration.nix
+++ b/hosts/ghaf-fleetdm/configuration.nix
@@ -21,7 +21,6 @@
     user-vadikas
   ]);
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-fleetdm";
   system.stateVersion = lib.mkForce "25.05";
   sops.defaultSopsFile = ./secrets.yaml;

--- a/hosts/ghaf-lighthouse/configuration.nix
+++ b/hosts/ghaf-lighthouse/configuration.nix
@@ -30,7 +30,6 @@
   };
 
   system.stateVersion = lib.mkForce "25.05";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-lighthouse";
 
   services.monitoring = {

--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -36,7 +36,6 @@
   };
 
   system.stateVersion = lib.mkForce "24.05";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-log";
 
   services.monitoring = {

--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -71,7 +71,6 @@ in
   };
 
   system.stateVersion = lib.mkForce "25.05";
-  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   networking.hostName = "ghaf-monitoring";
 
   nebula = {

--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -89,7 +89,6 @@ in
 
   sops.defaultSopsFile = ./secrets.yaml;
   system.stateVersion = lib.mkForce "25.11";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-registry";
 
   sops = {

--- a/hosts/ghaf-webserver/configuration.nix
+++ b/hosts/ghaf-webserver/configuration.nix
@@ -28,7 +28,6 @@
   environment.systemPackages = with pkgs; [ emacs ];
 
   system.stateVersion = lib.mkForce "24.05";
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "ghaf-webserver";
 
   services.nginx.virtualHosts."vedenemo.dev" = {

--- a/hosts/hetzci/common.nix
+++ b/hosts/hetzci/common.nix
@@ -20,8 +20,6 @@
     team-testers
   ]);
 
-  nixpkgs.hostPlatform = "x86_64-linux";
-
   environment.systemPackages = with pkgs; [
     screen
     tmux

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -1,183 +1,313 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
+# Inventory schema:
+# - module: path to the host configuration module.
+# - system: nixpkgs host platform for mkNixOS and deploy-rs grouping.
+# - machine: optional deploy/install metadata (ip, internal_ip, nebula_ip, publicKey).
+# - kind: optional; set to "vm" for outliers that should not be auto-generated via mkNixOS.
 {
-  ghaf-log = {
-    ip = "95.217.177.197";
-    internal_ip = "10.0.0.7";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
-  };
-
-  ghaf-webserver = {
-    ip = "37.27.204.82";
-    internal_ip = "10.0.0.8";
-  };
-
-  ghaf-auth = {
-    ip = "37.27.190.109";
-    internal_ip = "10.0.0.4";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPc04ZyZ7LgUKhV6Xr177qQn6Vf43FzUr1mS6g3jrSDj";
-  };
-
-  ghaf-monitoring = {
-    ip = "135.181.103.32";
-    internal_ip = "10.0.0.2";
-    nebula_ip = "10.42.42.2";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG4gFTuMYnoOpDrknKhD2qlBhsCLiR00K7dpRfmm14F7";
-  };
-
-  ghaf-lighthouse = {
-    ip = "65.109.141.136";
-    internal_ip = "10.0.0.10";
-    nebula_ip = "10.42.42.1";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG9dKZmXqN8in6/0jglv+/txjWRkRJkPOUSVUGTx6KaG";
-  };
-
-  ghaf-fleetdm = {
-    ip = "95.216.169.87";
-    internal_ip = "10.0.0.13";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILohl64vKdsBX3x8SkKjJDphXEYTJGpnE1mHQYERUXZM";
-  };
-
-  ghaf-registry = {
-    ip = "89.167.65.27";
-    internal_ip = "10.0.0.14";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMGfy1TgAnHfOFqVXDmSdYM60fInNKYOo4Bmf2T6Q8mC";
-  };
-
   hetzarm = {
-    ip = "65.21.20.242";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    module = ./builders/hetzarm/configuration.nix;
+    system = "aarch64-linux";
+    machine = {
+      ip = "65.21.20.242";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILx4zU4gIkTY/1oKEOkf9gTJChdx/jR3lDgZ7p/c7LEK";
+    };
   };
 
   hetzarm-dbg-1 = {
-    ip = "46.62.194.107";
-    internal_ip = "10.0.0.14";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3y9z/2FWQdM9nnUJSc8bdsXApC0ug/ttdOGM/r2Zoq";
+    module = ./builders/hetzarm-dbg-1/configuration.nix;
+    system = "aarch64-linux";
+    machine = {
+      ip = "46.62.194.107";
+      internal_ip = "10.0.0.14";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB3y9z/2FWQdM9nnUJSc8bdsXApC0ug/ttdOGM/r2Zoq";
+    };
   };
 
   hetzarm-rel-1 = {
-    ip = "46.62.196.166";
-    internal_ip = "10.0.0.12";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/4rUvG9LPsYGuPFIwjJLoip/DOa6NTWUPGQ20fxXFy";
-  };
-
-  hetz86-1 = {
-    ip = "37.27.170.242";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
-  };
-
-  hetz86-builder = {
-    ip = "65.108.7.79";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG68NdmOw3mhiBZwDv81dXitePoc1w//p/LpsHHA8QRp";
-  };
-
-  hetz86-dbg-1 = {
-    ip = "46.62.194.110";
-    internal_ip = "10.0.0.11";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGg4+l1ln0HycoqkN0vbwvU+fZBniozhLq0Z8hGsGfjx";
-  };
-
-  hetz86-rel-2 = {
-    ip = "65.21.200.168";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPG/KEdKxs3ws7aoHSar4UqK7RzmAGa8j9Xug6Eo7VMm";
-  };
-
-  hetzci-dbg = {
-    ip = "95.216.200.85";
-    internal_ip = "10.0.0.3";
-    nebula_ip = "10.42.42.6";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
-  };
-
-  hetzci-dev = {
-    ip = "157.180.119.138";
-    internal_ip = "10.0.0.6";
-    nebula_ip = "10.42.42.3";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ8XgXW7leM8yIOyU86aDztcWBGKkBAgTiu5yaAcJcvD";
-  };
-
-  hetzci-prod = {
-    ip = "157.180.43.236";
-    internal_ip = "10.0.0.5";
-    nebula_ip = "10.42.42.4";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBdDmtt7At/xDNCF0aIDvXc2T9GTP0HWaAt4DEAejcE6";
-  };
-
-  hetzci-release = {
-    ip = "95.217.210.252";
-    internal_ip = "10.0.0.9";
-    nebula_ip = "10.42.42.5";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILt+qbA7j8q+CjiAY2vX1rEhH3ow4xRKqyMszVI0zvmm";
-  };
-
-  testagent-dev = {
-    ip = "172.18.16.33";
-    nebula_ip = "10.42.42.11";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4";
+    module = ./builders/hetzarm-rel-1/configuration.nix;
+    system = "aarch64-linux";
+    machine = {
+      ip = "46.62.196.166";
+      internal_ip = "10.0.0.12";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/4rUvG9LPsYGuPFIwjJLoip/DOa6NTWUPGQ20fxXFy";
+    };
   };
 
   testagent-dbg = {
-    ip = "172.18.16.26";
-    nebula_ip = "10.42.42.15";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP3w98CfNka5zctBY5NJfOjKuvCjB7rJ8mSqg8EHoh/F";
-  };
-
-  testagent2-prod = {
-    ip = "172.18.16.25";
-    nebula_ip = "10.42.42.14";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhiyhuoKlkkzxXDYhzfa/lnchwWMt/GokyIk1lBhQD6";
+    module = ./testagent/dbg/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.18.16.26";
+      nebula_ip = "10.42.42.15";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP3w98CfNka5zctBY5NJfOjKuvCjB7rJ8mSqg8EHoh/F";
+    };
   };
 
   testagent-prod = {
-    ip = "172.18.16.60";
-    nebula_ip = "10.42.42.12";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx";
+    module = ./testagent/prod/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.18.16.60";
+      nebula_ip = "10.42.42.12";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXYn8XEtZ/LoRBnM/GwNJMg0gcpFMEYEyQX3X9DTENx";
+    };
+  };
+
+  testagent-dev = {
+    module = ./testagent/dev/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.18.16.33";
+      nebula_ip = "10.42.42.11";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVZVd2ZBBHBYCJVOhjhfVXi4lrVYtcH5CkQjTqBfg/4";
+    };
+  };
+
+  testagent2-prod = {
+    module = ./testagent/prod2/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.18.16.25";
+      nebula_ip = "10.42.42.14";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhiyhuoKlkkzxXDYhzfa/lnchwWMt/GokyIk1lBhQD6";
+    };
   };
 
   testagent-release = {
-    ip = "172.18.16.32";
-    nebula_ip = "10.42.42.13";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H";
+    module = ./testagent/release/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.18.16.32";
+      nebula_ip = "10.42.42.13";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPP2xRl4jtu1ARpyj9W3uEo+GACLywosKhal432CgK+H";
+    };
   };
 
   nethsm-gateway = {
-    ip = "192.168.70.11";
-    nebula_ip = "10.42.42.20";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGShuT9oEIq5SQ3lo6n/gT1/OQ3TeJ2r53UUAlWYPJoB";
+    module = ./nethsm-gateway/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "192.168.70.11";
+      nebula_ip = "10.42.42.20";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGShuT9oEIq5SQ3lo6n/gT1/OQ3TeJ2r53UUAlWYPJoB";
+    };
   };
 
-  uae-nethsm-gateway = {
-    ip = "172.31.141.51";
-    nebula_ip = "10.42.42.33";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ69aPBjri8UJi1KbVDEUYW5YeHzAkQ86acQNHzqyrD0";
+  ghaf-log = {
+    module = ./ghaf-log/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "95.217.177.197";
+      internal_ip = "10.0.0.7";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICMmB3Ws5MVq0DgVu+Hth/8NhNAYEwXyz4B6FRCF6Nu2";
+    };
+  };
+
+  ghaf-webserver = {
+    module = ./ghaf-webserver/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "37.27.204.82";
+      internal_ip = "10.0.0.8";
+    };
+  };
+
+  ghaf-auth = {
+    module = ./ghaf-auth/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "37.27.190.109";
+      internal_ip = "10.0.0.4";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPc04ZyZ7LgUKhV6Xr177qQn6Vf43FzUr1mS6g3jrSDj";
+    };
+  };
+
+  ghaf-monitoring = {
+    module = ./ghaf-monitoring/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "135.181.103.32";
+      internal_ip = "10.0.0.2";
+      nebula_ip = "10.42.42.2";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG4gFTuMYnoOpDrknKhD2qlBhsCLiR00K7dpRfmm14F7";
+    };
+  };
+
+  ghaf-lighthouse = {
+    module = ./ghaf-lighthouse/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "65.109.141.136";
+      internal_ip = "10.0.0.10";
+      nebula_ip = "10.42.42.1";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG9dKZmXqN8in6/0jglv+/txjWRkRJkPOUSVUGTx6KaG";
+    };
+  };
+
+  ghaf-fleetdm = {
+    module = ./ghaf-fleetdm/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "95.216.169.87";
+      internal_ip = "10.0.0.13";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILohl64vKdsBX3x8SkKjJDphXEYTJGpnE1mHQYERUXZM";
+    };
+  };
+
+  ghaf-registry = {
+    module = ./ghaf-registry/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "89.167.65.27";
+      internal_ip = "10.0.0.14";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMGfy1TgAnHfOFqVXDmSdYM60fInNKYOo4Bmf2T6Q8mC";
+    };
+  };
+
+  hetzci-dbg = {
+    module = ./hetzci/dbg/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "95.216.200.85";
+      internal_ip = "10.0.0.3";
+      nebula_ip = "10.42.42.6";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALs+OQDrCKRIKkwTwI4MI+oYC3RTEus9cXCBcIyRHzl";
+    };
+  };
+
+  hetzci-dev = {
+    module = ./hetzci/dev/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "157.180.119.138";
+      internal_ip = "10.0.0.6";
+      nebula_ip = "10.42.42.3";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ8XgXW7leM8yIOyU86aDztcWBGKkBAgTiu5yaAcJcvD";
+    };
+  };
+
+  hetzci-prod = {
+    module = ./hetzci/prod/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "157.180.43.236";
+      internal_ip = "10.0.0.5";
+      nebula_ip = "10.42.42.4";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBdDmtt7At/xDNCF0aIDvXc2T9GTP0HWaAt4DEAejcE6";
+    };
+  };
+
+  hetzci-release = {
+    module = ./hetzci/release/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "95.217.210.252";
+      internal_ip = "10.0.0.9";
+      nebula_ip = "10.42.42.5";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILt+qbA7j8q+CjiAY2vX1rEhH3ow4xRKqyMszVI0zvmm";
+    };
+  };
+
+  hetzci-vm = {
+    kind = "vm";
+    module = ./hetzci/vm/configuration.nix;
+    system = "x86_64-linux";
+  };
+
+  hetz86-1 = {
+    module = ./builders/hetz86-1/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "37.27.170.242";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG05U1SHacBIrp3dH7g5O1k8pct/QVwHfuW/TkBYxLnp";
+    };
+  };
+
+  hetz86-builder = {
+    module = ./builders/hetz86-builder/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "65.108.7.79";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG68NdmOw3mhiBZwDv81dXitePoc1w//p/LpsHHA8QRp";
+    };
+  };
+
+  hetz86-dbg-1 = {
+    module = ./builders/hetz86-dbg-1/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "46.62.194.110";
+      internal_ip = "10.0.0.11";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGg4+l1ln0HycoqkN0vbwvU+fZBniozhLq0Z8hGsGfjx";
+    };
+  };
+
+  hetz86-rel-2 = {
+    module = ./builders/hetz86-rel-2/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "65.21.200.168";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPG/KEdKxs3ws7aoHSar4UqK7RzmAGa8j9Xug6Eo7VMm";
+    };
   };
 
   uae-lab-node1 = {
-    ip = "172.19.16.37";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKZYL60TIQDoLwUwuZvzOdw/yikC181su5Cm1LAplcj";
+    module = ./uae/lab/node1/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.19.16.37";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKZYL60TIQDoLwUwuZvzOdw/yikC181su5Cm1LAplcj";
+    };
+  };
+
+  uae-nethsm-gateway = {
+    module = ./uae/nethsm-gateway/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.31.141.51";
+      nebula_ip = "10.42.42.33";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ69aPBjri8UJi1KbVDEUYW5YeHzAkQ86acQNHzqyrD0";
+    };
   };
 
   uae-azureci-prod = {
-    ip = "74.162.68.205";
-    nebula_ip = "10.42.42.34";
-    internal_ip = "10.51.16.4";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICgPq27pnOcNPRnYBCZpsOyHfRhhtWU2EiUQFUHZCqev";
+    module = ./uae/azureci/prod/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "74.162.68.205";
+      nebula_ip = "10.42.42.34";
+      internal_ip = "10.51.16.4";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICgPq27pnOcNPRnYBCZpsOyHfRhhtWU2EiUQFUHZCqev";
+    };
   };
 
   uae-azureci-az86-1 = {
-    ip = "20.46.48.30";
-    internal_ip = "10.51.16.5";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG23fArR5mkx9eCHVKZ2EN/fqxR5LcXKkz4e8DSwLwG+";
+    module = ./uae/azureci/builders/az86-1/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "20.46.48.30";
+      internal_ip = "10.51.16.5";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG23fArR5mkx9eCHVKZ2EN/fqxR5LcXKkz4e8DSwLwG+";
+    };
   };
 
   uae-testagent-prod = {
-    ip = "172.20.16.24";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS";
+    module = ./uae/testagent/prod/configuration.nix;
+    system = "x86_64-linux";
+    machine = {
+      ip = "172.20.16.24";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS";
+    };
   };
 
   uae-azureci-hetzarm-1 = {
-    ip = "91.98.90.243";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBM3zxG++iSjFGkQ6Kqghwm5mcbo+KM4vAzH1Cqftoew";
+    module = ./uae/azureci/builders/hetzarm-1/configuration.nix;
+    system = "aarch64-linux";
+    machine = {
+      ip = "91.98.90.243";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBM3zxG++iSjFGkQ6Kqghwm5mcbo+KM4vAzH1Cqftoew";
+    };
   };
-
 }

--- a/hosts/nethsm-gateway/configuration.nix
+++ b/hosts/nethsm-gateway/configuration.nix
@@ -33,7 +33,6 @@
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "nethsm-gateway";
   networking.useDHCP = true;
 

--- a/hosts/testagent/dbg/configuration.nix
+++ b/hosts/testagent/dbg/configuration.nix
@@ -13,7 +13,6 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   system.stateVersion = "25.11";
   networking.hostName = "testagent-dbg";
   services.testagent = {

--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -12,7 +12,6 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-dev";
   services.testagent = {
     variant = "dev";

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -13,7 +13,6 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-prod";
   services.testagent = {
     variant = "prod";

--- a/hosts/testagent/prod2/configuration.nix
+++ b/hosts/testagent/prod2/configuration.nix
@@ -26,7 +26,6 @@
     ];
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent2-prod";
   services.testagent = {
     variant = "prod";

--- a/hosts/testagent/release/configuration.nix
+++ b/hosts/testagent/release/configuration.nix
@@ -16,7 +16,6 @@
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "testagent-release";
   services.testagent = {
     variant = "release";

--- a/hosts/uae/azureci/builders/az86-1/configuration.nix
+++ b/hosts/uae/azureci/builders/az86-1/configuration.nix
@@ -33,7 +33,6 @@
   # initializing fails with 24.11
   system.stateVersion = lib.mkForce "25.05";
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   hardware.enableRedistributableFirmware = true;
 
   networking = {

--- a/hosts/uae/azureci/builders/hetzarm-1/configuration.nix
+++ b/hosts/uae/azureci/builders/hetzarm-1/configuration.nix
@@ -36,7 +36,6 @@ in
 
   # this server has been initialized with 25.05 with nixos-anywhere
   system.stateVersion = lib.mkForce "25.05";
-  nixpkgs.hostPlatform = "aarch64-linux";
 
   networking.hostName = "uae-azureci-hetzarm-1";
 

--- a/hosts/uae/lab/node1/configuration.nix
+++ b/hosts/uae/lab/node1/configuration.nix
@@ -33,7 +33,6 @@
   # this server has been installed with 25.05
   system.stateVersion = lib.mkForce "25.05";
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   hardware.enableRedistributableFirmware = true;
 
   networking = {

--- a/hosts/uae/nethsm-gateway/configuration.nix
+++ b/hosts/uae/nethsm-gateway/configuration.nix
@@ -34,7 +34,6 @@
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "uae-nethsm-gateway";
 
   # Assign IP configs because dhcp is disabled in network

--- a/hosts/uae/testagent/prod/configuration.nix
+++ b/hosts/uae/testagent/prod/configuration.nix
@@ -22,7 +22,6 @@
     };
   };
 
-  nixpkgs.hostPlatform = "x86_64-linux";
   networking.hostName = "uae-testagent-prod";
   services.testagent = {
     variant = "prod";

--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -7,7 +7,8 @@
   ...
 }:
 let
-  machines = import ../hosts/machines.nix;
+  hostInventory = import ../hosts/machines.nix;
+  isDeployableHost = host: host ? machine;
 
   inherit (inputs) deploy-rs;
 
@@ -24,41 +25,14 @@ let
       };
   };
 
-  x86-nodes = {
-    testagent-prod = mkDeployment "testagent-prod" machines.testagent-prod.ip;
-    testagent-dev = mkDeployment "testagent-dev" machines.testagent-dev.ip;
-    testagent-dbg = mkDeployment "testagent-dbg" machines.testagent-dbg.ip;
-    testagent2-prod = mkDeployment "testagent2-prod" machines.testagent2-prod.ip;
-    testagent-release = mkDeployment "testagent-release" machines.testagent-release.ip;
-    nethsm-gateway = mkDeployment "nethsm-gateway" machines.nethsm-gateway.ip;
-    ghaf-log = mkDeployment "ghaf-log" machines.ghaf-log.ip;
-    ghaf-webserver = mkDeployment "ghaf-webserver" machines.ghaf-webserver.ip;
-    ghaf-auth = mkDeployment "ghaf-auth" machines.ghaf-auth.ip;
-    ghaf-monitoring = mkDeployment "ghaf-monitoring" machines.ghaf-monitoring.ip;
-    ghaf-lighthouse = mkDeployment "ghaf-lighthouse" machines.ghaf-lighthouse.ip;
-    ghaf-fleetdm = mkDeployment "ghaf-fleetdm" machines.ghaf-fleetdm.ip;
-    ghaf-registry = mkDeployment "ghaf-registry" machines.ghaf-registry.ip;
-    hetzci-release = mkDeployment "hetzci-release" machines.hetzci-release.ip;
-    hetzci-prod = mkDeployment "hetzci-prod" machines.hetzci-prod.ip;
-    hetzci-dbg = mkDeployment "hetzci-dbg" machines.hetzci-dbg.ip;
-    hetzci-dev = mkDeployment "hetzci-dev" machines.hetzci-dev.ip;
-    hetz86-1 = mkDeployment "hetz86-1" machines.hetz86-1.ip;
-    hetz86-builder = mkDeployment "hetz86-builder" machines.hetz86-builder.ip;
-    hetz86-dbg-1 = mkDeployment "hetz86-dbg-1" machines.hetz86-dbg-1.ip;
-    hetz86-rel-2 = mkDeployment "hetz86-rel-2" machines.hetz86-rel-2.ip;
-    uae-lab-node1 = mkDeployment "uae-lab-node1" machines.uae-lab-node1.ip;
-    uae-nethsm-gateway = mkDeployment "uae-nethsm-gateway" machines.uae-nethsm-gateway.ip;
-    uae-azureci-prod = mkDeployment "uae-azureci-prod" machines.uae-azureci-prod.ip;
-    uae-azureci-az86-1 = mkDeployment "uae-azureci-az86-1" machines.uae-azureci-az86-1.ip;
-    uae-testagent-prod = mkDeployment "uae-testagent-prod" machines.uae-testagent-prod.ip;
-  };
+  mkNodesFor =
+    system:
+    lib.mapAttrs (name: host: mkDeployment name host.machine.ip) (
+      lib.filterAttrs (_: host: isDeployableHost host && host.system == system) hostInventory
+    );
 
-  aarch64-nodes = {
-    hetzarm = mkDeployment "hetzarm" machines.hetzarm.ip;
-    hetzarm-dbg-1 = mkDeployment "hetzarm-dbg-1" machines.hetzarm-dbg-1.ip;
-    hetzarm-rel-1 = mkDeployment "hetzarm-rel-1" machines.hetzarm-rel-1.ip;
-    uae-azureci-hetzarm-1 = mkDeployment "uae-azureci-hetzarm-1" machines.uae-azureci-hetzarm-1.ip;
-  };
+  x86-nodes = mkNodesFor "x86_64-linux";
+  aarch64-nodes = mkNodesFor "aarch64-linux";
 
   nodes = x86-nodes // aarch64-nodes;
 in


### PR DESCRIPTION
Collapses the three parallel host sources (`hosts/machines.nix`, `hostModules` in `hosts/default.nix`, and the per-arch node sets in `nix/deployments.nix`) into a single canonical inventory in `hosts/machines.nix`. Each entry carries `module`, `system`, optional `machine` (deploy metadata), and optional `kind = "vm"` for outliers.

Consumers derive their view from the inventory:

- `hosts/default.nix` auto-generates `flake.nixosConfigurations` and `flake.nixosModules`, and injects `nixpkgs.hostPlatform` from `system` (removes ~30 duplicated per-host lines).
- `nix/deployments.nix` derives per-arch node sets by filtering on `system`.
- A new `flake.lib.hostsBySystem` drives the build filter in `.github/workflows/test-ghaf-infra.yml`, replacing the `hetzarm`-substring regex so aarch64 hosts no longer need that name prefix.

Adding a host is now one inventory entry plus the configuration module. `docs/adding-a-host.md` updated accordingly (10 steps reduced to 8).

Also adds `workflow_dispatch` to `test-ghaf-infra.yml` so future workflow changes can be exercised on a branch before merge via`gh workflow run test-ghaf-infra.yml --ref <branch>` (this PR's own workflow changes cannot be tested that way because the trigger was only added in this branch).

#### How this has been tested
  - [x] `nix flake check --no-build --option allow-import-from-derivation false`
  - [x] `nix fmt`
  - [x] `nix eval .#nixosConfigurations --apply builtins.attrNames`: set of configs is identical pre/post (32 entries).
  - [x] Simulated both the old and the new CI build filters against the  target list produced by the extraction logic in `scripts/nix-fast-build.sh`. Target sets on `x86_64-linux` and `aarch64-linux` are identical to the old behavior.
  - [x] CI build (manually triggered) on x86_64 builder
  - [x] CI build (manually triggered)  on aarch64 builder
  - [x] Spot-deploy one host (hetzci-dbg) with `deploy-rs` to confirm the inventory-driven node metadata still resolves correctly.