### PR TITLE
slsa: trust provenance from hetzci-dbg

### DIFF
--- a/slsa/provenance-trust-policy.yaml
+++ b/slsa/provenance-trust-policy.yaml
@@ -14,10 +14,11 @@ criteria:
     cel: now - timestamp(predicate.runDetails.metadata.finishedOn) < duration('6h')
 
   - id: builder-id-hetzner
-    description: Built on Hetzner CI dev, prod, release or UAE Azure CI dev, prod, release
+    description: Built on Hetzner CI dbg, dev, prod, release or UAE Azure CI dev, prod, release
     required: true
     cel: |
       predicate.runDetails.builder.id in [
+        'https://ci-dbg.vedenemo.dev/',
         'https://ci-dev.vedenemo.dev/',
         'https://ci-prod.vedenemo.dev/',
         'https://ci-release.vedenemo.dev/',


### PR DESCRIPTION
The provenance trust policy accepts the dev, prod and release controllers, but it omitted the debug controller.

Add ci-dbg.vedenemo.dev to the allowed builder IDs so test agents accept provenance generated by hetzci-dbg.