### PR TITLE
Restructure tasks.py with helpers, tests, and perf fixes

### DIFF
--- a/nix/deployments.nix
+++ b/nix/deployments.nix
@@ -45,20 +45,21 @@ in
       aarch64-linux = deploy-rs.lib.aarch64-linux.deployChecks { nodes = aarch64-nodes; };
     };
 
-    # used by tasks.py
-    installationTargets = lib.attrsets.mapAttrs (
+    # Split between metadata (cheap) and secrets (forces nixosConfigurations eval)
+    # so tasks.py can list aliases without materialising every host config.
+    installationTargets = lib.attrsets.mapAttrs (_: node: {
+      inherit (node) hostname config;
+    }) nodes;
+
+    installationTargetSecrets = lib.attrsets.mapAttrs (
       _: node:
       let
         cnf = self.nixosConfigurations.${node.config}.config;
       in
-      {
-        inherit (node) hostname config;
-        secrets =
-          if (lib.attrsets.hasAttrByPath [ "sops" "defaultSopsFile" ] cnf) then
-            cnf.sops.defaultSopsFile
-          else
-            null;
-      }
+      if (lib.attrsets.hasAttrByPath [ "sops" "defaultSopsFile" ] cnf) then
+        cnf.sops.defaultSopsFile
+      else
+        null
     ) nodes;
   };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -52,6 +52,7 @@
             python3.pkgs.invoke
             python3.pkgs.loguru
             python3.pkgs.pycodestyle
+            python3.pkgs.pytest
             python3.pkgs.pylint
             python3.pkgs.tabulate
             reuse

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -105,6 +105,7 @@
                 loguru
                 prometheus-client
                 pycodestyle
+                pytest
                 pylint
                 requests
                 tabulate

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -116,6 +116,7 @@
           pylint = {
             enable = true;
             args = [
+              "--init-hook=import sys; sys.path.insert(0, \".\")"
               "--jobs=0"
               "--enable=useless-suppression"
               "--fail-on=useless-suppression"

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -37,6 +37,22 @@
           exec groovyc --classpath "${jenkins-groovy}" -d "$tmpdir" "$@"
         '';
       };
+
+      python-env = pkgs.python3.withPackages (
+        pp: with pp; [
+          aiohttp
+          deploykit
+          invoke
+          loguru
+          prometheus-client
+          pycodestyle
+          pytest
+          pylint
+          requests
+          tabulate
+          urllib3
+        ]
+      );
     in
     {
       # See https://flake.parts/options/pre-commit-hooks-nix
@@ -87,6 +103,13 @@
           };
           # python formatter
           ruff-format.enable = true;
+          pytest-tasks = {
+            enable = true;
+            name = "pytest-tasks";
+            entry = "${pkgs.lib.getExe' python-env "pytest"} -q tests/test_tasks.py";
+            files = "^(tasks\\.py|tests/test_tasks\\.py)$";
+            pass_filenames = false;
+          };
           # github actions linter
           actionlint.enable = true;
           # python linter
@@ -97,21 +120,7 @@
               "--enable=useless-suppression"
               "--fail-on=useless-suppression"
             ];
