### PR TITLE
jenkins: migrate utils.groovy to shared library

### DIFF
--- a/hosts/hetzci/casc/common.yaml
+++ b/hosts/hetzci/casc/common.yaml
@@ -75,6 +75,30 @@ groovy:
       import java.util.logging.Level
       import java.util.logging.Logger
       Logger.getLogger("hudson.security.csrf.CrumbFilter").setLevel(Level.SEVERE)
+  # Register the deployment-bundled shared library explicitly. Pipelines use
+  # @Library('ghafInfra') _, so Jenkins must expose /etc/jenkins/pipeline-library
+  # through the shared-library subsystem rather than via ad hoc load() calls.
+  - script: |
+      import jenkins.model.Jenkins
+      import jenkins.plugins.git.GitSCMSource
+      import org.jenkinsci.plugins.workflow.libs.GlobalUntrustedLibraries
+      import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
+      import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
+      println("Configuring shared library ghafInfra")
+      // The library is provisioned locally by Nix under /etc/jenkins. Model it
+      // as a normal Git-backed shared library so controller and agent-executed
+      // pipelines can resolve it through @Library in the usual Jenkins way.
+      def scm = new GitSCMSource("file:///etc/jenkins/pipeline-library").withId("ghaf-infra")
+      def library = new LibraryConfiguration("ghafInfra", new SCMSourceRetriever(scm))
+      library.setDefaultVersion("main")
+      library.setImplicit(false)
+      library.setAllowVersionOverride(false)
+      library.setIncludeInChangesets(false)
+      def globalUntrustedLibraries = Jenkins.get().getDescriptorByType(GlobalUntrustedLibraries.class)
+      def libraries = globalUntrustedLibraries.getLibraries().findAll { it.name != library.name }
+      libraries.add(library)
+      globalUntrustedLibraries.setLibraries(libraries)
+      globalUntrustedLibraries.save()
   # Load pipelines:
   - script: |
       import jenkins.model.*

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -15,11 +15,27 @@ let
   # copies only pipelines declared in cfg.pipelines
   filteredPipelines = pkgs.runCommand "pipelines" { } ''
     mkdir -p $out
-    cp -r ${./pipelines}/modules $out/
-
     ${pkgs.lib.concatMapStringsSep "\n" (name: ''
       cp ${./pipelines}/${name}.groovy "$out/"
     '') cfg.pipelines}
