### PR TITLE
Use OCI registry in hardware tests

### DIFF
--- a/hosts/hetzci/dbg/configuration.nix
+++ b/hosts/hetzci/dbg/configuration.nix
@@ -50,6 +50,7 @@ in
         "ghaf-manual"
         "ghaf-release-candidate"
       ];
+      withRegistryPublish = true;
       withCachix = false;
       withGithubStatus = false;
       withGithubWebhook = false;

--- a/hosts/hetzci/dbg/secrets.yaml
+++ b/hosts/hetzci/dbg/secrets.yaml
@@ -7,6 +7,7 @@ nebula-cert: ENC[AES256_GCM,data:7dsilE1svpdAGqmIxoPC9TD9pvKEI6sWnn7iqS8ZDyEBqQr
 nebula-key: ENC[AES256_GCM,data:aAEqZHwngngXsj3zKfb84EEwc7tvJT0KgmJVfaE3vNyriDAlLGm4ppI43WkAmJ8ccl/K1qsdC2vGidXzrzwZh7dDPJ4FsiNRA+7ku33qlTiVzSOFddiWl7diI590rQWumn3RWac1Rgfz+TJqCUE2Xjrj4afw3tGOaPAZf8WmDQ==,iv:Nla4f3LWFsdr/s72l9/2M97YDkSTktesXfgt3gyh3Xs=,tag:/VagOT7nQIAEHZaEGXbcMA==,type:str]
 tls-pks-file: ENC[AES256_GCM,data:DiP6j5eJmx+vzXXtq08p+IYmD45k769LAzkkBjp3qHsXcXtOD4AbkBYrLJY1hEIhWapGhmB4rWQprjD+czTd/GaYxHof7Hv7+uEF0Q==,iv:g2cpUHY7lZ5aHR2Y0J4hMTgDjphbBMgsj6S6cd/0L9U=,tag:hf4WvvlNfxhTpLlCGUsE8g==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:dGi6NMb4F5lEwXts,iv:MKC8XzFA0K3S7oOuHVHcObqWQ8+kksbqYtA9go+L5xQ=,tag:9oAc2EM4nc4C32vGG5m3Fw==,type:str]
+oci_registry_password: ENC[AES256_GCM,data:DFMCwwdq4Q9oVVSmr6xC,iv:jWSVXuIr2DitMWP24iAkmpcbeBP33O/JVLEBwdrLBC4=,tag:IntY7/9yt8Ta1g9ApxpxFA==,type:str]
 sops:
     age:
         - recipient: age1sv50w7ydcqxxng4nfpvretqhusfkjewtrzpu4006z685xgplha2sa9tv9v
@@ -63,7 +64,7 @@ sops:
             MjJVQUJrb00vRHNwRXA4UTFsKzE3WDAKKP6610tjY2uOxrUmjyh8r3sRM3yfCZjw
             3zmR0E1+Ghajinb0f7wklIct/7rOM1gb0VQ3TKT2dI34XIw6JF22CA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-24T12:06:23Z"
-    mac: ENC[AES256_GCM,data:WRc2brlYvtrZ+JX2n+DvAJKwrLZyqvMUR/sa3qSiz4T/cwvtPggRVpy0vLtdIUTbq5qqaaa0NepLFnqwUNT+kf7YY+XIW98VfRwU1nRylsw/GpzBQcdMWIfy5PyEreqYicwHslSMGzlH9iUTiIXORfMDeVMqhVZnBnmNM9nQqw8=,iv:ba5Y21/HQhQ0nvfoSoN5THD8LHaKdzrfyOAKq0O7rCs=,tag:tNbMCp4AIQxo59aGG/aaaA==,type:str]
+    lastmodified: "2026-04-15T10:19:37Z"
+    mac: ENC[AES256_GCM,data:nNgExvrC3PKzuQmSV/lUrLqg8CHv953JN+aQRv4ffPEhWj084S/zr9kg+ANojftrcJcE7CZ/lVa5w7GDS1oOYRIlvUZ/ET+uJPAC0lDzPL+Fy30/F3fhB6blp7EVBmVCcNAa/4AbZH6koH3ox+K0agIyDnxilRNLGRSJRz3ayHc=,iv:mscW1HkmJY4AcQWvCgNYM3OF6MuUQxwj9QJjtQfUS38=,tag:xMBK9YhCm8nXysY5W0Zp0A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -1,13 +1,18 @@
 #!/usr/bin/env groovy
 
+import groovy.transform.Field
+
 // SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 // SPDX-License-Identifier: Apache-2.0
 
 ////////////////////////////////////////////////////////////////////////////////
 
-def TMP_IMG_DIR = './image'
-def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
-def CI_TEST_PINNED_SOURCE_FILE = '/etc/jenkins/ci-test-automation-pinned-source'
+@Field def TMP_IMG_DIR = './image'
+@Field def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
+@Field def CI_TEST_PINNED_SOURCE_FILE = '/etc/jenkins/ci-test-automation-pinned-source'
+@Field def IMAGE_MEDIA_TYPE = 'application/octet-stream'
+@Field def SOURCE_REF_ANNOTATION = 'org.ghaf.source.ref'
+@Field def TARGET_ANNOTATION = 'org.ghaf.target'
 env.BOOT_PASSED = 'true'
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -23,6 +28,12 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
     string(name: 'CI_TEST_REPO_BRANCH', defaultValue: 'main', description: 'Select ci-test-automation branch to checkout.'),
     string(name: 'TEST_TAGS', defaultValue: '', description: 'Target test tags, e.g.: lenovo-x1ANDapps, SP-T140, SP-T45ORSP-T60, etc.'),
     string(
+      name: 'OCI_IMAGE_REF',
+      defaultValue: '',
+      description: '''
+        Published OCI image reference. If specified, the target device is flashed with the published image before running the tests.
+        Can be left empty, in which case IMG_URL or DEVICE_TAG may be used instead.'''.stripIndent()),
+    string(
       name: 'IMG_URL',
       defaultValue: '',
       description: '''
@@ -32,7 +43,7 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       name: 'GHAF_FLAKE_REF',
       defaultValue: '',
       description: '''
-        Optional pinned Ghaf flake reference for flash-script. Leave empty to derive the Ghaf revision from IMG_URL.
+        Optional pinned Ghaf flake reference for flash-script. Leave empty to derive it from OCI metadata or IMG_URL.
         Set this explicitly for images built from refs that are not fetchable by commit SHA alone, such as PR merge refs.'''.stripIndent()),
     booleanParam(
       name: 'USE_LEGACY_DD_FLASH',
@@ -43,9 +54,9 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       name: 'DEVICE_TAG',
       choiceType: 'PT_RADIO',
       description: '''
-        Select the target device. If DEVICE_TAG is selected and IMG_URL is left empty, the target device is not flashed.
+        Select the target device. If DEVICE_TAG is selected and both IMG_URL and OCI_IMAGE_REF are left empty, the target device is not flashed.
         Instead, tests will be run against the image flashed on the target device at the time of triggering this job.
-        If both IMG_URL and DEVICE_TAG are selected, the selected device is flashed with the given image.'''.stripIndent(),
+        If IMG_URL or OCI_IMAGE_REF is selected together with DEVICE_TAG, the selected device is flashed with the given image.'''.stripIndent(),
       script: [
         $class: 'GroovyScript',
         script: [
@@ -59,7 +70,8 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       name: 'JOB_SELECTOR',
       defaultValue: '',
       description: '''
-        Select the job. If device is flashed, the job is taken from the IMG_URL and this selection is ignored.
+        Select the job. If device is flashed, the job is derived from OCI_IMAGE_REF or IMG_URL when available.
+        Otherwise this selection is used.
         For example system76-darp11-b-storeDisk-debug-installer or system76-darp11-b-storeDisk-debug.
         DEVICE_TAG is used as the job by default when not flashing.'''.stripIndent()),
     [
@@ -68,7 +80,7 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       choiceType: 'PT_RADIO',
       description: '''
         Select the testagent-host. This parameter allows specifying the exact testagent in case Jenkins controller is
-        connected with multiple agents. Can be used together with both IMG_URL and DEVICE_TAG parameters.'''.stripIndent(),
+        connected with multiple agents. Can be used together with IMG_URL, OCI_IMAGE_REF, and DEVICE_TAG.'''.stripIndent(),
       script: [
         $class: 'GroovyScript',
         script: [
@@ -96,6 +108,16 @@ def init() {
   if(!params || params.RELOAD_ONLY) {
     return 'built-in'
   }
+  env.OCI_TARGET = ''
+  env.OCI_SOURCE_REF = ''
+  if (params.OCI_IMAGE_REF) {
+    def annotations = readJSON(
+      text: sh_ret_out("oras manifest fetch --format json '${params.OCI_IMAGE_REF}'")
+    ).content?.annotations ?: [:]
+    env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
+    env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
+  }
+  def flashTarget = derive_target_name(params.IMG_URL, env.OCI_TARGET)
   def deviceMap = [
     "orin-agx"           : [name: 'OrinAGX1'],
     "orin-agx-64"        : [name: 'OrinAGX64'],
@@ -105,39 +127,21 @@ def init() {
     "lenovo-x1"          : [name: 'LenovoX1-1'],
     "x1-sec-boot"        : [name: 'X1-Secure-Boot']
   ]
-  // Determine the device name
-  if(params.IMG_URL.contains("orin-agx-")) {
-    env.DEVICE_NAME = 'OrinAGX1'
-    env.DEVICE_TAG = 'orin-agx'
-  } else if(params.IMG_URL.contains("orin-agx64-")) {
-    env.DEVICE_NAME = 'OrinAGX64'
-    env.DEVICE_TAG = 'orin-agx-64'
-  } else if(params.IMG_URL.contains("orin-nx-")) {
-    env.DEVICE_NAME = 'OrinNX1'
-    env.DEVICE_TAG = 'orin-nx'
-  } else if(params.IMG_URL.contains("lenovo-x1-")) {
-    if (params.SECUREBOOT) {
-      env.DEVICE_NAME = 'X1-Secure-Boot'
-      env.DEVICE_TAG = 'x1-sec-boot'
-    } else {
-      env.DEVICE_NAME = 'LenovoX1-1'
-      env.DEVICE_TAG = 'lenovo-x1'
+  if (flashTarget) {
+    def deviceInfo = derive_device_info(flashTarget, params.SECUREBOOT)
+    if (deviceInfo) {
+      env.DEVICE_NAME = deviceInfo.name
+      env.DEVICE_TAG = deviceInfo.tag
     }
-  } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
-    env.DEVICE_NAME = 'Dell7330'
-    env.DEVICE_TAG = 'dell-7330'
-  } else if(params.IMG_URL.contains("system76-darp11-b-")) {
-    env.DEVICE_NAME = 'DarterPRO'
-    env.DEVICE_TAG = 'darter-pro'
   }
-  if (params.IMG_URL && params.DEVICE_TAG) {
+  if ((params.IMG_URL || params.OCI_IMAGE_REF) && params.DEVICE_TAG) {
     env.DEVICE_TAG = params.DEVICE_TAG
     env.DEVICE_NAME = deviceMap[env.DEVICE_TAG].name
   }
   if (!env.DEVICE_TAG || env.DEVICE_TAG == null) {
-    error("DEVICE_TAG is not defined and could not be derived from IMG_URL ${env.IMG_URL}")
+    error("DEVICE_TAG is not defined and could not be derived from IMG_URL '${params.IMG_URL}', OCI_IMAGE_REF '${params.OCI_IMAGE_REF}', or explicit DEVICE_TAG")
   }
-  if (!params.IMG_URL || params.IMG_URL == null) {
+  if ((!params.IMG_URL && !params.OCI_IMAGE_REF) || params.DEVICE_TAG) {
     env.DEVICE_NAME = deviceMap[env.DEVICE_TAG].name
   }
   def label = env.DEVICE_TAG
@@ -174,11 +178,55 @@ def run_wget(String url, String to_dir) {
   return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
 }
 
+def derive_target_name(String imgUrl, String ociTarget) {
+  def normalizedTarget = ociTarget?.trim()
+  if (normalizedTarget) {
+    return normalizedTarget
+  }
+  if (!imgUrl) {
+    return null
+  }
+  def match = imgUrl =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
+  if (match) {
+    return match.group(1)
+  }
+  return null
+}
+
 @NonCPS
-def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl) {
+def derive_device_info(String target, boolean secureboot) {
+  if (target.contains("nvidia-jetson-orin-agx64")) {
+    return [name: 'OrinAGX64', tag: 'orin-agx-64']
+  }
+  if (target.contains("nvidia-jetson-orin-agx")) {
+    return [name: 'OrinAGX1', tag: 'orin-agx']
+  }
+  if (target.contains("nvidia-jetson-orin-nx")) {
+    return [name: 'OrinNX1', tag: 'orin-nx']
+  }
+  if (target.contains("lenovo-x1")) {
+    if (secureboot && !target.contains("installer")) {
+      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
+    }
+    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
+  }
+  if (target.contains("dell-latitude-7330")) {
+    return [name: 'Dell7330', tag: 'dell-7330']
+  }
+  if (target.contains("system76-darp11-b")) {
+    return [name: 'DarterPRO', tag: 'darter-pro']
+  }
+  return null
+}
+
+def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
   def normalizedFlakeRef = explicitFlakeRef?.trim()
   if (normalizedFlakeRef) {
     return normalizedFlakeRef
+  }
+  def normalizedOciFlakeRef = ociFlakeRef?.trim()
+  if (normalizedOciFlakeRef) {
+    return normalizedOciFlakeRef
   }
   def match = imgUrl =~ /commit_([a-f0-9]{40})/
   if (match) {
@@ -233,12 +281,13 @@ def ghaf_robot_test(String tags) {
 ////////////////////////////////////////////////////////////////////////////////
 
 pipeline {
-  agent { label init() }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Set properties') {
+      agent { label 'built-in' }
       steps {
         script {
           properties([
@@ -248,6 +297,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -257,227 +307,252 @@ pipeline {
         }
       }
     }
-    stage('Checkout') {
+    stage('Initialize') {
+      agent { label 'built-in' }
       steps {
-        deleteDir()
         script {
-          if (params.USE_FLAKE_PINNED_CI_TEST) {
-            def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
-            println("Using flake-pinned ci-test-automation source: ${pinned_src}")
-            sh """
-              if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
-                echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
-                exit 1
-              fi
-              cp -r "${pinned_src}/." .
-              chmod -R u+w .
-            """
-          } else {
-            checkout scmGit(
-              branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
-              userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
-            )
-          }
+          env.TEST_AGENT_LABEL = init()
         }
       }
     }
-    stage('Setup') {
-      steps {
-        script {
-          env.TARGET = env.DEVICE_TAG
-          if(params.IMG_URL) {
-            def match = params.IMG_URL =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
-            if(match) {
-              env.TARGET = "${match.group(1)}"
+    stage('Run on test agent') {
+      agent { label "${env.TEST_AGENT_LABEL}" }
+      stages {
+        stage('Checkout') {
+          steps {
+            deleteDir()
+            script {
+              if (params.USE_FLAKE_PINNED_CI_TEST) {
+                def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
+                println("Using flake-pinned ci-test-automation source: ${pinned_src}")
+                sh """
+                  if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
+                    echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
+                    exit 1
+                  fi
+                  cp -r "${pinned_src}/." .
+                  chmod -R u+w .
+                """
+              } else {
+                checkout scmGit(
+                  branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
+                  userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
+                )
+              }
             }
-          } else {
-            def sel = params.JOB_SELECTOR
-            if (!sel) {
+          }
+        }
+        stage('Setup') {
+          steps {
+            script {
               env.TARGET = env.DEVICE_TAG
-            } else {
-              env.TARGET = sel
+              def explicitTarget = derive_target_name(params.IMG_URL, env.OCI_TARGET)
+              if (explicitTarget) {
+                env.TARGET = explicitTarget
+              } else {
+                def sel = params.JOB_SELECTOR
+                if (!sel) {
+                  env.TARGET = env.DEVICE_TAG
+                } else {
+                  env.TARGET = sel
+                }
+              }
+              env.TEST_CONFIG_DIR = 'Robot-Framework/config'
+              sh """
+                mkdir -p ${TEST_CONFIG_DIR}
+                rm -f ${TEST_CONFIG_DIR}/*.json
+                ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
+                echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+                ls -la ${TEST_CONFIG_DIR}
+              """
+              // Determine mount commands
+              if(env.TARGET.contains("microchip-icicle-")) {
+                def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
+                env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
+                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
+              } else {
+                def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
+                env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
+                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
+              }
             }
           }
-          env.TEST_CONFIG_DIR = 'Robot-Framework/config'
-          sh """
-            mkdir -p ${TEST_CONFIG_DIR}
-            rm -f ${TEST_CONFIG_DIR}/*.json
-            ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
-            echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
-            ls -la ${TEST_CONFIG_DIR}
-          """
-          // Determine mount commands
-          if(params.IMG_URL.contains("microchip-icicle-")) {
-            def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
-            env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
-            env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
-          } else {
-            def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
-            env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
-            env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
+        }
+        stage('Image download') {
+          when { expression { params && (params.IMG_URL || params.OCI_IMAGE_REF) } }
+          steps {
+            script {
+              def img_path
+              if (params.OCI_IMAGE_REF) {
+                def pullResult = readJSON(
+                  text: sh_ret_out("oras pull --format json -o '${TMP_IMG_DIR}' '${params.OCI_IMAGE_REF}'")
+                )
+                img_path = pullResult.files?.find { it.mediaType == IMAGE_MEDIA_TYPE }?.path
+                if (!img_path) {
+                  error("Unable to derive image file from OCI image '${params.OCI_IMAGE_REF}'")
+                }
+              } else {
+                img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
+              }
+              println "Downloaded image to workspace: ${img_path}"
+              if (params.USE_LEGACY_DD_FLASH) {
+                // Uncompress for the legacy dd flashing path.
+                if(img_path.endsWith(".zst")) {
+                  sh "zstd -dfv ${img_path}"
+                  // env.IMG_PATH stores the path to the uncompressed image
+                  env.IMG_PATH = img_path.substring(0, img_path.lastIndexOf('.'))
+                } else {
+                  env.IMG_PATH = img_path
+                }
+                println "Uncompressed image at: ${env.IMG_PATH}"
+              } else {
+                // flash-script handles .zst natively; pass the original download path.
+                env.FLASH_INPUT_PATH = img_path
+                println "Flash input: ${env.FLASH_INPUT_PATH}"
+              }
+            }
+          }
+        }
+        stage('Flash') {
+          when { expression { params && (params.IMG_URL || params.OCI_IMAGE_REF) } }
+          steps {
+            script {
+              // Mount the target disk
+              sh "${env.MOUNT_CMD}"
+              // Read the device name
+              def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
+              println "Checking that flash target '$dev' is connected..."
+              sh """
+                if /run/wrappers/bin/sudo test -f ${dev}; then
+                  echo "dev ${dev} found as regular file, removing the file and trying re-mount"
+                  ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
+                fi
+                if ! /run/wrappers/bin/sudo test -L ${dev}; then
+                  echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
+                  echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
+                  echo "Aborting flashing ${env.DEVICE_NAME}"
+                  exit 1
+                fi
+              """
+              if (params.USE_LEGACY_DD_FLASH) {
+                // Wipe possible ZFS leftovers, more details here:
+                // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
+                if(env.TARGET.contains("lenovo-x1")) {
+                  echo "Wiping filesystem..."
+                  def SECTOR = 512
+                  def MIB_TO_SECTORS = 20480
+                  // Disk size in 512-byte sectors
+                  def SECTORS = sh(script: "/run/wrappers/bin/sudo blockdev --getsz ${dev}", returnStdout: true).trim()
+                  // Unmount possible mounted filesystems
+                  sh "sync; /run/wrappers/bin/sudo umount -q ${dev}* || true"
+                  // Wipe first 10MiB of disk
+                  sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} conv=fsync status=none"
+                  // Wipe last 10MiB of disk
+                  sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} seek=\$(( ${SECTORS} - ${MIB_TO_SECTORS} )) conv=fsync status=none"
+                }
+                // Write the image
+                sh "/run/wrappers/bin/sudo dd if=${env.IMG_PATH} of=${dev} bs=1M status=progress conv=fsync"
+              } else {
+                if (env.FLASH_INPUT_PATH.endsWith('.raw')) {
+                  error("flash-script does not support '.raw' images. Enable USE_LEGACY_DD_FLASH to flash '${env.FLASH_INPUT_PATH}' with dd.")
+                }
+                def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+                if (!ghafFlakeRef) {
+                  if (params.OCI_IMAGE_REF) {
+                    error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
+                  }
+                  error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
+                }
+                println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
+                def flashScriptPath = sh_ret_out(
+                  "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
+                )
+                // flash-script validates /dev/sdX format; resolve the by-id symlink.
+                def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
+                sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
+              }
+              // Unmount
+              sh "${env.UNMOUNT_CMD}"
+              sh """
+                if /run/wrappers/bin/sudo test -L ${dev}; then
+                  echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
+                  exit 1
+                fi
+              """
+              currentBuild.description = "${currentBuild.description}<br>✅ Device flashed"
+            }
+          }
+        }
+        stage('Run Ghaf-installer') {
+          when { expression { env.TARGET.contains("installer") && !params.WIPE_ONLY } }
+          steps {
+            script {
+              sh "${env.UNMOUNT_CMD}"
+              println "Run ghaf-installer"
+              ghaf_robot_test('installer')
+              println "Disconnect SSD from the laptop"
+              sh "${env.MOUNT_CMD}"
+            }
+          }
+        }
+        stage('Boot test') {
+          when { expression { params && params.BOOT && !params.WIPE_ONLY } }
+          steps {
+            script {
+              ghaf_robot_test("relaybootAND${env.DEVICE_BOOT_TAG}")
+            }
+          }
+        }
+        stage('HW test') {
+          when { expression { env.BOOT_PASSED == 'true' && params.TEST_TAGS && !params.WIPE_ONLY } }
+          steps {
+            script {
+              ghaf_robot_test("${params.TEST_TAGS}")
+            }
+          }
+        }
+        stage('Wipe system') {
+          when { expression { env.TARGET.contains("installer")} }
+          steps {
+            script {
+              if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
+                ghaf_robot_test('break')
+              }
+              ghaf_robot_test('relay-turnoff')
+              println "Connect SSD to the laptop"
+              sh "${env.UNMOUNT_CMD}; sleep 10"
+              println "Wipe the internal memory of the laptop"
+              ghaf_robot_test('wiping')
+            }
+          }
+        }
+        stage('Turn off') {
+          when { expression { params && params.TURN_OFF } }
+          steps {
+            script {
+              ghaf_robot_test("relay-turnoff")
+            }
           }
         }
       }
-    }
-    stage('Image download') {
-      when { expression { params && params.IMG_URL } }
-      steps {
-        script {
-          def img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
-          println "Downloaded image to workspace: ${img_path}"
-          if (params.USE_LEGACY_DD_FLASH) {
-            // Uncompress for the legacy dd flashing path.
-            if(img_path.endsWith(".zst")) {
-              sh "zstd -dfv ${img_path}"
-              // env.IMG_PATH stores the path to the uncompressed image
-              env.IMG_PATH = img_path.substring(0, img_path.lastIndexOf('.'))
-            } else {
-              env.IMG_PATH = img_path
+      post {
+        always {
+          script {
+            if (env.ROBOT_EXECUTED != null) {
+              def test_artifacts = '' +
+                'Robot-Framework/test-suites/**/*.html, ' +
+                'Robot-Framework/test-suites/**/*.xml, ' +
+                'Robot-Framework/test-suites/**/*.png, ' +
+                'Robot-Framework/test-suites/**/*.jpeg, ' +
+                'Robot-Framework/test-suites/**/*.mp4, ' +
+                'Robot-Framework/test-suites/**/*.mkv, ' +
+                'Robot-Framework/test-suites/**/*.wav, ' +
+                'Robot-Framework/test-suites/**/*.txt'
+              archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
             }
-            println "Uncompressed image at: ${env.IMG_PATH}"
-          } else {
-            // flash-script handles .zst natively; pass the original download path.
-            env.FLASH_INPUT_PATH = img_path
-            println "Flash input: ${env.FLASH_INPUT_PATH}"
+            sh "rm -rf ${TMP_IMG_DIR} || true"
           }
         }
-      }
-    }
-    stage('Flash') {
-      when { expression { params && params.IMG_URL } }
-      steps {
-        script {
-          // Mount the target disk
-          sh "${env.MOUNT_CMD}"
-          // Read the device name
-          def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
-          println "Checking that flash target '$dev' is connected..."
-          sh """
-            if /run/wrappers/bin/sudo test -f ${dev}; then
-              echo "dev ${dev} found as regular file, removing the file and trying re-mount"
-              ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
-            fi
-            if ! /run/wrappers/bin/sudo test -L ${dev}; then
-              echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
-              echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
-              echo "Aborting flashing ${env.DEVICE_NAME}"
-              exit 1
-            fi
-          """
-          if (params.USE_LEGACY_DD_FLASH) {
-            // Wipe possible ZFS leftovers, more details here:
-            // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
-            if(params.IMG_URL.contains("lenovo-x1-")) {
-              echo "Wiping filesystem..."
-              def SECTOR = 512
-              def MIB_TO_SECTORS = 20480
-              // Disk size in 512-byte sectors
-              def SECTORS = sh(script: "/run/wrappers/bin/sudo blockdev --getsz ${dev}", returnStdout: true).trim()
-              // Unmount possible mounted filesystems
-              sh "sync; /run/wrappers/bin/sudo umount -q ${dev}* || true"
-              // Wipe first 10MiB of disk
-              sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} conv=fsync status=none"
-              // Wipe last 10MiB of disk
-              sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} seek=\$(( ${SECTORS} - ${MIB_TO_SECTORS} )) conv=fsync status=none"
-            }
-            // Write the image
-            sh "/run/wrappers/bin/sudo dd if=${env.IMG_PATH} of=${dev} bs=1M status=progress conv=fsync"
-          } else {
-            if (env.FLASH_INPUT_PATH.endsWith('.raw')) {
-              error("flash-script does not support '.raw' images. Enable USE_LEGACY_DD_FLASH to flash '${env.FLASH_INPUT_PATH}' with dd.")
-            }
-            def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL)
-            if (!ghafFlakeRef) {
-              error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
-            }
-            println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-            def flashScriptPath = sh_ret_out(
-              "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
-            )
-            // flash-script validates /dev/sdX format; resolve the by-id symlink.
-            def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
-            sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
-          }
-          // Unmount
-          sh "${env.UNMOUNT_CMD}"
-          sh """
-            if /run/wrappers/bin/sudo test -L ${dev}; then
-              echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
-              exit 1
-            fi
-          """
-          currentBuild.description = "${currentBuild.description}<br>✅ Device flashed"
-        }
-      }
-    }
-    stage('Run Ghaf-installer') {
-      when { expression { ( env.IMG_URL.contains("installer") || env.TARGET.contains("installer") ) && !params.WIPE_ONLY } }
-      steps {
-        script {
-          sh "${env.UNMOUNT_CMD}"
-          println "Run ghaf-installer"
-          ghaf_robot_test('installer')
-          println "Disconnect SSD from the laptop"
-          sh "${env.MOUNT_CMD}"
-        }
-      }
-    }
-    stage('Boot test') {
-      when { expression { params && params.BOOT && !params.WIPE_ONLY } }
-      steps {
-        script {
-          ghaf_robot_test("relaybootAND${env.DEVICE_BOOT_TAG}")
-        }
-      }
-    }
-    stage('HW test') {
-      when { expression { env.BOOT_PASSED == 'true' && params.TEST_TAGS && !params.WIPE_ONLY } }
-      steps {
-        script {
-          ghaf_robot_test("${params.TEST_TAGS}")
-        }
-      }
-    }
-    stage('Wipe system') {
-      when { expression { env.TARGET.contains("installer")} }
-      steps {
-        script {
-          if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
-            ghaf_robot_test('break')
-          }
-          ghaf_robot_test('relay-turnoff')
-          println "Connect SSD to the laptop"
-          sh "${env.UNMOUNT_CMD}; sleep 10"
-          println "Wipe the internal memory of the laptop"
-          ghaf_robot_test('wiping')
-        }
-      }
-    }
-    stage('Turn off') {
-      when { expression { params && params.TURN_OFF } }
-      steps {
-        script {
-          ghaf_robot_test("relay-turnoff")
-        }
-      }
-    }
-  }
-  post {
-    always {
-      script {
-        if (env.ROBOT_EXECUTED != null) {
-          def test_artifacts = '' +
-            'Robot-Framework/test-suites/**/*.html, ' +
-            'Robot-Framework/test-suites/**/*.xml, ' +
-            'Robot-Framework/test-suites/**/*.png, ' +
-            'Robot-Framework/test-suites/**/*.jpeg, ' +
-            'Robot-Framework/test-suites/**/*.mp4, ' +
-            'Robot-Framework/test-suites/**/*.mkv, ' +
-            'Robot-Framework/test-suites/**/*.wav, ' +
-            'Robot-Framework/test-suites/**/*.txt'
-          archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
-        }
-        sh "rm -rf ${TMP_IMG_DIR} || true"
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -1,13 +1,21 @@
 #!/usr/bin/env groovy
 
+import groovy.transform.Field
+
 // SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 // SPDX-License-Identifier: Apache-2.0
 
 ////////////////////////////////////////////////////////////////////////////////
 
-def TMP_IMG_DIR = './image'
-def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
-def CI_TEST_PINNED_SOURCE_FILE = '/etc/jenkins/ci-test-automation-pinned-source'
+@Field def TMP_IMG_DIR = './image'
+@Field def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
+@Field def CI_TEST_PINNED_SOURCE_FILE = '/etc/jenkins/ci-test-automation-pinned-source'
+@Field def IN_TOTO_MEDIA_TYPE = 'application/vnd.in-toto+json'
+@Field def DETACHED_SIGNATURE_MEDIA_TYPE = 'application/vnd.ghaf.signature.v1'
+@Field def IMAGE_MEDIA_TYPE = 'application/octet-stream'
+@Field def SOURCE_REF_ANNOTATION = 'org.ghaf.source.ref'
+@Field def TARGET_ANNOTATION = 'org.ghaf.target'
+@Field def SOURCE_REVISION_ANNOTATION = 'org.opencontainers.image.revision'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -20,8 +28,9 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
     ),
     string(name: 'CI_TEST_REPO_URL', defaultValue: 'https://github.com/tiiuae/ci-test-automation.git', description: 'Select ci-test-automation repository.'),
     string(name: 'CI_TEST_REPO_BRANCH', defaultValue: 'main', description: 'Select ci-test-automation branch to checkout.'),
+    string(name: 'OCI_IMAGE_REF', defaultValue: '', description: 'Published OCI image reference.'),
     string(name: 'IMG_URL', defaultValue: '', description: 'Target image url.'),
-    string(name: 'GHAF_FLAKE_REF', defaultValue: '', description: 'Pinned Ghaf flake reference for flash-script. If empty, derive from IMG_URL commit.'),
+    string(name: 'GHAF_FLAKE_REF', defaultValue: '', description: 'Pinned Ghaf flake reference for flash-script. If empty, derive it from OCI metadata or IMG_URL commit.'),
     string(name: 'TESTSET', defaultValue: '_relayboot_', description: 'Target testset, e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.'),
     string(name: 'TESTAGENT_HOST', defaultValue: null, description: 'Target testagent host, e.g.: dev, prod, release'),
     booleanParam(name: 'SECUREBOOT', defaultValue: false, description: 'Test on secure boot enabled hardware'),
@@ -38,46 +47,37 @@ def init() {
   if(!params || params.RELOAD_ONLY) {
     return 'built-in'
   }
-  if(params.IMG_URL.isEmpty() ) {
-    error("Missing IMG_URL parameter")
+  def ociImageRef = params.OCI_IMAGE_REF?.trim()
+  def imgUrl = params.IMG_URL?.trim()
+  env.OCI_TARGET = ''
+  env.OCI_SOURCE_REF = ''
+  env.OCI_IMAGE_REVISION = ''
+  if (ociImageRef) {
+    def annotations = readJSON(
+      text: sh_ret_out("oras manifest fetch --format json '${ociImageRef}'")
+    ).content?.annotations ?: [:]
+    env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
+    env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
+    env.OCI_IMAGE_REVISION = annotations[SOURCE_REVISION_ANNOTATION] ?: ''
   }
-  // Parse out the TARGET from the IMG_URL
-  def match = params.IMG_URL =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
-  if(match) {
-    env.TARGET = "${match.group(1)}"
-    match = null // https://stackoverflow.com/questions/40454558
-    println("Using TARGET: ${env.TARGET}")
-  } else {
+  if (!ociImageRef && !imgUrl) {
+    error("Missing OCI_IMAGE_REF or IMG_URL parameter")
+  }
+  env.TARGET = derive_target_name(imgUrl, env.OCI_TARGET)
+  if (!env.TARGET) {
+    if (ociImageRef) {
+      error("Unable to derive target name from OCI image '${ociImageRef}'")
+    }
     error("Unexpected IMG_URL: ${params.IMG_URL}")
   }
-  // Determine the device name
-  if(params.IMG_URL.contains("orin-agx-")) {
-    env.DEVICE_NAME = 'OrinAGX1'
-    env.DEVICE_TAG = 'orin-agx'
-  } else if(params.IMG_URL.contains("orin-agx64-")) {
-    env.DEVICE_NAME = 'OrinAGX64'
-    env.DEVICE_TAG = 'orin-agx-64'
-  } else if(params.IMG_URL.contains("orin-nx-")) {
-    env.DEVICE_NAME = 'OrinNX1'
-    env.DEVICE_TAG = 'orin-nx'
-  } else if(params.IMG_URL.contains("lenovo-x1-")) {
-    // we don't support running installer tests on secure boot hardware
-    if (params.SECUREBOOT && !params.IMG_URL.contains("installer")) {
-      env.DEVICE_NAME = 'X1-Secure-Boot'
-      env.DEVICE_TAG = 'x1-sec-boot'
-    } else {
-      env.DEVICE_NAME = 'LenovoX1-1'
-      env.DEVICE_TAG = 'lenovo-x1'
-    }
-  } else if(params.IMG_URL.contains("dell-latitude-7330-")) {
-    env.DEVICE_NAME = 'Dell7330'
-    env.DEVICE_TAG = 'dell-7330'
-  } else if(params.IMG_URL.contains("system76-darp11-b-")) {
-    env.DEVICE_NAME = 'DarterPRO'
-    env.DEVICE_TAG = 'darter-pro'
-  } else {
-    error("Unable to parse device config for image '${params.IMG_URL}'")
+  println("Using TARGET: ${env.TARGET}")
+
+  def deviceInfo = derive_device_info(env.TARGET, params.SECUREBOOT)
+  if (!deviceInfo) {
+    error("Unable to parse device config for target '${env.TARGET}'")
   }
+  env.DEVICE_NAME = deviceInfo.name
+  env.DEVICE_TAG = deviceInfo.tag
   println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
   println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
   // Determine additional test tags based on target
@@ -129,6 +129,12 @@ def sh_ret_out(String cmd) {
   return sh(script: cmd, returnStdout:true).trim()
 }
 
+def oras_pull_json(String reference, String outputDir) {
+  return readJSON(
+    text: sh_ret_out("oras pull --format json -o '${outputDir}' '${reference}'")
+  )
+}
+
 def run_wget(String url, String to_dir) {
   // Download `url` setting the directory prefix `to_dir` preserving
   // the hierarchy of directories locally.
@@ -136,6 +142,12 @@ def run_wget(String url, String to_dir) {
   // Re-run wget: this will not re-download anything, it's needed only to
   // get the local path to the downloaded file
   return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
+}
+
+@NonCPS
+def find_oci_pull_file(Map pullResult, String mediaType) {
+  def file = pullResult.files?.find { it.mediaType == mediaType }
+  return file?.path
 }
 
 @NonCPS
@@ -151,10 +163,82 @@ def split_img_url(String img_url) {
 }
 
 @NonCPS
-def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl) {
+def parse_oci_reference(String reference) {
+  def digestSeparator = reference.indexOf('@')
+  if (digestSeparator >= 0) {
+    return [
+      repository: reference.substring(0, digestSeparator),
+      tag: null,
+      digest: reference.substring(digestSeparator + 1),
+    ]
+  }
+
+  def tagSeparator = reference.lastIndexOf(':')
+  def lastSlash = reference.lastIndexOf('/')
+  if (tagSeparator > lastSlash) {
+    return [
+      repository: reference.substring(0, tagSeparator),
+      tag: reference.substring(tagSeparator + 1),
+      digest: null,
+    ]
+  }
+
+  return [
+    repository: reference,
+    tag: null,
+    digest: null,
+  ]
+}
+
+def derive_target_name(String imgUrl, String ociTarget) {
+  def normalizedTarget = ociTarget?.trim()
+  if (normalizedTarget) {
+    return normalizedTarget
+  }
+  if (!imgUrl) {
+    return null
+  }
+  def match = imgUrl =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
+  if (match) {
+    return match.group(1)
+  }
+  return null
+}
+
+@NonCPS
+def derive_device_info(String target, boolean secureboot) {
+  if (target.contains("nvidia-jetson-orin-agx64")) {
+    return [name: 'OrinAGX64', tag: 'orin-agx-64']
+  }
+  if (target.contains("nvidia-jetson-orin-agx")) {
+    return [name: 'OrinAGX1', tag: 'orin-agx']
+  }
+  if (target.contains("nvidia-jetson-orin-nx")) {
+    return [name: 'OrinNX1', tag: 'orin-nx']
+  }
+  if (target.contains("lenovo-x1")) {
+    if (secureboot && !target.contains("installer")) {
+      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
+    }
+    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
+  }
+  if (target.contains("dell-latitude-7330")) {
+    return [name: 'Dell7330', tag: 'dell-7330']
+  }
+  if (target.contains("system76-darp11-b")) {
+    return [name: 'DarterPRO', tag: 'darter-pro']
+  }
+  return null
+}
+
+def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
   def normalizedFlakeRef = explicitFlakeRef?.trim()
   if (normalizedFlakeRef) {
     return normalizedFlakeRef
+  }
+  def normalizedOciFlakeRef = ociFlakeRef?.trim()
+  if (normalizedOciFlakeRef) {
+    return normalizedOciFlakeRef
   }
   def match = imgUrl =~ /commit_([a-f0-9]{40})/
   if (match) {
@@ -191,7 +275,15 @@ def ghaf_robot_test(String testname='relayboot') {
   dir("Robot-Framework/test-suites") {
     sh 'rm -f *.txt *.png *.jpeg *.mp4 *.mkv *.wav output.xml report.html log.html'
     // On failure, continue the pipeline execution
-    env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
+    env.COMMIT_HASH = 'NONE'
+    if (env.OCI_IMAGE_REVISION ==~ /[a-f0-9]{40}/) {
+      env.COMMIT_HASH = env.OCI_IMAGE_REVISION
+    } else if (params.IMG_URL) {
+      def match = params.IMG_URL =~ /commit_([a-f0-9]{40})/
+      if (match) {
+        env.COMMIT_HASH = match[0][1]
+      }
+    }
     try {
       // Pass variables as environment variables to shell.
       // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
@@ -223,12 +315,13 @@ def ghaf_robot_test(String testname='relayboot') {
 ////////////////////////////////////////////////////////////////////////////////
 
 pipeline {
-  agent { label init() }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '1000'))
   }
   stages {
     stage('Set properties') {
+      agent { label 'built-in' }
       steps {
         script {
           properties([
@@ -238,6 +331,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -247,222 +341,272 @@ pipeline {
         }
       }
     }
-    stage('Checkout') {
+    stage('Initialize') {
+      agent { label 'built-in' }
       steps {
-        deleteDir()
         script {
-          if (params.USE_FLAKE_PINNED_CI_TEST) {
-            def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
-            println("Using flake-pinned ci-test-automation source: ${pinned_src}")
-            sh """
-              if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
-                echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
-                exit 1
-              fi
-              cp -r "${pinned_src}/." .
-              chmod -R u+w .
-            """
-          } else {
-            checkout scmGit(
-              branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
-              userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
-            )
+          env.TEST_AGENT_LABEL = init()
+        }
+      }
+    }
+    stage('Run on test agent') {
+      agent { label "${env.TEST_AGENT_LABEL}" }
+      stages {
+        stage('Checkout') {
+          steps {
+            deleteDir()
+            script {
+              if (params.USE_FLAKE_PINNED_CI_TEST) {
+                def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
+                println("Using flake-pinned ci-test-automation source: ${pinned_src}")
+                sh """
+                  if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
+                    echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
+                    exit 1
+                  fi
+                  cp -r "${pinned_src}/." .
+                  chmod -R u+w .
+                """
+              } else {
+                checkout scmGit(
+                  branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
+                  userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
+                )
+              }
+            }
+          }
+        }
+        stage('Setup') {
+          steps {
+            script {
+              env.TEST_CONFIG_DIR = 'Robot-Framework/config'
+              sh """
+                mkdir -p ${TEST_CONFIG_DIR}
+                rm -f ${TEST_CONFIG_DIR}/*.json
+                ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
+                echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+                ls -la ${TEST_CONFIG_DIR}
+              """
+            }
+          }
+        }
+        stage('Verify provenance') {
+          steps {
+            script {
+              def provenance_path
+              def sig_path
+              if (params.OCI_IMAGE_REF) {
+                def discovery = readJSON(
+                  text: sh_ret_out("oras discover --format json '${params.OCI_IMAGE_REF}'")
+                )
+                def referrer = discovery.referrers?.find { it.artifactType == IN_TOTO_MEDIA_TYPE }
+                def provenanceRef = referrer?.reference
+                if (!provenanceRef && referrer?.digest) {
+                  provenanceRef = "${parse_oci_reference(params.OCI_IMAGE_REF).repository}@${referrer.digest}"
+                }
+                if (!provenanceRef) {
+                  error("Unable to discover provenance referrer for OCI image '${params.OCI_IMAGE_REF}'")
+                }
+                def pullResult = oras_pull_json(provenanceRef, TMP_IMG_DIR)
+                provenance_path = find_oci_pull_file(pullResult, IN_TOTO_MEDIA_TYPE)
+                sig_path = find_oci_pull_file(pullResult, DETACHED_SIGNATURE_MEDIA_TYPE)
+                if (!provenance_path || !sig_path) {
+                  error("Unable to derive provenance files from OCI referrer '${provenanceRef}'")
+                }
+              } else {
+                def split = split_img_url(params.IMG_URL)
+                def artifacts_url = split["artifacts_url"]
+                def target = split["target_name"]
+                def provenance_url = "${artifacts_url}/${target}/attestations/provenance.json"
+                def signature_url = "${provenance_url}.sig"
+                println("provenance_url: ${provenance_url}")
+                provenance_path = run_wget(provenance_url, TMP_IMG_DIR)
+                sig_path = run_wget(signature_url, TMP_IMG_DIR)
+              }
+              sh "policy-checker ${provenance_path} --sig ${sig_path} --policy /etc/jenkins/provenance-trust-policy.yaml"
+            }
+          }
+        }
+        stage('Image download') {
+          steps {
+            script {
+              def img_path
+              def sig_path
+              if (params.OCI_IMAGE_REF) {
+                def pullResult = oras_pull_json(params.OCI_IMAGE_REF, TMP_IMG_DIR)
+                img_path = find_oci_pull_file(pullResult, IMAGE_MEDIA_TYPE)
+                sig_path = find_oci_pull_file(pullResult, DETACHED_SIGNATURE_MEDIA_TYPE)
+                if (!img_path || !sig_path) {
+                  error("Unable to derive image files from OCI image '${params.OCI_IMAGE_REF}'")
+                }
+              } else {
+                img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
+                def split = split_img_url(params.IMG_URL)
+                def artifacts_url = split["artifacts_url"]
+                def img_relpath = split["img_relpath"]
+                def target = split["target_name"]
+                def sig_url = "${artifacts_url}/${target}/${img_relpath}.sig"
+                sig_path = run_wget(sig_url, TMP_IMG_DIR)
+              }
+              println "Downloaded image to workspace: ${img_path}"
+              println "Downloaded SLSA signature file to workspace: ${sig_path}"
+              sh "verify-signature image ${img_path} ${sig_path}"
+              // flash-script handles .zst natively; pass the original download path.
+              env.FLASH_INPUT_PATH = img_path
+              println "Flash input: ${env.FLASH_INPUT_PATH}"
+            }
+          }
+        }
+        stage('Flash') {
+          steps {
+            script {
+              // Determine mount commands
+              if(env.TARGET.contains("microchip-icicle-")) {
+                def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
+                env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
+                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
+              } else {
+                def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
+                env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
+                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
+              }
+              // Mount the target disk
+              sh "${env.MOUNT_CMD}"
+              // Read the device name
+              def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
+              println "Checking that flash target '$dev' is connected..."
+              sh """
+                if /run/wrappers/bin/sudo test -f ${dev}; then
+                  echo "dev ${dev} found as regular file, removing the file and trying re-mount"
+                  ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
+                fi
+                if ! /run/wrappers/bin/sudo test -L ${dev}; then
+                  echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
+                  echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
+                  echo "Aborting flashing ${env.DEVICE_NAME}"
+                  exit 1
+                fi
+              """
+              def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+              if (!ghafFlakeRef) {
+                if (params.OCI_IMAGE_REF) {
+                  error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'")
+                }
+                error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'")
+              }
+              env.GHAF_FLAKE_REF = ghafFlakeRef
+              println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
+              def flashScriptPath = sh_ret_out(
+                "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
+              )
+              // flash-script validates /dev/sdX format; resolve the by-id symlink
+              def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
+              sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
+              // Unmount
+              sh "${env.UNMOUNT_CMD}"
+              sh """
+                if /run/wrappers/bin/sudo test -L ${dev}; then
+                  echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
+                  exit 1
+                fi
+              """
+            }
+          }
+        }
+        stage('Run Ghaf-installer') {
+          when { expression { env.TARGET.contains("installer") } }
+          steps {
+            script {
+              println "Run ghaf-installer"
+              ghaf_robot_test('installer')
+              println "Disconnect SSD from the laptop"
+              sh "${env.MOUNT_CMD}"
+            }
+          }
+        }
+        stage('Relay Boot test') {
+          when { expression { env.TESTSET.contains('_relayboot_')} }
+          steps {
+            script {
+              env.BOOT_PASSED = 'false'
+              ghaf_robot_test('relayboot')
+              println "Relay boot test passed: ${env.BOOT_PASSED}"
+            }
+          }
+        }
+        stage('Pre-merge test') {
+          when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_pre-merge_')} }
+          steps {
+            script {
+              ghaf_robot_test('pre-merge')
+            }
+          }
+        }
+        stage('Bat test') {
+          when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_bat_')} }
+          steps {
+            script {
+              ghaf_robot_test('bat')
+            }
+          }
+        }
+        stage('Regression test') {
+          when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_regression_')} }
+          steps {
+            script {
+              ghaf_robot_test('regression')
+            }
+          }
+        }
+        stage('Perf test') {
+          when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_perf_')} }
+          steps {
+            script {
+              ghaf_robot_test('performance')
+            }
+          }
+        }
+        stage('Wipe system') {
+          when { expression { env.TARGET.contains("installer")} }
+          steps {
+            script {
+              if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
+                ghaf_robot_test('break')
+              }
+              ghaf_robot_test('relay-turnoff')
+              println "Connect SSD to the laptop"
+              sh "${env.UNMOUNT_CMD}; sleep 10"
+              println "Wipe the internal memory of the laptop"
+              ghaf_robot_test('wiping')
+            }
+          }
+        }
+        stage('Relay Turn off') {
+          steps {
+            script {
+              ghaf_robot_test('relay-turnoff')
+            }
           }
         }
       }
-    }
-    stage('Setup') {
-      steps {
-        script {
-          env.TEST_CONFIG_DIR = 'Robot-Framework/config'
-          sh """
-            mkdir -p ${TEST_CONFIG_DIR}
-            rm -f ${TEST_CONFIG_DIR}/*.json
-            ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
-            echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
-            ls -la ${TEST_CONFIG_DIR}
-          """
-        }
-      }
-    }
-    stage('Verify provenance') {
-      steps {
-        script {
-          def split = split_img_url(params.IMG_URL)
-          def artifacts_url = split["artifacts_url"]
-          def target = split["target_name"]
-          def provenance_url = "${artifacts_url}/${target}/attestations/provenance.json"
-          def sig_url = "${provenance_url}.sig"
-          println("provenance_url: ${provenance_url}")
-          def provenance_path = run_wget(provenance_url, TMP_IMG_DIR)
-          def sig_path = run_wget(sig_url, TMP_IMG_DIR)
-          sh "policy-checker ${provenance_path} --sig ${sig_path} --policy /etc/jenkins/provenance-trust-policy.yaml"
-        }
-      }
-    }
-    stage('Image download') {
-      steps {
-        script {
-          def img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
-          println "Downloaded image to workspace: ${img_path}"
-          def split = split_img_url(params.IMG_URL)
-          def artifacts_url = split["artifacts_url"]
-          def img_relpath = split["img_relpath"]
-          def target = split["target_name"]
-          def sig_url = "${artifacts_url}/${target}/${img_relpath}.sig"
-          def sig_path = run_wget(sig_url, TMP_IMG_DIR)
-          println "Downloaded SLSA signature file to workspace: ${sig_path}"
-          sh "verify-signature image ${img_path} ${sig_path}"
-          // flash-script handles .zst natively; pass the original download path.
-          env.FLASH_INPUT_PATH = img_path
-          println "Flash input: ${env.FLASH_INPUT_PATH}"
-        }
-      }
-    }
-    stage('Flash') {
-      steps {
-        script {
-          // Determine mount commands
-          if(params.IMG_URL.contains("microchip-icicle-")) {
-            def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
-            env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
-            env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
-          } else {
-            def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
-            env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
-            env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
+      post {
+        always {
+          script {
+            if (env.BOOT_PASSED != null) {
+              def test_artifacts = '' +
+                'Robot-Framework/test-suites/**/*.html, ' +
+                'Robot-Framework/test-suites/**/*.xml, ' +
+                'Robot-Framework/test-suites/**/*.png, ' +
+                'Robot-Framework/test-suites/**/*.jpeg, ' +
+                'Robot-Framework/test-suites/**/*.mp4, ' +
+                'Robot-Framework/test-suites/**/*.mkv, ' +
+                'Robot-Framework/test-suites/**/*.wav, ' +
+                'Robot-Framework/test-suites/**/*.txt'
+              archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
+            }
+            sh "rm -rf ${TMP_IMG_DIR} || true"
           }
-          // Mount the target disk
-          sh "${env.MOUNT_CMD}"
-          // Read the device name
-          def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
-          println "Checking that flash target '$dev' is connected..."
-          sh """
-            if /run/wrappers/bin/sudo test -f ${dev}; then
-              echo "dev ${dev} found as regular file, removing the file and trying re-mount"
-              ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
-            fi
-            if ! /run/wrappers/bin/sudo test -L ${dev}; then
-              echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
-              echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
-              echo "Aborting flashing ${env.DEVICE_NAME}"
-              exit 1
-            fi
-          """
-          def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL)
-          if (!ghafFlakeRef) {
-            error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'")
-          }
-          println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-          def flashScriptPath = sh_ret_out(
-            "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
-          )
-          // flash-script validates /dev/sdX format; resolve the by-id symlink
-          def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
-          sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
-          // Unmount
-          sh "${env.UNMOUNT_CMD}"
-          sh """
-            if /run/wrappers/bin/sudo test -L ${dev}; then
-              echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
-              exit 1
-            fi
-          """
         }
-      }
-    }
-    stage('Run Ghaf-installer') {
-      when { expression { env.TARGET.contains("installer") } }
-      steps {
-        script {
-          println "Run ghaf-installer"
-          ghaf_robot_test('installer')
-          println "Disconnect SSD from the laptop"
-          sh "${env.MOUNT_CMD}"
-        }
-      }
-    }
-    stage('Relay Boot test') {
-      when { expression { env.TESTSET.contains('_relayboot_')} }
-      steps {
-        script {
-          env.BOOT_PASSED = 'false'
-          ghaf_robot_test('relayboot')
-          println "Relay boot test passed: ${env.BOOT_PASSED}"
-        }
-      }
-    }
-    stage('Pre-merge test') {
-      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_pre-merge_')} }
-      steps {
-        script {
-          ghaf_robot_test('pre-merge')
-        }
-      }
-    }
-    stage('Bat test') {
-      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_bat_')} }
-      steps {
-        script {
-          ghaf_robot_test('bat')
-        }
-      }
-    }
-    stage('Regression test') {
-      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_regression_')} }
-      steps {
-        script {
-          ghaf_robot_test('regression')
-        }
-      }
-    }
-    stage('Perf test') {
-      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_perf_')} }
-      steps {
-        script {
-          ghaf_robot_test('performance')
-        }
-      }
-    }
-    stage('Wipe system') {
-      when { expression { env.TARGET.contains("installer")} }
-      steps {
-        script {
-          if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
-            ghaf_robot_test('break')
-          }
-          ghaf_robot_test('relay-turnoff')
-          println "Connect SSD to the laptop"
-          sh "${env.UNMOUNT_CMD}; sleep 10"
-          println "Wipe the internal memory of the laptop"
-          ghaf_robot_test('wiping')
-        }
-      }
-    }
-    stage('Relay Turn off') {
-      steps {
-        script {
-          ghaf_robot_test('relay-turnoff')
-        }
-      }
-    }
-  }
-  post {
-    always {
-      script {
-        if (env.BOOT_PASSED != null) {
-          def test_artifacts = '' +
-            'Robot-Framework/test-suites/**/*.html, ' +
-            'Robot-Framework/test-suites/**/*.xml, ' +
-            'Robot-Framework/test-suites/**/*.png, ' +
-            'Robot-Framework/test-suites/**/*.jpeg, ' +
-            'Robot-Framework/test-suites/**/*.mp4, ' +
-            'Robot-Framework/test-suites/**/*.mkv, ' +
-            'Robot-Framework/test-suites/**/*.wav, ' +
-            'Robot-Framework/test-suites/**/*.txt'
-          archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
-        }
-        sh "rm -rf ${TMP_IMG_DIR} || true"
       }
     }
   }

--- a/hosts/hetzci/pipelines/modules/utils.groovy
+++ b/hosts/hetzci/pipelines/modules/utils.groovy
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
 import groovy.json.JsonOutput
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 def run_cmd(String cmd) {
   return sh(script: cmd, returnStdout:true).trim()
@@ -81,6 +82,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         repository: target_repo,
         ref: target_commit,
         revision: target_commit,
+        flake_ref: target_flake_ref,
       ],
       target: it.target,
       build: [
@@ -119,6 +121,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         ],
       ],
     ]
+    def oci_result = null
     if (it.no_image) {
       manifest.uefi.reason = "no_image"
     } else if (!signing_possible) {
@@ -319,41 +322,51 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
                   -t '${immutable_tag}' \
                   -o '${oci_result_json}'
               """
+              oci_result = readJSON file: oci_result_json
             }
           }
         }
       }
       // Test
       if (it.testset != null && !it.testset.isEmpty()) {
-        stage("Test ${shortname}") {
-          def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image.path}"
-          def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
-          def test_params = [
-              string(name: "IMG_URL", value: img_url),
-              string(name: "GHAF_FLAKE_REF", value: target_flake_ref),
-              string(name: "TESTSET", value: it.testset),
-              string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
-              string(name: "TESTAGENT_HOST", value: testagent_host),
-              booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
-              booleanParam(name: "RELOAD_ONLY", value: false),
-              booleanParam(name: "SECUREBOOT", value: false),
-          ]
-          def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
-            parameters: test_params
-          )
-          println("ghaf-hw-test log '${shortname}:")
-          sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
-          if (job.result != "SUCCESS") {
-            unstable("FAILED: ${shortname} ${it.testset}")
-            currentBuild.result = "FAILURE"
-            append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${shortname}</a>")
+        def testStageName = "Test ${shortname}"
+        stage(testStageName) {
+          if (env.CI_ENV == "vm") {
+            Utils.markStageSkippedForConditional(testStageName)
+            println("Skipping hardware tests for ${shortname}: CI_ENV is vm")
+          } else {
+            def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
+            def test_params = [
+                string(name: "TESTSET", value: it.testset),
+                string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
+                string(name: "TESTAGENT_HOST", value: testagent_host),
+                booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
+                booleanParam(name: "RELOAD_ONLY", value: false),
+                booleanParam(name: "SECUREBOOT", value: false),
+            ]
+            if (oci_result == null) {
+              error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
+            }
+            test_params += [
+              string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
+            ]
+            def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
+              parameters: test_params
+            )
+            println("ghaf-hw-test log '${shortname}:")
+            sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
+            if (job.result != "SUCCESS") {
+              unstable("FAILED: ${shortname} ${it.testset}")
+              currentBuild.result = "FAILURE"
+              append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${shortname}</a>")
+            }
+            copyArtifacts(
+              projectName: "ghaf-hw-test",
+              selector: specific("${job.number}"),
+              target: "${output}/test-results",
+              optional: true
+            )
           }
-          copyArtifacts(
-            projectName: "ghaf-hw-test",
-            selector: specific("${job.number}"),
-            target: "${output}/test-results",
-            optional: true
-          )
         }
         // Run an additional secure boot test only when the target requests it and
         // secure-boot-capable hardware is available in prod. X1 update tests
@@ -361,16 +374,20 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         // regular test run cannot be replaced with a secure boot-only run.
         if (it.test_secboot && manifest.uefi.signed && env.CI_ENV == "prod") {
           stage("Test SB ${shortname}") {
-            def img_url = "${env.JENKINS_URL}/${artifacts}/${it.target}/${manifest.image.path}"
             def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
             def test_params = [
-              string(name: "IMG_URL", value: img_url),
               string(name: "TESTSET", value: it.testset),
               string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
               string(name: "TESTAGENT_HOST", value: testagent_host),
               booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
               booleanParam(name: "RELOAD_ONLY", value: false),
               booleanParam(name: "SECUREBOOT", value: true)
+            ]
+            if (oci_result == null) {
+              error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
+            }
+            test_params += [
+              string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
             ]
             def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
               parameters: test_params

--- a/hosts/hetzci/vm/configuration.nix
+++ b/hosts/hetzci/vm/configuration.nix
@@ -32,6 +32,7 @@
       "ghaf-release-publish"
     ];
     withArchiveArtifacts = true;
+    withRegistryPublish = true;
     extraCasc = {
       jenkins.authorizationStrategy = "unsecured";
     };

--- a/hosts/hetzci/vm/secrets.yaml
+++ b/hosts/hetzci/vm/secrets.yaml
@@ -5,6 +5,7 @@ vedenemo_builder_ssh_key: ENC[AES256_GCM,data:w5iotEvbKgW1rM19DF9MWwENYFMXLel+kY
 cachix-auth-token: ENC[AES256_GCM,data:q1H1kWm+1qa9xII8NxUkp6RMjpf88JEvAKkmg4P84LW0/PwFppT70o37TBjCXH8lZvKN7+h9/gXrE8bLeSARYhWBXCJEritJ2ye/2W2/W3VcvY7P68naVCFp3mIWwzPWBxo9XBUc/9bFaqCapZsk5BR/uOuHJdIzJqze6jsVF1jlEJFCpnNfedMD3OwBq3/Z4a2BSYsL,iv:rrROigvVeQBe7+xkkMcAf0mHAPGDxMJwY/39GX92p8s=,tag:8rtcMtX6kW8b/EZXR/w8UA==,type:str]
 jenkins_archive_access_key: ENC[AES256_GCM,data:kwBhM+PrJwb/kbB9HbpAD1awBic=,iv:bgQhgOsqHFV89QeY0Daxz6QJEj/tgeKqSe52mOAjLQ4=,tag:2t+kRezzJ3Ilr5B2Bagqfw==,type:str]
 jenkins_archive_secret_key: ENC[AES256_GCM,data:etAtmEovP2QefEp/M+vgVj0MdzoqYw0DxOPnUen2QcrcU6EOl+8h0g==,iv:pbxe21PyYvpQoXhtipGOkxI75XzrvLxxUVPysjuykh0=,tag:hHdDhUMnszLFllaTXSKFIQ==,type:str]
+oci_registry_password: ENC[AES256_GCM,data:MENXsJ2DPohymwAjx9uY,iv:Xky9zuIYdUWa0znEUPwixat9lQFof34lVWEGM7E3KMs=,tag:pS7L8j877PmW4/5/pNwUSA==,type:str]
 sops:
     age:
         - recipient: age1lur2w9nehe2thcjrnddh554gygncs8dynv0fmr74sgytd69qqcdsr42d8j
@@ -61,7 +62,7 @@ sops:
             akNPdXppMzd2cGs2bzFha01WdnFIYXMKiVyKv6ZyrrxdlIv8unTPntUDOIe2rkIs
             zyI7rI0t+ux7SoW3Dbwcf1t+X5xdcPo5+UIJODDT9mZe53wNfv5W/w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-12-05T06:14:43Z"
-    mac: ENC[AES256_GCM,data:5+mDrQ4puwP4a5A1xpo+42MTrpZcQTN/pT9Cxp/YD14R5W23aejqbeSTguK57oakdDsLXIGQNFVok4QLm2KlxGBXqyVVxwMGSTSwTWkeXiw52x7cdSKo3cPhyPYQ3xiYEHxk79LljlJ0bTuB5V5i32eWaul/T9uGKpjZ+KBi6a8=,iv:pvx8u0tbF6om+3teanYszrWRtH+HRTZL7VmLmItsWQY=,tag:xbGCVZf8QQwNY9hnP9so/g==,type:str]
+    lastmodified: "2026-04-15T10:34:40Z"
+    mac: ENC[AES256_GCM,data:XQaja+/rLB5HOVKY1VOT/yaIhE57kVyMkavF3ZGrozzogchCzBRf/Jnfw0v0IaJlA8sfZyZSo3iVWozfW7krSn791+jAogQgKflEbJ6/rxZfwB7d0eIqS+6RN8yB8BS8qD8YYys2hFu9QZ5C7mU8QZV2xgFasM+lDtJpp7dW0HA=,iv:uMGCFOjVGEOJx39cacivrwh8JatQAiE/BxaFXCMhP5s=,tag:mDgBT/Sh1OQRlloii7/hKg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/hosts/testagent/agent.nix
+++ b/hosts/testagent/agent.nix
@@ -32,6 +32,7 @@ let
       ++ (with pkgs; [
         curl
         wget
+        oras
         jdk
         git
         bashInteractive

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -10,9 +10,21 @@
     let
       # Stubbed Jenkins specific classes so they don't prevent groovy from compiling
       # Add more classes here if they block compilation
-      jenkins-groovy-stubs = pkgs.writeText "stubs.groovy" ''
-        @interface NonCPS {}
-      '';
+      jenkins-groovy-stubs = pkgs.symlinkJoin {
+        name = "jenkins-groovy-stubs-src";
+        paths = [
+          (pkgs.writeTextDir "NonCPS.groovy" ''
+            @interface NonCPS {}
+          '')
+          (pkgs.writeTextDir "org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy" ''
+            package org.jenkinsci.plugins.pipeline.modeldefinition
+
+            class Utils {
+              static void markStageSkippedForConditional(String stageName) {}
+            }
+          '')
+        ];
+      };
 
       jenkins-groovy =
         pkgs.runCommand "jenkins-groovy-stubs"
@@ -23,7 +35,7 @@
           }
           ''
             mkdir -p "$out"
-            groovyc -d "$out" ${jenkins-groovy-stubs}
+            groovyc -d "$out" $(find ${jenkins-groovy-stubs} -name '*.groovy' -print)
           '';
 
       groovyc-check = pkgs.writeShellApplication {

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -28,6 +28,8 @@ REFERRER_MEDIA_TYPES = {
     "sbom_csv": "text/csv",
 }
 REPOSITORY_COMPONENT_PATTERN = re.compile(r"^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$")
+SOURCE_REF_ANNOTATION = "org.ghaf.source.ref"
+TARGET_ANNOTATION = "org.ghaf.target"
 
 
 def fail(message: str) -> NoReturn:
@@ -162,6 +164,14 @@ def publish_target_artifacts(
     image = manifest["image"]
     image_path = image["path"]
     image_signature = image["signature"]["path"]
+    source = manifest.get("source", {})
+    primary_annotations = {
+        "org.opencontainers.image.title": target,
+        "org.opencontainers.image.source": source.get("repository", ""),
+        "org.opencontainers.image.revision": source.get("revision", ""),
+        SOURCE_REF_ANNOTATION: source.get("flake_ref", ""),
+        TARGET_ANNOTATION: target,
+    }
 
     push_files = [f"{image_path}:application/octet-stream"]
     if image_signature:
@@ -171,7 +181,7 @@ def publish_target_artifacts(
         [
             "push",
             *common_args,
-            *annotation_args({"org.opencontainers.image.title": target}),
+            *annotation_args(primary_annotations),
             "--disable-path-validation",
             "--artifact-type",
             TARGET_ARTIFACT_TYPE,


### PR DESCRIPTION
- Refactor ghaf-hw-test and ghaf-hw-test-manual to accept OCI artifact reference instead of image url. Legacy IMG_URL still works for the time being to not break tester workflows.
- All relevant metadata is stored on the artifact as annotations, so no additional parameters are required. This keeps the OCI artifact as the single source of truth.
- Any testagent can run tests for any arbitrary OCI artifact, regardless of where it was built. In pipeline runs, the immutable sha256 digest of the artifact is used to make sure the artifact matches what was just built.
- To fetch the OCI manifest and read the target annotation and device, jenkins node context must be present. This requires building the init stage on built-in agent, before handing the testing stage over to the testagent. This required some heavy refactoring of the pipelines.