-            package = pkgs.python3.withPackages (
-              pp: with pp; [
-                aiohttp
-                deploykit
-                invoke
-                loguru
-                prometheus-client
-                pycodestyle
-                pytest
-                pylint
-                requests
-                tabulate
-                urllib3
-              ]
-            );
+            package = python-env;
           };
           groovyc = {
             enable = true;

--- a/tasks.py
+++ b/tasks.py
@@ -4,9 +4,6 @@
 # SPDX-FileCopyrightText: 2023 Nix community projects
 # SPDX-License-Identifier: MIT
 
-# pylint: disable=global-statement, too-many-locals
-# pylint: disable=too-many-statements, too-many-branches
-
 # This file originates from:
 # https://github.com/nix-community/infra/blob/c4c8c32b51/tasks.py
 
@@ -27,57 +24,94 @@
 # https://docs.pyinvoke.org/en/stable/getting-started.html
 
 
-"""Misc dev and deployment helper tasks"""
+"""Misc dev and deployment helper tasks."""
 
+import getpass
 import json
 import os
+import shlex
+import shutil
 import socket
 import subprocess
 import sys
 import time
-import shutil
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional
+from typing import Any
 
 from deploykit import DeployHost, HostKeyCheck
+from invoke.context import Context
 from invoke.tasks import task
 from loguru import logger
 from tabulate import tabulate
 
 
 ################################################################################
+# Configuration
+################################################################################
 
 ROOT, TARGETS = (None, None)
 
+REVISION_DELIM = "\x1f"  # ASCII unit separator — can't appear in commit metadata
+
+NIXOS_IMAGES_URL = "https://github.com/nix-community/nixos-images/releases/download"
+KEXEC_IMAGES = {
+    "hetz86-rel-2": (
+        f"{NIXOS_IMAGES_URL}/nixos-24.05/"
+        "nixos-kexec-installer-noninteractive-x86_64-linux.tar.gz"
+    ),
+    "hetzarm-rel-1": (
+        f"{NIXOS_IMAGES_URL}/nixos-25.11/"
+        "nixos-kexec-installer-noninteractive-aarch64-linux.tar.gz"
+    ),
+}
+
+RELEASE_BUILDER_USERS = (
+    "hetz86-rel-2-builder",
+    "hetzarm-rel-1-builder",
+)
+RELEASE_BUILDER_ALIASES = (
+    "hetz86-rel-2",
+    "hetzarm-rel-1",
+)
+RELEASE_CONTROLLER_ALIAS = "hetzci-release"
+RELEASE_TESTAGENT_ALIAS = "testagent-release"
+RELEASE_TESTAGENT_URL = "https://ci-release.vedenemo.dev"
+RELEASE_CONNECT_ATTEMPTS = 3
+RELEASE_CONNECT_SLEEP_SEC = 5
+
+
+################################################################################
+# Data models
 ################################################################################
 
 
 @dataclass(eq=False)
 class TargetHost:
-    """Represents target host"""
+    """Represents target host."""
 
     hostname: str
     nixosconfig: str
-    secretspath: Optional[str] = None
+    secretspath: str | None = None
 
 
 class Targets:
-    """Represents all installation targets"""
+    """Represents all installation targets."""
 
-    populated = False
-    target_dict = OrderedDict()
+    def __init__(self) -> None:
+        self.populated = False
+        self.target_dict: OrderedDict[str, TargetHost] = OrderedDict()
 
-    def all(self) -> OrderedDict:
-        """Get all hosts"""
+    def all(self) -> OrderedDict[str, TargetHost]:
+        """Get all hosts."""
         if not self.populated:
-            self.populate()
+            self._populate()
         return self.target_dict
 
-    def populate(self):
-        """Populate the target dictionary from nix evaluation"""
+    def _populate(self) -> None:
+        """Populate the target dictionary from nix evaluation."""
         logger.debug("Reading targets")
         self.target_dict = OrderedDict(
             {
@@ -86,131 +120,147 @@ class Targets:
                     nixosconfig=node["config"],
                     secretspath=node["secrets"],
                 )
-                for name, node in json.loads(
-                    subprocess.check_output(
-                        ["nix", "eval", "--json", f"{ROOT}#installationTargets"]
-                    )
+                for name, node in _run_json(
+                    ["nix", "eval", "--json", f"{ROOT}#installationTargets"]
                 ).items()
             }
         )
         self.populated = True
 
     def get(self, alias: str) -> TargetHost:
-        """Get one host"""
+        """Get one host, exiting cleanly on unknown aliases."""
         logger.debug(f"Reading target '{alias}'")
-        if self.populated:
-            if alias not in self.target_dict:
-                logger.error(f"Unknown alias '{alias}'")
-                sys.exit(1)
-
-            return self.target_dict[alias]
-
-        node = json.loads(
-            subprocess.check_output(
-                ["nix", "eval", "--json", f"{ROOT}#installationTargets.{alias}"]
-            )
-        )
-        return TargetHost(
-            hostname=node["hostname"],
-            nixosconfig=node["config"],
-            secretspath=node["secrets"],
-        )
+        if not self.populated:
+            self._populate()
+        if alias not in self.target_dict:
+            logger.error(f"Unknown alias '{alias}'")
+            sys.exit(1)
+        return self.target_dict[alias]
 
 
-@task
-def alias_list(_c: Any) -> None:
-    """
-    List available targets (i.e. configurations and alias names)
-
-    Example usage:
-    inv alias-list
-    """
-    table_rows = []
-    table_rows.append(["alias", "nixosconfig", "hostname"])
-    for alias, host in TARGETS.all().items():
-        row = [alias, host.nixosconfig, host.hostname]
-        table_rows.append(row)
-    table = tabulate(table_rows, headers="firstrow", tablefmt="fancy_outline")
-    print(f"\nCurrent ghaf-infra targets:\n\n{table}")
+################################################################################
+# Common helpers
+################################################################################
 
 
-@task
-def update_sops_files(c: Any) -> None:
-    """
-    Update all sops yaml and json files according to .sops.yaml rules.
+def _run_checked(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    """Run a local command and require success."""
+    return subprocess.run(cmd, check=True, text=True, **kwargs)
 
-    Example usage:
-    inv update-sops-files
-    """
-    c.run(
-        r"""
-find . \
-        -type f \
-        \( -iname '*.enc.json' -o -iname 'secrets.yaml' \) \
-        -exec sops updatekeys --yes {} \;
-"""
+
+def _run_json(cmd: list[str]) -> Any:
+    """Run a local command that returns JSON, exiting cleanly on failure."""
+    try:
+        proc = _run_checked(cmd, capture_output=True)
+    except subprocess.CalledProcessError as err:
+        detail = (err.stderr or "").strip() or str(err)
+        logger.error(f"Command failed: {shlex.join(cmd)}\n{detail}")
+        sys.exit(1)
+    return json.loads(proc.stdout)
+
+
+def _confirm(prompt: str, yes: bool) -> bool:
+    """Return True when the user confirms or `yes` bypasses the prompt."""
+    if yes:
+        return True
+    return input(prompt) == "y"
+
+
+def _warn_and_confirm(message: str, yes: bool) -> None:
+    """Log a warning and ask the operator to continue."""
+    logger.warning(message)
+    if not _confirm("Still continue? [y/N] ", yes):
+        sys.exit(1)
+
+
+def _remote_stdout(
+    host: DeployHost,
+    cmd: str,
+    *,
+    timeout: int | None = None,
+    become_root: bool = False,
+    suppress_stderr: bool = False,
+) -> str:
+    """Run a remote command and return stdout."""
+    run_kwargs: dict[str, object] = {
+        "cmd": cmd,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE if suppress_stderr else None,
+        "become_root": become_root,
+    }
+    if timeout is not None:
+        run_kwargs["timeout"] = timeout
+    return host.run(**run_kwargs).stdout.strip()
+
+
+def _build_target_ref(target: TargetHost) -> str:
+    """Return the flake output used for local system builds."""
+    return f".#nixosConfigurations.{target.nixosconfig}.config.system.build.toplevel"
+
+
+def _build_local_build_command(target: TargetHost) -> str:
+    """Return the `nix build` command string used by invoke."""
+    return shlex.join(["nix", "build", "--no-link", _build_target_ref(target)])
+
+
+def _build_nixos_anywhere_command(
+    ssh_target: str,
+    tmpdir: str,
+    target: TargetHost,
+    *,
+    kexec_url: str | None = None,
+) -> str:
+    """Return the `nixos-anywhere` command string used by invoke."""
+    cmd = [
+        "nixos-anywhere",
+        ssh_target,
+        "--extra-files",
+        tmpdir,
+    ]
+    if kexec_url is not None:
+        cmd.extend(["--kexec", kexec_url])
+    cmd.extend(
+        [
+            "--flake",
+            f".#{target.nixosconfig}",
+            "--option",
+            "accept-flake-config",
+            "true",
+        ]
     )
+    return shlex.join(cmd)
 
 
-@task
-def print_keys(_c: Any, alias: str) -> None:
-    """
-    Decrypt host private key, print ssh and age public keys for `alias` config.
-
-    Example usage:
-    inv print-keys hetzci-release
-    """
-    target = TARGETS.get(alias)
-    with TemporaryDirectory() as tmpdir:
-        decrypt_host_key(target, tmpdir)
-        key = f"{tmpdir}/etc/ssh/ssh_host_ed25519_key"
-        pubkey = subprocess.run(
-            ["ssh-keygen", "-y", "-f", f"{key}"],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        print("###### Public keys ######")
-        print(pubkey.stdout)
-        print("###### Age keys ######")
-        subprocess.run(
-            ["ssh-to-age"],
-            input=pubkey.stdout,
-            check=True,
-            text=True,
-        )
-
-
-def get_deploy_host(alias: str, user: str | None = None) -> DeployHost:
-    """
-    Return DeployHost object, given `alias`
-    """
+def _get_deploy_host(alias: str, user: str | None = None) -> DeployHost:
+    """Return DeployHost object, given `alias`."""
     hostname = TARGETS.get(alias).hostname
-    deploy_host = DeployHost(
+    return DeployHost(
         host=hostname,
         user=user,
         host_key_check=HostKeyCheck.NONE,
         # verbose_ssh=True,
     )
-    return deploy_host
 
 
-def decrypt_host_key(target: TargetHost, tmpdir: str) -> None:
-    """
-    Run sops to extract `nixosconfig` secret 'ssh_host_ed25519_key'
-    """
+################################################################################
+# Secrets helpers
+################################################################################
+
+
+def _decrypt_host_key(target: TargetHost, tmpdir: str, yes: bool) -> None:
+    """Run sops to extract `nixosconfig` secret `ssh_host_ed25519_key`."""
 
     def opener(path: str, flags: int) -> int:
         return os.open(path, flags, 0o400)
 
-    t = Path(tmpdir)
-    t.mkdir(parents=True, exist_ok=True)
-    t.chmod(0o755)
-    host_key = t / "etc/ssh/ssh_host_ed25519_key"
+    tmpdir_path = Path(tmpdir)
+    tmpdir_path.mkdir(parents=True, exist_ok=True)
+    tmpdir_path.chmod(0o755)
+    host_key = tmpdir_path / "etc/ssh/ssh_host_ed25519_key"
     host_key.parent.mkdir(parents=True, exist_ok=True)
     with open(host_key, "w", opener=opener, encoding="utf-8") as fh:
         try:
-            subprocess.run(
+            _run_checked(
                 [
                     "sops",
                     "--extract",
@@ -218,259 +268,30 @@ def decrypt_host_key(target: TargetHost, tmpdir: str) -> None:
                     "--decrypt",
                     f"{target.secretspath}",
                 ],
-                check=True,
                 stdout=fh,
             )
         except subprocess.CalledProcessError:
-            logger.warning(
-                f"Failed reading secret 'ssh_host_ed25519_key' for '{target.nixosconfig}'"
+            _warn_and_confirm(
+                f"Failed reading secret 'ssh_host_ed25519_key' for '{target.nixosconfig}'",
+                yes,
             )
-            ask = input("Still continue? [y/N] ")
-            if ask != "y":
-                sys.exit(1)
         else:
-            pub_key = t / "etc/ssh/ssh_host_ed25519_key.pub"
+            pub_key = tmpdir_path / "etc/ssh/ssh_host_ed25519_key.pub"
             with open(pub_key, "w", encoding="utf-8") as fh:
-                subprocess.run(
+                _run_checked(
                     ["ssh-keygen", "-y", "-f", f"{host_key}"],
                     stdout=fh,
-                    text=True,
-                    check=True,
                 )
             pub_key.chmod(0o644)
 
 
-@task
-def install_release(c: Any) -> None:
-    """
-    Initialize hetzner release environment
-
-    Example usage:
-    inv install-release
-    """
-    with TemporaryDirectory(delete=True) as t:
-        tmpdir = Path(t)
-        # Generate an ssh CA used for this release installation instance
-        ca = tmpdir / "ca/ssh_user_ca"
-        ca.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            ["ssh-keygen", "-f", f"{ca}", "-C", "", "-N", ""],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        # CA public key will be copied to builders and declared in TrustedUserCAKeys
-        ca_pub = tmpdir / "builder/etc/ssh/keys/ssh_user_ca.pub"
-        ca_pub.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            ["cp", f"{ca}.pub", f"{ca_pub}"],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        # Generate an ssh key and sign a certificate that allows ssh to x86 builder
-        user = "hetz86-rel-2-builder"
-        key = tmpdir / f"controller/etc/ssh/certs/{user}"
-        key.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            ["ssh-keygen", "-f", f"{key}", "-C", "", "-N", ""],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        subprocess.run(
-            ["ssh-keygen", "-s", f"{ca}", "-I", "", "-n", f"{user}", f"{key}.pub"],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        # Generate an ssh key and sign a certificate that allows ssh to arm builder
-        user = "hetzarm-rel-1-builder"
-        key = tmpdir / f"controller/etc/ssh/certs/{user}"
-        key.parent.mkdir(parents=True, exist_ok=True)
-        subprocess.run(
-            ["ssh-keygen", "-f", f"{key}", "-C", "", "-N", ""],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        subprocess.run(
-            ["ssh-keygen", "-s", f"{ca}", "-I", "", "-n", f"{user}", f"{key}.pub"],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-        # Install builders and the controller copying the relevant ssh trusted CA
-        # public key (builders) and the ssh keys (controller) from tmpdir to host.
-        # The temporary ssh CA private key gets removed when tmpdir is deleted
-        # on exiting this code block.
-        install(c, "hetz86-rel-2", yes=True, copy_dir=tmpdir / "builder")
-        install(c, "hetzarm-rel-1", yes=True, copy_dir=tmpdir / "builder")
-        install(c, "hetzci-release", yes=True, copy_dir=tmpdir / "controller")
-
-    h = get_deploy_host("testagent-release")
-
-    # Deploy (don't re-install) testagent-release
-    deploy = c.run("deploy -s --targets .#testagent-release", warn=True)
-    if not deploy.ok:
-        logger.info(
-            "Failed deploying 'testagent-release'. "
-            "The release environment is otherwise up, but you should manually deploy "
-            "the testagent-release, then connect it to the release Jenkins instance. "
-            f"Hint: is the testagent at '{h.host}' accessible over SSH? "
-            "Perhaps you need to connect a VPN?"
-        )
-        return
-
-    # Connect testagent-release to the installed release jenkins controller
-    try:
-        cmd = (
-            "retries=3; for i in $(seq 0 $retries); do "
-            "  connect https://ci-release.vedenemo.dev && exit 0; "
-            "  if (( $i < (( $retries-1 )) )); then sleep 5; else exit 1; fi; "
-            "done"
-        )
-        h.run(cmd=cmd, timeout=20)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        logger.info(
-            "Failed connecting 'testagent-release' to the installed release environment. "
-            "The release environment is otherwise up, but you need to manually connect "
-            "the testagent to the release Jenkins instance. "
-            f"Hint: is the testagent at '{h.host}' accessible over SSH? "
-            "Perhaps you need to connect a VPN?"
-        )
+################################################################################
+# Install helpers
+################################################################################
 
 
-@task
-def install(
-    c: Any,
-    alias: str,
-    user: str | None = None,
-    yes: bool = False,
-    copy_dir: str | None = None,
-) -> None:
-    """
-    Install `alias` configuration using nixos-anywhere, deploying host private key.
-    Note: this will automatically partition and re-format the target hard drive,
-    meaning all data on the target will be completely overwritten with no option
-    to rollback. Option `--yes` allows running the script non-interactively assuming
-    "yes" as answer to all prompts.
-
-    Example usage:
-    inv install hetzci-release --yes
-    """
-    logger.info(f"Installing '{alias}'")
-    h = get_deploy_host(alias, user)
-
-    # Map host alias to kexec image tarball used for the given host during nixos-anywhere
-    # kexec switch. If not specified in the below dictionary, uses the nixos-anywhere
-    # default kexec image which depends on the nixos-anywhere version, see:
-    # https://github.com/nix-community/nixos-anywhere/blob/bad98b/src/nixos-anywhere.sh#L706
-    nixos_images_url = "https://github.com/nix-community/nixos-images/releases/download"
-    kexec_images = {
-        "hetz86-rel-2": (
-            f"{nixos_images_url}/nixos-24.05/"
-            "nixos-kexec-installer-noninteractive-x86_64-linux.tar.gz"
-        ),
-        "hetzarm-rel-1": (
-            f"{nixos_images_url}/nixos-25.11/"
-            "nixos-kexec-installer-noninteractive-aarch64-linux.tar.gz"
-        ),
-    }
-
-    if not yes:
-        ask = input(f"Install configuration '{alias}'? [y/N] ")
-        if ask != "y":
-            return
-
-    assert_stateversion(alias, yes)
-
-    # Check ssh and remote user
-    try:
-        remote_user = h.run(cmd="whoami", stdout=subprocess.PIPE).stdout.strip()
-        ret = subprocess.run(["whoami"], capture_output=True, text=True, check=True)
-        assert ret is not None
-        local_user = ret.stdout.strip()
-        if (
-            not yes
-            and user is None
-            and remote_user
-            and local_user
-            and remote_user != local_user
-        ):
-            logger.warning(
-                f"Remote user '{remote_user}' is not your current local user. "
-                "You will likely not be able to login to the remote host "
-                f"'{TARGETS.get(alias).hostname}' "
-                "after nixos-anywhere installation. Consider adding your local "
-                f"user to the remote host and make sure user '{local_user}' "
-                "also has access to remote host after nixos-anywhere installation "
-                "by adding your local user as a user to nixos configuration "
-                f"'{TARGETS.get(alias).nixosconfig}'. "
-                "Hint: you might want to try the helper script at "
-                "'scripts/add-remote-user.sh' to add your current local "
-                "user to the remote host."
-            )
-            ask = input("Still continue? [y/N] ")
-            if ask != "y":
-                sys.exit(1)
-    except subprocess.CalledProcessError:
-        logger.error("No ssh access to the remote host")
-        sys.exit(1)
-    # Check sudo nopasswd
-    try:
-        h.run("sudo -n true", become_root=True)
-    except subprocess.CalledProcessError:
-        logger.warning(
-            f"sudo on '{h.host}' needs password: installation will likely fail"
-        )
-        if not yes:
-            ask = input("Still continue? [y/N] ")
-            if ask != "y":
-                sys.exit(1)
-    # Check dynamic ip
-    try:
-        h.run("ip a | grep dynamic")
-    except subprocess.CalledProcessError:
-        pass
-    else:
-        logger.warning(f"Above address(es) on '{h.host}' use dynamic addressing.")
-        logger.warning(
-            "This might cause issues if you assume the target host is reachable "
-            "from any such address also after kexec switch. "
-            "If you do, consider making the address temporarily static "
-            "before continuing."
-        )
-        if not yes:
-            ask = input("Still continue? [y/N] ")
-            if ask != "y":
-                sys.exit(1)
-
-    target = TARGETS.get(alias)
-    # Build the target nixosConfiguration locally before calling nixos-anywhere
-    # to abort early in case the build fails
-    command = "nix build --no-link .#nixosConfigurations."
-    command += f"{target.nixosconfig}.config.system.build.toplevel"
-    c.run(command)
-    with TemporaryDirectory() as tmpdir:
-        if copy_dir:
-            shutil.copytree(Path(copy_dir), Path(tmpdir), dirs_exist_ok=True)
-        decrypt_host_key(target, tmpdir)
-        ssh_target = f"{h.user}@{h.host}" if h.user is not None else h.host
-        kexec = f"--kexec {kexec_images[alias]}" if alias in kexec_images else ""
-        command = f"nixos-anywhere {ssh_target} --extra-files {tmpdir} {kexec} "
-        command += f"--flake .#{target.nixosconfig} --option accept-flake-config true"
-        logger.warning(command)
-        c.run(command)
-
-    # Reboot
-    print(f"Wait for {h.host} to start", end="")
-    wait_for_port(h.host, 22)
-    reboot(c, alias)
-
-
-def assert_stateversion(alias: str, yes: bool):
-    """Assert that stateVersion matches nixpkgs version"""
+def _assert_stateversion(alias: str, yes: bool) -> None:
+    """Assert that stateVersion matches nixpkgs version."""
     host = TARGETS.get(alias).nixosconfig
     ret = subprocess.run(
         [
@@ -500,20 +321,157 @@ def assert_stateversion(alias: str, yes: bool):
     state_version = version_data["stateVersion"]
     nixpkgs_version = version_data["nixpkgsVersion"]
     if state_version != nixpkgs_version:
-        logger.warning(
+        _warn_and_confirm(
             f"Attempting to install {alias} with nixpkgs version "
-            f"'{nixpkgs_version}' but `{host}.config.system.stateVersion` is '{state_version}'."
+            f"'{nixpkgs_version}' but `{host}.config.system.stateVersion` is "
+            f"'{state_version}'. stateVersion should be bumped to match "
+            "installation state!",
+            yes,
         )
-        logger.warning("stateVersion should be bumped to match installation state!")
-        if not yes:
-            ask = input("Still continue? [y/N] ")
-            if ask != "y":
-                sys.exit(1)
 
 
-def wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
-    """Wait for `host`:`port`"""
+def _check_remote_user_alignment(
+    target: TargetHost,
+    host: DeployHost,
+    user: str | None,
+    yes: bool,
+) -> None:
+    """Warn when the remote login user differs from the local user."""
+    try:
+        remote_user = _remote_stdout(host, "whoami")
+    except subprocess.CalledProcessError:
+        logger.error("No ssh access to the remote host")
+        sys.exit(1)
 
+    local_user = getpass.getuser()
+    if (
+        yes
+        or user is not None
+        or not remote_user
+        or not local_user
+        or remote_user == local_user
+    ):
+        return
+
+    _warn_and_confirm(
+        f"Remote user '{remote_user}' is not your current local user. "
+        "You will likely not be able to login to the remote host "
+        f"'{target.hostname}' "
+        "after nixos-anywhere installation. Consider adding your local "
+        f"user to the remote host and make sure user '{local_user}' "
+        "also has access to remote host after nixos-anywhere installation "
+        "by adding your local user as a user to nixos configuration "
+        f"'{target.nixosconfig}'. "
+        "Hint: you might want to try the helper script at "
+        "'scripts/add-remote-user.sh' to add your current local "
+        "user to the remote host.",
+        yes,
+    )
+
+
+def _check_remote_sudo(host: DeployHost, yes: bool) -> None:
+    """Warn when passwordless sudo is unavailable on the target."""
+    try:
+        host.run("sudo -n true", become_root=True)
+    except subprocess.CalledProcessError:
+        _warn_and_confirm(
+            f"sudo on '{host.host}' needs password: installation will likely fail",
+            yes,
+        )
+
+
+def _check_dynamic_ip(host: DeployHost, yes: bool) -> None:
+    """Warn when the target reports dynamic IP addresses."""
+    try:
+        host.run("ip a | grep dynamic")
+    except subprocess.CalledProcessError:
+        return
+
+    _warn_and_confirm(
+        f"Above address(es) on '{host.host}' use dynamic addressing. "
+        "This might cause issues if you assume the target host is reachable "
+        "from any such address also after kexec switch. "
+        "If you do, consider making the address temporarily static "
+        "before continuing.",
+        yes,
+    )
+
+
+################################################################################
+# Release-install helpers
+################################################################################
+
+
+def _generate_release_ssh_ca(tmpdir: Path) -> Path:
+    """Generate a temporary SSH CA used during release installation."""
+    ca = tmpdir / "ca/ssh_user_ca"
+    ca.parent.mkdir(parents=True, exist_ok=True)
+    _run_checked(
+        ["ssh-keygen", "-f", f"{ca}", "-C", "", "-N", ""],
+        stdout=subprocess.PIPE,
+    )
+    return ca
+
+
+def _generate_signed_user_key(ca: Path, tmpdir: Path, user: str) -> Path:
+    """Generate and sign a controller SSH key for one release builder user."""
+    key = tmpdir / f"controller/etc/ssh/certs/{user}"
+    key.parent.mkdir(parents=True, exist_ok=True)
+    _run_checked(
+        ["ssh-keygen", "-f", f"{key}", "-C", "", "-N", ""],
+        stdout=subprocess.PIPE,
+    )
+    _run_checked(
+        ["ssh-keygen", "-s", f"{ca}", "-I", "", "-n", f"{user}", f"{key}.pub"],
+        stdout=subprocess.PIPE,
+    )
+    return key
+
+
+def _install_release_hosts(c: Context, tmpdir: Path) -> None:
+    """Install release builders and controller using the public install task."""
+    for alias in RELEASE_BUILDER_ALIASES:
+        install(c, alias, yes=True, copy_dir=str(tmpdir / "builder"))
+    install(c, RELEASE_CONTROLLER_ALIAS, yes=True, copy_dir=str(tmpdir / "controller"))
+
+
+def _deploy_release_testagent(c: Context, host: DeployHost) -> bool:
+    """Deploy the release testagent without reinstalling it."""
+    deploy = c.run(f"deploy -s --targets .#{RELEASE_TESTAGENT_ALIAS}", warn=True)
+    if deploy.ok:
+        return True
+
+    logger.info(
+        "Failed deploying 'testagent-release'. "
+        "The release environment is otherwise up, but you should manually deploy "
+        "the testagent-release, then connect it to the release Jenkins instance. "
+        f"Hint: is the testagent at '{host.host}' accessible over SSH? "
+        "Perhaps you need to connect a VPN?"
+    )
+    return False
+
+
+def _connect_release_testagent(host: DeployHost) -> bool:
+    """Try to connect the release testagent to the Jenkins controller."""
+    command = shlex.join(["connect", RELEASE_TESTAGENT_URL])
+    for attempt in range(RELEASE_CONNECT_ATTEMPTS):
+        try:
+            host.run(cmd=command, timeout=20)
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            if attempt + 1 == RELEASE_CONNECT_ATTEMPTS:
+                return False
+            time.sleep(RELEASE_CONNECT_SLEEP_SEC)
+    return False
+
+
+################################################################################
+# Reporting helpers
+################################################################################
+
+
+def _wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
+    """Wait for `host`:`port`."""
     while True:
         time.sleep(1)
         sys.stdout.write(".")
@@ -528,29 +486,182 @@ def wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
     print("")
 
 
+def _git_revision_info() -> dict[str, list[str]]:
+    """Read local git metadata used to annotate deployed revisions."""
+    proc = _run_checked(
+        ["git", "log", f"--pretty=format:%H{REVISION_DELIM}%cs{REVISION_DELIM}%s"],
+        capture_output=True,
+    )
+    git_info: dict[str, list[str]] = {}
+    for line in proc.stdout.splitlines():
+        split_line = line.split(REVISION_DELIM)
+        git_info[split_line[0]] = split_line
+    return git_info
+
+
+################################################################################
+# Invoke tasks
+################################################################################
+
+
 @task
-def reboot(_c: Any, alias: str) -> None:
+def alias_list(_c: Context) -> None:
+    """
+    List available targets (i.e. configurations and alias names)
+
+    Example usage:
+    inv alias-list
+    """
+    table_rows = [["alias", "nixosconfig", "hostname"]]
+    for alias, host in TARGETS.all().items():
+        table_rows.append([alias, host.nixosconfig, host.hostname])
+    table = tabulate(table_rows, headers="firstrow", tablefmt="fancy_outline")
+    print(f"\nCurrent ghaf-infra targets:\n\n{table}")
+
+
+@task
+def update_sops_files(c: Context) -> None:
+    """
+    Update all sops yaml and json files according to .sops.yaml rules.
+
+    Example usage:
+    inv update-sops-files
+    """
+    c.run(
+        r"""
+find . \
+        -type f \
+        \( -iname '*.enc.json' -o -iname 'secrets.yaml' \) \
+        -exec sops updatekeys --yes {} \;
+"""
+    )
+
+
+@task
+def print_keys(_c: Context, alias: str) -> None:
+    """
+    Decrypt host private key, print ssh and age public keys for `alias` config.
+
+    Example usage:
+    inv print-keys hetzci-release
+    """
+    target = TARGETS.get(alias)
+    with TemporaryDirectory() as tmpdir:
+        _decrypt_host_key(target, tmpdir, yes=False)
+        pub_key = Path(tmpdir) / "etc/ssh/ssh_host_ed25519_key.pub"
+        pub_data = pub_key.read_text(encoding="utf-8")
+        print("###### Public keys ######")
+        print(pub_data)
+        print("###### Age keys ######")
+        _run_checked(["ssh-to-age"], input=pub_data)
+
+
+@task
+def install_release(c: Context) -> None:
+    """
+    Initialize hetzner release environment
+
+    Example usage:
+    inv install-release
+    """
+    with TemporaryDirectory() as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        ca = _generate_release_ssh_ca(tmpdir)
+        ca_pub = tmpdir / "builder/etc/ssh/keys/ssh_user_ca.pub"
+        ca_pub.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(f"{ca}.pub", ca_pub)
+        for user in RELEASE_BUILDER_USERS:
+            _generate_signed_user_key(ca, tmpdir, user)
+        _install_release_hosts(c, tmpdir)
+
+    host = _get_deploy_host(RELEASE_TESTAGENT_ALIAS)
+    if not _deploy_release_testagent(c, host):
+        return
+    if _connect_release_testagent(host):
+        return
+    logger.info(
+        "Failed connecting 'testagent-release' to the installed release environment. "
+        "The release environment is otherwise up, but you need to manually connect "
+        "the testagent to the release Jenkins instance. "
+        f"Hint: is the testagent at '{host.host}' accessible over SSH? "
+        "Perhaps you need to connect a VPN?"
+    )
+
+
+@task
+def install(
+    c: Context,
+    alias: str,
+    user: str | None = None,
+    yes: bool = False,
+    copy_dir: str | None = None,
+) -> None:
+    """
+    Install `alias` configuration using nixos-anywhere, deploying host private key.
+    Note: this will automatically partition and re-format the target hard drive,
+    meaning all data on the target will be completely overwritten with no option
+    to rollback. Option `--yes` allows running the script non-interactively assuming
+    "yes" as answer to all prompts.
+
+    Example usage:
+    inv install hetzci-release --yes
+    """
+    logger.info(f"Installing '{alias}'")
+    if not _confirm(f"Install configuration '{alias}'? [y/N] ", yes):
+        return
+
+    target = TARGETS.get(alias)
+    host = _get_deploy_host(alias, user)
+
+    _assert_stateversion(alias, yes)
+    _check_remote_user_alignment(target, host, user, yes)
+    _check_remote_sudo(host, yes)
+    _check_dynamic_ip(host, yes)
+    c.run(_build_local_build_command(target))
+
+    with TemporaryDirectory() as tmpdir:
+        if copy_dir:
+            shutil.copytree(Path(copy_dir), Path(tmpdir), dirs_exist_ok=True)
+        _decrypt_host_key(target, tmpdir, yes)
+        ssh_target = f"{host.user}@{host.host}" if host.user is not None else host.host
+        command = _build_nixos_anywhere_command(
+            ssh_target,
+            tmpdir,
+            target,
+            kexec_url=KEXEC_IMAGES.get(alias),
+        )
+        logger.warning(command)
+        c.run(command)
+
+    print(f"Wait for {host.host} to start", end="")
+    sys.stdout.flush()
+    _wait_for_port(host.host, 22)
+    reboot(c, alias)
+
+
+@task
+def reboot(_c: Context, alias: str) -> None:
     """
     Reboot host identified as `alias`.
 
     Example usage:
     inv reboot hetzci-release
     """
-    h = get_deploy_host(alias)
-    h.run("sudo reboot &")
+    host = _get_deploy_host(alias)
+    host.run("sudo reboot &")
 
-    print(f"Wait for {h.host} to shutdown", end="")
+    print(f"Wait for {host.host} to shutdown", end="")
     sys.stdout.flush()
-    port = h.port or 22
-    wait_for_port(h.host, port, shutdown=True)
+    port = host.port or 22
+    _wait_for_port(host.host, port, shutdown=True)
 
-    print(f"Wait for {h.host} to start", end="")
+    print(f"Wait for {host.host} to start", end="")
     sys.stdout.flush()
-    wait_for_port(h.host, port)
+    _wait_for_port(host.host, port)
 
 
 @task
-def print_revision(_c: Any, alias: str = "") -> None:
+def print_revision(_c: Context, alias: str = "") -> None:
     """
     Print the currently deployed git revision on the 'alias' host.
     If 'alias' is not specified, prints deployed revisions on all TARGETS.
@@ -560,33 +671,19 @@ def print_revision(_c: Any, alias: str = "") -> None:
     inv print-revision --alias=hetzci-release
     """
     header_row = ["alias", "revision", "revision date", "revision subject"]
+    git_info = _git_revision_info()
+    git_info_def = ["", "", ""]
+    target_aliases = [alias] if alias else list(TARGETS.all().keys())
     table_rows = []
-    target_aliases = [alias]
-    git_info = {}
-    git_info_map = {"hash": 0, "date": 1, "subj": 2}
-    git_info_def = [""] * len(git_info_map)
-    delim = "_;_;_;_"
-    # Read the following git log info:
-    #   %H    - commit hash
-    #   %cs   - committer date, short format (YYYY-MM-DD)
-    #   %s    - commit subject line
-    # Note: We don't fetch remote so the git info might not be fully up-to-date
-    cmd = f"git log --pretty=format:'%H{delim}%cs{delim}%s'"
-    proc = subprocess.run(cmd, capture_output=True, shell=True, text=True, check=True)
-    for line in proc.stdout.splitlines():
-        split_line = line.split(delim)
-        githash = split_line[git_info_map["hash"]]
-        git_info.setdefault(githash, split_line)
-    if not alias:
-        target_aliases = list(TARGETS.all().keys())
-    for target in target_aliases:
-        h = get_deploy_host(target)
+
+    for target_alias in target_aliases:
+        host = _get_deploy_host(target_alias)
         try:
-            rev = h.run(
-                cmd="nixos-version --configuration-revision",
-                stdout=subprocess.PIPE,
+            rev = _remote_stdout(
+                host,
+                "nixos-version --configuration-revision",
                 timeout=5,
-            ).stdout.strip()
+            )
             if "-dirty" not in rev:
                 # Format as terminal link: https://github.com/Alhadis/OSC8-Adoption/
                 url = f"https://github.com/tiiuae/ghaf-infra/commit/{rev}"
@@ -596,27 +693,27 @@ def print_revision(_c: Any, alias: str = "") -> None:
         except subprocess.TimeoutExpired:
             rev = "(unknown)"
             rev_link = rev
-        git_date = git_info.get(rev, git_info_def)[git_info_map["date"]]
-        git_subj = git_info.get(rev, git_info_def)[git_info_map["subj"]]
-        row = [target, rev_link, git_date, git_subj]
-        table_rows.append(row)
-    table_rows.sort(reverse=True, key=lambda x: x[2])  # sort by git_date
+
+        git_date = git_info.get(rev, git_info_def)[1]
+        git_subj = git_info.get(rev, git_info_def)[2]
+        table_rows.append([target_alias, rev_link, git_date, git_subj])
+
+    table_rows.sort(reverse=True, key=lambda row: row[2])  # sort by git_date
     table = tabulate(table_rows, headers=header_row, tablefmt="fancy_outline")
     print(f"\nCurrently deployed revision(s):\n\n{table}")
 
 
 ################################################################################
+# Initialization
+################################################################################
 
 
 def init() -> None:
-    """
-    Module initialization
-    """
-    # Set default logging level to DEBUG
+    """Module initialization."""
     logger.remove(0)
     logger.add(sys.stderr, level="DEBUG")
-    # Init global variables
-    global ROOT, TARGETS
+
+    global ROOT, TARGETS  # pylint: disable=global-statement
     ROOT = Path(__file__).parent.resolve()
     os.chdir(ROOT)
     TARGETS = Targets()

--- a/tasks.py
+++ b/tasks.py
@@ -533,6 +533,7 @@ def _read_deployed_revision(target_alias: str) -> tuple[str, str]:
             host,
             "nixos-version --configuration-revision",
             timeout=5,
+            suppress_stderr=True,
         )
     except subprocess.TimeoutExpired:
         return target_alias, "(unknown)"
@@ -723,6 +724,7 @@ def print_revision(_c: Context, alias: str = "") -> None:
     git_info_def = ["", "", ""]
     target_aliases = [alias] if alias else list(TARGETS.all().keys())
     max_workers = min(32, len(target_aliases))
+    logger.info(f"Probing {len(target_aliases)} host(s) (up to 5s each)")
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         deployed_revisions = list(executor.map(_read_deployed_revision, target_aliases))
 
@@ -753,7 +755,7 @@ def print_revision(_c: Context, alias: str = "") -> None:
 def init() -> None:
     """Module initialization."""
     logger.remove(0)
-    logger.add(sys.stderr, level="DEBUG")
+    logger.add(sys.stderr, level="INFO")
 
     global ROOT, TARGETS  # pylint: disable=global-statement
     ROOT = Path(__file__).parent.resolve()

--- a/tasks.py
+++ b/tasks.py
@@ -95,6 +95,7 @@ class TargetHost:
     hostname: str
     nixosconfig: str
     secretspath: str | None = None
+    secrets_resolved: bool = False
 
 
 class Targets:
@@ -118,7 +119,6 @@ class Targets:
                 name: TargetHost(
                     hostname=node["hostname"],
                     nixosconfig=node["config"],
-                    secretspath=node["secrets"],
                 )
                 for name, node in _run_json(
                     ["nix", "eval", "--json", f"{ROOT}#installationTargets"]
@@ -136,6 +136,18 @@ class Targets:
             logger.error(f"Unknown alias '{alias}'")
             sys.exit(1)
         return self.target_dict[alias]
+
+    def resolve_secrets(self, alias: str) -> TargetHost:
+        """Populate the secret path for one target on demand."""
+        target = self.get(alias)
+        if target.secrets_resolved:
+            return target
+
+        target.secretspath = _run_json(
+            ["nix", "eval", "--json", f"{ROOT}#installationTargetSecrets.{alias}"]
+        )
+        target.secrets_resolved = True
+        return target
 
 
 ################################################################################
@@ -249,6 +261,12 @@ def _get_deploy_host(alias: str, user: str | None = None) -> DeployHost:
 
 def _decrypt_host_key(target: TargetHost, tmpdir: str, yes: bool) -> None:
     """Run sops to extract `nixosconfig` secret `ssh_host_ed25519_key`."""
+
+    if target.secretspath is None:
+        logger.error(
+            f"Missing sops secret path for '{target.nixosconfig}'; cannot decrypt host key"
+        )
+        sys.exit(1)
 
     def opener(path: str, flags: int) -> int:
         return os.open(path, flags, 0o400)
@@ -545,7 +563,7 @@ def print_keys(_c: Context, alias: str) -> None:
     Example usage:
     inv print-keys hetzci-release
     """
-    target = TARGETS.get(alias)
+    target = TARGETS.resolve_secrets(alias)
     with TemporaryDirectory() as tmpdir:
         _decrypt_host_key(target, tmpdir, yes=False)
         pub_key = Path(tmpdir) / "etc/ssh/ssh_host_ed25519_key.pub"
@@ -610,7 +628,7 @@ def install(
     if not _confirm(f"Install configuration '{alias}'? [y/N] ", yes):
         return
 
-    target = TARGETS.get(alias)
+    target = TARGETS.resolve_secrets(alias)
     host = _get_deploy_host(alias, user)
 
     _assert_stateversion(alias, yes)

--- a/tasks.py
+++ b/tasks.py
@@ -35,7 +35,9 @@ import socket
 import subprocess
 import sys
 import time
+from collections.abc import Iterable
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -504,17 +506,46 @@ def _wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
     print("")
 
 
-def _git_revision_info() -> dict[str, list[str]]:
+def _git_revision_info(revisions: Iterable[str] | None = None) -> dict[str, list[str]]:
     """Read local git metadata used to annotate deployed revisions."""
-    proc = _run_checked(
-        ["git", "log", f"--pretty=format:%H{REVISION_DELIM}%cs{REVISION_DELIM}%s"],
-        capture_output=True,
-    )
+    cmd = ["git", "log", f"--pretty=format:%H{REVISION_DELIM}%cs{REVISION_DELIM}%s"]
+    if revisions is not None:
+        unique_revisions = list(dict.fromkeys(revisions))
+        if not unique_revisions:
+            return {}
+        cmd.insert(2, "--ignore-missing")
+        cmd.insert(2, "--no-walk")
+        cmd.extend(unique_revisions)
+
+    proc = _run_checked(cmd, capture_output=True)
     git_info: dict[str, list[str]] = {}
     for line in proc.stdout.splitlines():
         split_line = line.split(REVISION_DELIM)
         git_info[split_line[0]] = split_line
     return git_info
+
+
+def _read_deployed_revision(target_alias: str) -> tuple[str, str]:
+    """Read the currently deployed revision from one target host."""
+    host = _get_deploy_host(target_alias)
+    try:
+        return target_alias, _remote_stdout(
+            host,
+            "nixos-version --configuration-revision",
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return target_alias, "(unknown)"
+
+
+def _format_revision_link(rev: str) -> str:
+    """Format a revision as a terminal hyperlink when applicable."""
+    if "-dirty" in rev or rev == "(unknown)":
+        return rev
+
+    # Format as terminal link: https://github.com/Alhadis/OSC8-Adoption/
+    url = f"https://github.com/tiiuae/ghaf-infra/commit/{rev}"
+    return f"\033]8;;{url}\033\\{rev}\033]8;;\033\\"
 
 
 ################################################################################
@@ -689,32 +720,25 @@ def print_revision(_c: Context, alias: str = "") -> None:
     inv print-revision --alias=hetzci-release
     """
     header_row = ["alias", "revision", "revision date", "revision subject"]
-    git_info = _git_revision_info()
     git_info_def = ["", "", ""]
     target_aliases = [alias] if alias else list(TARGETS.all().keys())
+    max_workers = min(32, len(target_aliases))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        deployed_revisions = list(executor.map(_read_deployed_revision, target_aliases))
+
+    git_info = _git_revision_info(
+        rev
+        for _, rev in deployed_revisions
+        if rev != "(unknown)" and "-dirty" not in rev
+    )
     table_rows = []
 
-    for target_alias in target_aliases:
-        host = _get_deploy_host(target_alias)
-        try:
-            rev = _remote_stdout(
-                host,
-                "nixos-version --configuration-revision",
-                timeout=5,
-            )
-            if "-dirty" not in rev:
-                # Format as terminal link: https://github.com/Alhadis/OSC8-Adoption/
-                url = f"https://github.com/tiiuae/ghaf-infra/commit/{rev}"
-                rev_link = f"\033]8;;{url}\033\\{rev}\033]8;;\033\\"
-            else:
-                rev_link = rev
-        except subprocess.TimeoutExpired:
-            rev = "(unknown)"
-            rev_link = rev
-
+    for target_alias, rev in deployed_revisions:
         git_date = git_info.get(rev, git_info_def)[1]
         git_subj = git_info.get(rev, git_info_def)[2]
-        table_rows.append([target_alias, rev_link, git_date, git_subj])
+        table_rows.append(
+            [target_alias, _format_revision_link(rev), git_date, git_subj]
+        )
 
     table_rows.sort(reverse=True, key=lambda row: row[2])  # sort by git_date
     table = tabulate(table_rows, headers=header_row, tablefmt="fancy_outline")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=protected-access, too-few-public-methods, wrong-import-position
+
+"""Tests for extracted helper logic in tasks.py."""
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import tasks
+
+
+def test_confirm_respects_yes_without_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`yes=True` should bypass interactive prompting."""
+
+    def fail_input(_prompt: str) -> str:
+        raise AssertionError("input() should not be called when yes=True")
+
+    monkeypatch.setattr("builtins.input", fail_input)
+    assert tasks._confirm("Still continue? [y/N] ", yes=True)
+
+
+def test_remote_stdout_omits_timeout_when_unspecified() -> None:
+    """_remote_stdout should let DeployHost use its own infinite timeout."""
+    calls: list[dict[str, object]] = []
+
+    class FakeHost:
+        """DeployHost-like stub that records keyword arguments."""
+
+        def run(self, **kwargs: object) -> SimpleNamespace:
+            """Record the forwarded arguments and return fake stdout."""
+            calls.append(kwargs)
+            return SimpleNamespace(stdout="demo-user\n")
+
+    assert tasks._remote_stdout(FakeHost(), "whoami") == "demo-user"
+    assert calls == [
+        {
+            "cmd": "whoami",
+            "stdout": subprocess.PIPE,
+            "stderr": None,
+            "become_root": False,
+        }
+    ]
+
+
+def test_remote_stdout_passes_requested_timeout_and_stderr_pipe() -> None:
+    """Optional timeout and stderr capture should still be forwarded."""
+    calls: list[dict[str, object]] = []
+
+    class FakeHost:
+        """DeployHost-like stub that records keyword arguments."""
+
+        def run(self, **kwargs: object) -> SimpleNamespace:
+            """Record the forwarded arguments and return fake stdout."""
+            calls.append(kwargs)
+            return SimpleNamespace(stdout="abc123\n")
+
+    assert (
+        tasks._remote_stdout(
+            FakeHost(),
+            "nixos-version --configuration-revision",
+            timeout=5,
+            suppress_stderr=True,
+        )
+        == "abc123"
+    )
+    assert calls == [
+        {
+            "cmd": "nixos-version --configuration-revision",
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "become_root": False,
+            "timeout": 5,
+        }
+    ]
+
+
+def test_assert_stateversion_exits_when_confirmation_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Version mismatch should exit when the operator declines confirmation."""
+
+    def fake_confirm(_prompt: str, yes: bool) -> bool:
+        return yes
+
+    def fake_run(*args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout='{"stateVersion": "24.05", "nixpkgsVersion": "24.11"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        tasks,
+        "TARGETS",
+        SimpleNamespace(get=lambda _alias: SimpleNamespace(nixosconfig="demo-host")),
+    )
+    monkeypatch.setattr(tasks, "ROOT", Path("/tmp/ghaf-infra"))
+    monkeypatch.setattr(tasks, "_confirm", fake_confirm)
+    monkeypatch.setattr(tasks.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit):
+        tasks._assert_stateversion("demo", yes=False)
+
+
+def test_generate_signed_user_key_runs_expected_commands(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Release key generation should run ssh-keygen and signing in sequence."""
+    calls: list[list[str]] = []
+
+    def fake_run_checked(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    ca = tmp_path / "ca/ssh_user_ca"
+    monkeypatch.setattr(tasks, "_run_checked", fake_run_checked)
+
+    key = tasks._generate_signed_user_key(ca, tmp_path, "builder-user")
+    assert key == tmp_path / "controller/etc/ssh/certs/builder-user"
+    assert calls == [
+        ["ssh-keygen", "-f", str(key), "-C", "", "-N", ""],
+        ["ssh-keygen", "-s", str(ca), "-I", "", "-n", "builder-user", f"{key}.pub"],
+    ]
+
+
+def test_build_nixos_anywhere_command_is_shell_safe(tmp_path: Path) -> None:
+    """The assembled invoke command should round-trip through shlex safely."""
+    target = tasks.TargetHost(hostname="host", nixosconfig="demo-config")
+    command = tasks._build_nixos_anywhere_command(
+        "root@example",
+        str(tmp_path / "tmp dir"),
+        target,
+        kexec_url="https://example.test/image.tar.gz",
+    )
+
+    assert shlex.split(command) == [
+        "nixos-anywhere",
+        "root@example",
+        "--extra-files",
+        str(tmp_path / "tmp dir"),
+        "--kexec",
+        "https://example.test/image.tar.gz",
+        "--flake",
+        ".#demo-config",
+        "--option",
+        "accept-flake-config",
+        "true",
+    ]
+
+
+def test_connect_release_testagent_retries_until_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection helper should retry locally before succeeding."""
+    attempts = {"count": 0}
+    sleeps: list[int] = []
+
+    class FakeHost:
+        """DeployHost-like stub used for retry logic tests."""
+
+        def run(self, *, cmd: str, timeout: int) -> SimpleNamespace:
+            """Simulate a flaky remote `connect` command."""
+            assert cmd == shlex.join(["connect", tasks.RELEASE_TESTAGENT_URL])
+            assert timeout == 20
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise subprocess.CalledProcessError(1, cmd)
+            return SimpleNamespace(stdout="")
+
+    def fake_sleep(seconds: int) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(tasks.time, "sleep", fake_sleep)
+
+    assert tasks._connect_release_testagent(FakeHost()) is True
+    assert attempts["count"] == 3
+    assert sleeps == [
+        tasks.RELEASE_CONNECT_SLEEP_SEC,
+        tasks.RELEASE_CONNECT_SLEEP_SEC,
+    ]
+
+
+def test_decrypt_host_key_respects_yes_on_sops_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """sops failure with yes=True should not block on an interactive prompt."""
+
+    def fail_sops(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["sops", "--extract"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    def fail_input(_prompt: str) -> str:
+        raise AssertionError("input() must not be called when yes=True")
+
+    monkeypatch.setattr(tasks, "_run_checked", fail_sops)
+    monkeypatch.setattr("builtins.input", fail_input)
+
+    target = tasks.TargetHost(
+        hostname="h",
+        nixosconfig="demo",
+        secretspath=str(tmp_path / "secrets.yaml"),
+    )
+    tasks._decrypt_host_key(target, str(tmp_path / "out"), yes=True)
+
+
+def test_warn_and_confirm_exits_when_declined(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_warn_and_confirm should exit when the user declines."""
+    monkeypatch.setattr(tasks, "_confirm", lambda _prompt, yes: yes)
+    with pytest.raises(SystemExit):
+        tasks._warn_and_confirm("scary warning", yes=False)
+
+
+def test_run_json_exits_on_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_json should exit cleanly when the underlying command fails."""
+
+    def fail_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(1, cmd, output="", stderr="nix error")
+
+    monkeypatch.setattr(tasks, "_run_checked", fail_run)
+    with pytest.raises(SystemExit):
+        tasks._run_json(["nix", "eval", "--json", "."])
+
+
+def test_git_revision_info_parses_log_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_git_revision_info parses the delimited git log output by hash."""
+    delim = tasks.REVISION_DELIM
+    stdout = (
+        f"abc123{delim}2026-01-01{delim}initial commit\n"
+        f"def456{delim}2026-01-02{delim}fix bug\n"
+    )
+
+    def fake_run_checked(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(tasks, "_run_checked", fake_run_checked)
+
+    assert tasks._git_revision_info() == {
+        "abc123": ["abc123", "2026-01-01", "initial commit"],
+        "def456": ["def456", "2026-01-02", "fix bug"],
+    }
+
+
+def test_targets_get_exits_on_unknown_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Targets.get should exit cleanly when the alias is not in nix output."""
+
+    def fake_run_json(_cmd: list[str]) -> dict:
+        return {"demo": {"hostname": "h", "config": "demo-config", "secrets": None}}
+
+    monkeypatch.setattr(tasks, "_run_json", fake_run_json)
+    monkeypatch.setattr(tasks, "ROOT", Path("/tmp/ghaf-infra"))
+
+    targets = tasks.Targets()
+    with pytest.raises(SystemExit):
+        targets.get("missing")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,6 +8,7 @@
 import shlex
 import subprocess
 import sys
+from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -261,6 +262,103 @@ def test_git_revision_info_parses_log_output(
         "abc123": ["abc123", "2026-01-01", "initial commit"],
         "def456": ["def456", "2026-01-02", "fix bug"],
     }
+
+
+def test_git_revision_info_limits_lookup_to_selected_hashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filtered lookup should avoid traversing the full git history."""
+    calls: list[list[str]] = []
+    delim = tasks.REVISION_DELIM
+
+    def fake_run_checked(
+        cmd: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=f"abc123{delim}2026-01-01{delim}initial commit\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(tasks, "_run_checked", fake_run_checked)
+
+    assert tasks._git_revision_info(["abc123", "abc123"]) == {
+        "abc123": ["abc123", "2026-01-01", "initial commit"],
+    }
+    assert calls == [
+        [
+            "git",
+            "log",
+            "--no-walk",
+            "--ignore-missing",
+            f"--pretty=format:%H{delim}%cs{delim}%s",
+            "abc123",
+        ]
+    ]
+
+
+def test_print_revision_collects_remote_hosts_before_git_lookup(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """print_revision should only ask git for clean deployed revisions."""
+
+    class FakeExecutor:
+        """Minimal executor stub for deterministic tests."""
+
+        def __init__(self, *, max_workers: int) -> None:
+            self.max_workers = max_workers
+
+        def __enter__(self) -> "FakeExecutor":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def map(self, func: object, aliases: list[str]) -> list[tuple[str, str]]:
+            """Apply the submitted function in-order for deterministic tests."""
+            assert self.max_workers == len(aliases)
+            assert func is tasks._read_deployed_revision
+            return [func(alias) for alias in aliases]
+
+    revisions = {
+        "alpha": "abc123",
+        "beta": "abc123",
+        "gamma": "dirtyrev-dirty",
+        "delta": "(unknown)",
+    }
+
+    monkeypatch.setattr(
+        tasks,
+        "TARGETS",
+        SimpleNamespace(
+            all=lambda: OrderedDict((alias, object()) for alias in revisions)
+        ),
+    )
+    monkeypatch.setattr(
+        tasks,
+        "_read_deployed_revision",
+        lambda alias: (alias, revisions[alias]),
+    )
+    monkeypatch.setattr(
+        tasks,
+        "_git_revision_info",
+        lambda selected: {"abc123": ["abc123", "2026-01-01", "initial commit"]}
+        if list(selected) == ["abc123", "abc123"]
+        else {},
+    )
+    monkeypatch.setattr(tasks, "ThreadPoolExecutor", FakeExecutor)
+
+    tasks.print_revision.body(None, alias="")
+
+    output = capsys.readouterr().out
+    assert "alpha" in output
+    assert "beta" in output
+    assert "gamma" in output
+    assert "delta" in output
+    assert "2026-01-01" in output
+    assert "initial commit" in output
 
 
 def test_targets_get_exits_on_unknown_alias(


### PR DESCRIPTION
Restructure tasks.py with helpers, tests, and perf fixes:

  - Extract private helpers from install / install-release flows in `tasks.py`, promote config to module-level constants, and add pytest coverage in `tests/test_tasks.py`.
  - Add a scoped pytest pre-commit hook via `nix/git-hooks.nix` (shares the Python env with pylint); add pytest to the devshell.
  - Speed up `alias-list `by splitting `deployments.nix` into a cheap `installationTargets` index and a separate `installationTargetSecrets` map resolved on demand.
  `inv alias-list` runtime improvement: **~9s** (before) --> **~0.1s** (after)
  - Parallelize print-revision SSH probes so unreachable hosts no longer stack their timeouts.
  `inv print-revision` runtime improvement: **~80s** (before) --> **~9s** (after) on 30 targets.

Tested:
  - `inv alias-list` and `inv print-revision` against the real fleet
  - `inv install-release`: no behavioral regressions 