+  '';
+
+  # Jenkins shared libraries expect a Git repository. Turn the repository-local
+  # pipeline-library sources into a tiny synthetic repo and expose it as
+  # /etc/jenkins/pipeline-library for the file:// retriever configured in CasC.
+  pipelineSharedLibrary = pkgs.runCommand "pipeline-library" { nativeBuildInputs = [ pkgs.git ]; } ''
+    mkdir -p "$out"
+    cp -r ${./pipeline-library}/. "$out/"
+    chmod -R u+w "$out"
+    cd "$out"
+    # Create a single deterministic commit so the Nix output is reproducible
+    # while still looking like a normal Git repository to Jenkins.
+    git init --initial-branch=main
+    git add .
+    GIT_AUTHOR_DATE="@''${SOURCE_DATE_EPOCH} +0000" \
+    GIT_COMMITTER_DATE="@''${SOURCE_DATE_EPOCH} +0000" \
+    git -c user.email=nix@example.invalid -c user.name=Nix \
+      commit -m "Provision Jenkins shared library"
   '';
 
   cascConfig = pkgs.writeText "config.yaml" (
@@ -202,6 +218,8 @@ in
         "-Dcasc.jenkins.config=/etc/jenkins/casc"
         # Disable the initial setup wizard, and the creation of initialAdminPassword.
         "-Djenkins.install.runSetupWizard=false"
+        # Shared library retrieval uses file:///etc/jenkins/pipeline-library.
+        "-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true"
         # Allow setting the following possibly undefined parameters
         "-Dhudson.model.ParametersAction.safeParameters=DESC,RELOAD_ONLY,GHAF_FLAKE_REF"
         # Ensure workspace root dir is what we expect
@@ -241,6 +259,7 @@ in
       {
         "jenkins/nix-fast-build.sh".source = "${self.outPath}/scripts/nix-fast-build.sh";
         "jenkins/pipelines".source = filteredPipelines;
+        "jenkins/pipeline-library".source = pipelineSharedLibrary;
         "jenkins/casc/common.yaml".source = ./casc/common.yaml;
         "jenkins/casc/config.yaml".source = cascConfig;
         "jenkins/casc/extraConfig.yaml".source = pkgs.writeText "extraConfig.yaml" (

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -1,10 +1,11 @@
-#!/usr/bin/env groovy
+// SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
 
 import groovy.json.JsonOutput
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 def run_cmd(String cmd) {
-  return sh(script: cmd, returnStdout:true).trim()
+  return sh(script: cmd, returnStdout: true).trim()
 }
 
 def path_basename(String path) {
@@ -25,7 +26,7 @@ def image_role(String path) {
 
 def append_to_build_description(String text) {
   lock('build-description') {
-    if(!currentBuild.description) {
+    if (!currentBuild.description) {
       currentBuild.description = text
     } else {
       currentBuild.description = "${currentBuild.description}<br>${text}"
@@ -439,5 +440,3 @@ def set_github_commit_status(
     """
   }
 }
-
-return this

--- a/hosts/hetzci/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/pipelines/ghaf-main.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -85,8 +84,7 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
-            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+            PIPELINE = utils.create_pipeline(TARGETS)
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def DEFAULT_REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -135,8 +134,7 @@ pipeline {
                 [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug-installer", uefisigniso: params.UEFISIGN, testset: null ])
             }
 
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
-            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+            PIPELINE = utils.create_pipeline(TARGETS)
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -96,11 +95,10 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             if (params.SET_TESTAGENT_HOST && params.TESTAGENT_HOST) {
-              PIPELINE = MODULES.utils.create_pipeline(TARGETS, params.TESTAGENT_HOST)
+              PIPELINE = utils.create_pipeline(TARGETS, params.TESTAGENT_HOST)
             } else {
-              PIPELINE = MODULES.utils.create_pipeline(TARGETS, env.CI_ENV)
+              PIPELINE = utils.create_pipeline(TARGETS, env.CI_ENV)
             }
           }
         }

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -108,8 +107,7 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
-            PIPELINE = MODULES.utils.create_pipeline(TARGETS)
+            PIPELINE = utils.create_pipeline(TARGETS)
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -94,18 +93,17 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             if (params.SET_PR_STATUS) {
-              MODULES.utils.set_github_commit_status("Manual trigger: pending", "pending", env.TARGET_COMMIT)
+              utils.set_github_commit_status("Manual trigger: pending", "pending", env.TARGET_COMMIT)
             }
             def pr_href = "<a href=\"${REPO_URL}/pull/${params.GITHUB_PR_NUMBER}\">🧩 PR#${params.GITHUB_PR_NUMBER}</a>"
-            MODULES.utils.append_to_build_description(pr_href)
+            utils.append_to_build_description(pr_href)
             def merge_commit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
             // The downstream hw-test job needs the PR merge ref as well as the
             // merge SHA, otherwise it cannot refetch GitHub's synthetic merge commit.
             def normalizedRepoUrl = REPO_URL.replaceAll('/+$', '')
             def merge_flake_ref = "git+${normalizedRepoUrl}?ref=refs/pull/${params.GITHUB_PR_NUMBER}/merge&rev=${merge_commit}"
-            PIPELINE = MODULES.utils.create_pipeline(TARGETS, null, merge_flake_ref)
+            PIPELINE = utils.create_pipeline(TARGETS, null, merge_flake_ref)
           }
         }
       }
@@ -124,14 +122,14 @@ pipeline {
     success {
       script {
         if (params.SET_PR_STATUS) {
-          MODULES.utils.set_github_commit_status("Manual trigger: success", "success", env.TARGET_COMMIT)
+          utils.set_github_commit_status("Manual trigger: success", "success", env.TARGET_COMMIT)
         }
       }
     }
     unsuccessful {
       script {
         if (params.SET_PR_STATUS) {
-          MODULES.utils.set_github_commit_status("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+          utils.set_github_commit_status("Manual trigger: failure", "failure", env.TARGET_COMMIT)
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -121,14 +120,13 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
-            MODULES.utils.set_github_commit_status("Pending", "pending", env.TARGET_COMMIT)
+            utils.set_github_commit_status("Pending", "pending", env.TARGET_COMMIT)
             def merge_commit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
             // The downstream hw-test job needs the PR merge ref as well as the
             // merge SHA, otherwise it cannot refetch GitHub's synthetic merge commit.
             def normalizedRepoUrl = REPO_URL.replaceAll('/+$', '')
             def merge_flake_ref = "git+${normalizedRepoUrl}?ref=refs/pull/${GITHUB_PR_NUMBER}/merge&rev=${merge_commit}"
-            PIPELINE = MODULES.utils.create_pipeline(TARGETS, null, merge_flake_ref)
+            PIPELINE = utils.create_pipeline(TARGETS, null, merge_flake_ref)
           }
         }
       }
@@ -146,12 +144,12 @@ pipeline {
   post {
     success {
       script {
-        MODULES.utils.set_github_commit_status("Successful", "success", env.TARGET_COMMIT)
+        utils.set_github_commit_status("Successful", "success", env.TARGET_COMMIT)
       }
     }
     unsuccessful {
       script {
-        MODULES.utils.set_github_commit_status("Failure", "failure", env.TARGET_COMMIT)
+        utils.set_github_commit_status("Failure", "failure", env.TARGET_COMMIT)
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
+++ b/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
-import groovy.transform.Field
-@Field def MODULES = [:]
+@Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
 def WORKDIR  = 'checkout'
@@ -119,16 +118,15 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            MODULES.utils = load "/etc/jenkins/pipelines/modules/utils.groovy"
             if (params.RELEASE_TARGETS_SET.contains('All targets')) {
               println('All release targets selected')
-              PIPELINE = MODULES.utils.create_pipeline(ALL_RELEASE_TARGETS)
+              PIPELINE = utils.create_pipeline(ALL_RELEASE_TARGETS)
             } else if (params.RELEASE_TARGETS_SET.contains('Only laptop targets')){
               println('Only laptop release targets selected')
-              PIPELINE = MODULES.utils.create_pipeline(LAPTOP_RELEASE_TARGETS)
+              PIPELINE = utils.create_pipeline(LAPTOP_RELEASE_TARGETS)
             } else if (params.RELEASE_TARGETS_SET.contains('Minimal build targets')){
               println('Minimal build targets selected')
-              PIPELINE = MODULES.utils.create_pipeline(MINIMAL_BUILD_TARGETS)
+              PIPELINE = utils.create_pipeline(MINIMAL_BUILD_TARGETS)
             } else {
               error('Release targets pre-set was not selected')
             }

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -16,6 +16,9 @@
           (pkgs.writeTextDir "NonCPS.groovy" ''
             @interface NonCPS {}
           '')
+          (pkgs.writeTextDir "Library.groovy" ''
+            @interface Library { String[] value() }
+          '')
           (pkgs.writeTextDir "org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy" ''
             package org.jenkinsci.plugins.pipeline.modeldefinition
 
@@ -139,7 +142,7 @@
             enable = true;
             name = "groovyc";
             entry = "${pkgs.lib.getExe groovyc-check}";
-            files = "^hosts/hetzci/pipelines/.*\\.groovy$";
+            files = "^hosts/hetzci/(pipelines|pipeline-library)/.*\\.groovy$";
           };
         };
       };


### PR DESCRIPTION
**Summary**:
  - Migrate utils.groovy from ad-hoc load() to a proper Jenkins shared library (@Library('ghafInfra')) 
  - Register the library via a CasC init script backed by a Nix-provisioned synthetic Git repo under /etc/jenkins/pipeline-library
  - Update all pipeline scripts to use the @Library annotation instead of the MODULES load pattern
 
**Motivation**:
The previous approach used load "/etc/jenkins/pipelines/modules/utils.groovy" which only works on the controller node. By switching to a Jenkins shared library, utils.groovy is resolved through the standard @Library mechanism, which works on any node. This enables using utils.groovy (and possible other future shared libraries) from hw-test agents: a separate PR will follow to refactor hw-test pipelines so they also use the shared library (edit: [already available here](https://github.com/tiiuae/ghaf-infra/pull/1012)).

**Security / Risk**:
To let Jenkins register the Nix-provisioned shared library from `file:///etc/jenkins/pipeline-library`, this change enables `-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true` on the controller.

This is an intentional controller-wide policy relaxation compared to the previous design, which loaded one fixed local Groovy file directly. In our deployment, this surface remains admin-only: authenticated users have read access, while only the `tiiuae:devenv-fi` admin group can administer Jenkins and define or modify SCM-backed jobs/libraries. This is an acceptable tradeoff for the shared-library design, but it is a real security-boundary change and worth calling out explicitly.

**How this was tested**
See: https://ci-dbg.vedenemo.dev/job/ghaf-manual/