### PR TITLE
jenkins: refactor hw-test pipelines to use shared utils

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -45,6 +45,66 @@ def ghaf_flake_ref(String repo, String rev) {
   return "${normalizedRepo}${separator}rev=${rev}"
 }
 
+@NonCPS
+// Why NonCPS? Jenkins CPS does not handle regex matchers reliably.
+// See: https://stackoverflow.com/a/48465528
+def derive_target_name(String imgUrl, String ociTarget) {
+  def normalizedTarget = ociTarget?.trim()
+  if (normalizedTarget) {
+    return normalizedTarget
+  }
+  if (!imgUrl) {
+    return null
+  }
+  def match = imgUrl =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
+  if (match) {
+    return match.group(1)
+  }
+  return null
+}
+
+@NonCPS
+def derive_device_info(String target, boolean secureboot) {
+  if (target.contains("nvidia-jetson-orin-agx64")) {
+    return [name: 'OrinAGX64', tag: 'orin-agx-64']
+  }
+  if (target.contains("nvidia-jetson-orin-agx")) {
+    return [name: 'OrinAGX1', tag: 'orin-agx']
+  }
+  if (target.contains("nvidia-jetson-orin-nx")) {
+    return [name: 'OrinNX1', tag: 'orin-nx']
+  }
+  if (target.contains("lenovo-x1")) {
+    if (secureboot && !target.contains("installer")) {
+      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
+    }
+    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
+  }
+  if (target.contains("dell-latitude-7330")) {
+    return [name: 'Dell7330', tag: 'dell-7330']
+  }
+  if (target.contains("system76-darp11-b")) {
+    return [name: 'DarterPRO', tag: 'darter-pro']
+  }
+  return null
+}
+
+def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
+  def normalizedFlakeRef = explicitFlakeRef?.trim()
+  if (normalizedFlakeRef) {
+    return normalizedFlakeRef
+  }
+  def normalizedOciFlakeRef = ociFlakeRef?.trim()
+  if (normalizedOciFlakeRef) {
+    return normalizedOciFlakeRef
+  }
+  def match = imgUrl =~ /commit_([a-f0-9]{40})/
+  if (match) {
+    return "git+https://github.com/tiiuae/ghaf?rev=${match[0][1]}"
+  }
+  return null
+}
+
 def create_pipeline(List<Map> targets, String testagent_host = null, String target_flake_ref = null) {
   def pipeline = [:]
   def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -8,6 +8,44 @@ def run_cmd(String cmd) {
   return sh(script: cmd, returnStdout: true).trim()
 }
 
+def run_wget(String url, String to_dir) {
+  sh "wget --show-progress --progress=dot:giga --force-directories --timestamping -P ${to_dir} ${url}"
+  return run_cmd(
+    "wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'"
+  )
+}
+
+def get_test_conf_property(String file_path, String device, String property) {
+  def device_data = readJSON file: file_path
+  def property_data = "${device_data['addresses'][device][property]}"
+  println "Got device '${device}' property '${property}' value: '${property_data}'"
+  return property_data
+}
+
+def checkout_ci_test_sources(
+  String pinned_source_file,
+  boolean use_flake_pinned_ci_test,
+  String ci_test_repo_branch,
+  String ci_test_repo_url) {
+  if (use_flake_pinned_ci_test) {
+    def pinned_src = run_cmd("cat ${pinned_source_file}")
+    println("Using flake-pinned ci-test-automation source: ${pinned_src}")
+    sh """
+      if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
+        echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
+        exit 1
+      fi
+      cp -r "${pinned_src}/." .
+      chmod -R u+w .
+    """
+    return
+  }
+  checkout scmGit(
+    branches: [[name: ci_test_repo_branch]],
+    userRemoteConfigs: [[url: ci_test_repo_url]]
+  )
+}
+
 def path_basename(String path) {
   if (path == null) {
     return null
@@ -117,6 +155,22 @@ def extra_tag_suffix(String target, String deviceTag) {
 
 def boot_tag_for(String deviceTag) {
   return deviceTag == 'x1-sec-boot' ? 'lenovo-x1' : deviceTag
+}
+
+def archive_robot_artifacts(String tmp_img_dir, boolean should_archive) {
+  if (should_archive) {
+    def test_artifacts = '' +
+      'Robot-Framework/test-suites/**/*.html, ' +
+      'Robot-Framework/test-suites/**/*.xml, ' +
+      'Robot-Framework/test-suites/**/*.png, ' +
+      'Robot-Framework/test-suites/**/*.jpeg, ' +
+      'Robot-Framework/test-suites/**/*.mp4, ' +
+      'Robot-Framework/test-suites/**/*.mkv, ' +
+      'Robot-Framework/test-suites/**/*.wav, ' +
+      'Robot-Framework/test-suites/**/*.txt'
+    archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
+  }
+  sh "rm -rf ${tmp_img_dir} || true"
 }
 
 def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -173,6 +173,49 @@ def archive_robot_artifacts(String tmp_img_dir, boolean should_archive) {
   sh "rm -rf ${tmp_img_dir} || true"
 }
 
+def setup_mount_commands(String conf_file_path, String target, String device_name) {
+  if (target.contains("microchip-icicle-")) {
+    def muxport = get_test_conf_property(conf_file_path, device_name, 'usb_sd_mux_port')
+    return [
+      mount_cmd: "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10",
+      unmount_cmd: "/run/wrappers/bin/sudo usbsdmux ${muxport} dut",
+    ]
+  }
+  def serial = get_test_conf_property(conf_file_path, device_name, 'usbhub_serial')
+  return [
+    mount_cmd: "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10",
+    unmount_cmd: "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10",
+  ]
+}
+
+def resolve_flash_target(String conf_file_path, String device_name, String mount_cmd, String unmount_cmd) {
+  sh mount_cmd
+  def dev = get_test_conf_property(conf_file_path, device_name, 'ext_drive_by-id')
+  println "Checking that flash target '${dev}' is connected..."
+  sh """
+    if /run/wrappers/bin/sudo test -f ${dev}; then
+      echo "dev ${dev} found as regular file, removing the file and trying re-mount"
+      ${unmount_cmd}; /run/wrappers/bin/sudo rm ${dev}; ${mount_cmd}
+    fi
+    if ! /run/wrappers/bin/sudo test -L ${dev}; then
+      echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
+      echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
+      echo "Aborting flashing ${device_name}"
+      exit 1
+    fi
+  """
+  return dev
+}
+
+def assert_flash_target_unmounted(String dev) {
+  sh """
+    if /run/wrappers/bin/sudo test -L ${dev}; then
+      echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
+      exit 1
+    fi
+  """
+}
+
 def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
   def normalizedFlakeRef = explicitFlakeRef?.trim()
   if (normalizedFlakeRef) {

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -84,6 +84,19 @@ def ghaf_flake_ref(String repo, String rev) {
 }
 
 @NonCPS
+def device_catalog() {
+  return [
+    [target_substring: "nvidia-jetson-orin-agx64", name: 'OrinAGX64', tag: 'orin-agx-64'],
+    [target_substring: "nvidia-jetson-orin-agx", name: 'OrinAGX1', tag: 'orin-agx'],
+    [target_substring: "nvidia-jetson-orin-nx", name: 'OrinNX1', tag: 'orin-nx'],
+    [target_substring: "lenovo-x1", name: 'LenovoX1-1', tag: 'lenovo-x1'],
+    [target_substring: null, name: 'X1-Secure-Boot', tag: 'x1-sec-boot'],
+    [target_substring: "dell-latitude-7330", name: 'Dell7330', tag: 'dell-7330'],
+    [target_substring: "system76-darp11-b", name: 'DarterPRO', tag: 'darter-pro'],
+  ]
+}
+
+@NonCPS
 // Why NonCPS? Jenkins CPS does not handle regex matchers reliably.
 // See: https://stackoverflow.com/a/48465528
 def derive_target_name(String imgUrl, String ociTarget) {
@@ -103,42 +116,23 @@ def derive_target_name(String imgUrl, String ociTarget) {
 
 @NonCPS
 def derive_device_info(String target, boolean secureboot) {
-  if (target.contains("nvidia-jetson-orin-agx64")) {
-    return [name: 'OrinAGX64', tag: 'orin-agx-64']
-  }
-  if (target.contains("nvidia-jetson-orin-agx")) {
-    return [name: 'OrinAGX1', tag: 'orin-agx']
-  }
-  if (target.contains("nvidia-jetson-orin-nx")) {
-    return [name: 'OrinNX1', tag: 'orin-nx']
-  }
+  def devices = device_catalog()
   if (target.contains("lenovo-x1")) {
     if (secureboot && !target.contains("installer")) {
-      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
+      def securebootDevice = devices.find { it.tag == 'x1-sec-boot' }
+      return securebootDevice ? [name: securebootDevice.name, tag: securebootDevice.tag] : null
     }
-    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
   }
-  if (target.contains("dell-latitude-7330")) {
-    return [name: 'Dell7330', tag: 'dell-7330']
-  }
-  if (target.contains("system76-darp11-b")) {
-    return [name: 'DarterPRO', tag: 'darter-pro']
+  def device = devices.find { it.target_substring && target.contains(it.target_substring) }
+  if (device) {
+    return [name: device.name, tag: device.tag]
   }
   return null
 }
 
 @NonCPS
 def device_name_from_tag(String deviceTag) {
-  def deviceInfo = [
-    'orin-agx': 'OrinAGX1',
-    'orin-agx-64': 'OrinAGX64',
-    'orin-nx': 'OrinNX1',
-    'lenovo-x1': 'LenovoX1-1',
-    'x1-sec-boot': 'X1-Secure-Boot',
-    'dell-7330': 'Dell7330',
-    'darter-pro': 'DarterPRO',
-  ]
-  return deviceInfo[deviceTag]
+  return device_catalog().find { it.tag == deviceTag }?.name
 }
 
 def extra_tag_suffix(String target, String deviceTag) {
@@ -216,6 +210,9 @@ def assert_flash_target_unmounted(String dev) {
   """
 }
 
+@NonCPS
+// Why NonCPS? Jenkins CPS does not handle regex matchers reliably.
+// See: https://stackoverflow.com/a/48465528
 def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
   def normalizedFlakeRef = explicitFlakeRef?.trim()
   if (normalizedFlakeRef) {
@@ -230,6 +227,49 @@ def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFla
     return "git+https://github.com/tiiuae/ghaf?rev=${match[0][1]}"
   }
   return null
+}
+
+def trigger_hw_test(
+  String shortname,
+  String testset,
+  String testagent_host,
+  Map oci_result,
+  String output,
+  boolean secureboot) {
+  def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
+  def test_params = [
+    string(name: "TESTSET", value: testset),
+    string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
+    string(name: "TESTAGENT_HOST", value: testagent_host),
+    booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
+    booleanParam(name: "RELOAD_ONLY", value: false),
+    booleanParam(name: "SECUREBOOT", value: secureboot),
+  ]
+  if (oci_result == null) {
+    error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
+  }
+  test_params += [
+    string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
+  ]
+  def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
+    parameters: test_params
+  )
+  def logPrefix = secureboot ? "ghaf-hw-test log SB '${shortname}:" : "ghaf-hw-test log '${shortname}:"
+  println(logPrefix)
+  sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
+  if (job.result != "SUCCESS") {
+    unstable("FAILED: ${shortname} ${testset}")
+    currentBuild.result = "FAILURE"
+    def buildDescriptionName = secureboot ? "${shortname} (SB)" : shortname
+    append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${buildDescriptionName}</a>")
+  }
+  def artifactsTarget = secureboot ? "${output}/test-results/secureboot" : "${output}/test-results"
+  copyArtifacts(
+    projectName: "ghaf-hw-test",
+    selector: specific("${job.number}"),
+    target: artifactsTarget,
+    optional: true
+  )
 }
 
 def create_pipeline(List<Map> targets, String testagent_host = null, String target_flake_ref = null) {
@@ -523,37 +563,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             Utils.markStageSkippedForConditional(testStageName)
             println("Skipping hardware tests for ${shortname}: CI_ENV is vm")
           } else {
-            def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
-            def test_params = [
-                string(name: "TESTSET", value: it.testset),
-                string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
-                string(name: "TESTAGENT_HOST", value: testagent_host),
-                booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
-                booleanParam(name: "RELOAD_ONLY", value: false),
-                booleanParam(name: "SECUREBOOT", value: false),
-            ]
-            if (oci_result == null) {
-              error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
-            }
-            test_params += [
-              string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
-            ]
-            def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
-              parameters: test_params
-            )
-            println("ghaf-hw-test log '${shortname}:")
-            sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
-            if (job.result != "SUCCESS") {
-              unstable("FAILED: ${shortname} ${it.testset}")
-              currentBuild.result = "FAILURE"
-              append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${shortname}</a>")
-            }
-            copyArtifacts(
-              projectName: "ghaf-hw-test",
-              selector: specific("${job.number}"),
-              target: "${output}/test-results",
-              optional: true
-            )
+            trigger_hw_test(shortname, it.testset, testagent_host, oci_result, output, false)
           }
         }
         // Run an additional secure boot test only when the target requests it and
@@ -562,37 +572,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         // regular test run cannot be replaced with a secure boot-only run.
         if (it.test_secboot && manifest.uefi.signed && env.CI_ENV == "prod") {
           stage("Test SB ${shortname}") {
-            def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
-            def test_params = [
-              string(name: "TESTSET", value: it.testset),
-              string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
-              string(name: "TESTAGENT_HOST", value: testagent_host),
-              booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: env.CI_ENV == "release"),
-              booleanParam(name: "RELOAD_ONLY", value: false),
-              booleanParam(name: "SECUREBOOT", value: true)
-            ]
-            if (oci_result == null) {
-              error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
-            }
-            test_params += [
-              string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
-            ]
-            def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
-              parameters: test_params
-            )
-            println("ghaf-hw-test log SB '${shortname}:")
-            sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
-            if (job.result != "SUCCESS") {
-              unstable("FAILED: ${shortname} ${it.testset}")
-              currentBuild.result = "FAILURE"
-              append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${shortname} (SB)</a>")
-            }
-            copyArtifacts(
-              projectName: "ghaf-hw-test",
-              selector: specific("${job.number}"),
-              target: "${output}/test-results/secureboot",
-              optional: true
-            )
+            trigger_hw_test(shortname, it.testset, testagent_host, oci_result, output, true)
           }
         }
       }

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -89,6 +89,36 @@ def derive_device_info(String target, boolean secureboot) {
   return null
 }
 
+@NonCPS
+def device_name_from_tag(String deviceTag) {
+  def deviceInfo = [
+    'orin-agx': 'OrinAGX1',
+    'orin-agx-64': 'OrinAGX64',
+    'orin-nx': 'OrinNX1',
+    'lenovo-x1': 'LenovoX1-1',
+    'x1-sec-boot': 'X1-Secure-Boot',
+    'dell-7330': 'Dell7330',
+    'darter-pro': 'DarterPRO',
+  ]
+  return deviceInfo[deviceTag]
+}
+
+def extra_tag_suffix(String target, String deviceTag) {
+  def filters = []
+  if (target.contains("lenovo-x1") || target.contains("darp11-b")) {
+    filters.add(target.contains("storeDisk") ? 'NOTexcl-storeDisk' : 'NOTstoreDisk-only')
+    filters.add(target.contains("installer") ? 'NOTexcl-installer' : 'NOTinstaller-only')
+  }
+  if (target.contains("lenovo-x1")) {
+    filters.add(deviceTag == 'x1-sec-boot' ? 'NOTexcl-secboot' : 'NOTsecboot-only')
+  }
+  return filters.unique().join('')
+}
+
+def boot_tag_for(String deviceTag) {
+  return deviceTag == 'x1-sec-boot' ? 'lenovo-x1' : deviceTag
+}
+
 def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
   def normalizedFlakeRef = explicitFlakeRef?.trim()
   if (normalizedFlakeRef) {

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -113,7 +113,7 @@ def init() {
   env.OCI_SOURCE_REF = ''
   if (params.OCI_IMAGE_REF) {
     def annotations = readJSON(
-      text: sh_ret_out("oras manifest fetch --format json '${params.OCI_IMAGE_REF}'")
+      text: utils.run_cmd("oras manifest fetch --format json '${params.OCI_IMAGE_REF}'")
     ).content?.annotations ?: [:]
     env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
     env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
@@ -144,28 +144,6 @@ def init() {
     error("No test agents online")
   }
   return label
-}
-
-def sh_ret_out(String cmd) {
-  // Run cmd returning stdout
-  return sh(script: cmd, returnStdout:true).trim()
-}
-
-def run_wget(String url, String to_dir) {
-  // Download `url` setting the directory prefix `to_dir` preserving
-  // the hierarchy of directories locally.
-  sh "wget --show-progress --progress=dot:giga --force-directories --timestamping -P ${to_dir} ${url}"
-  // Re-run wget: this will not re-download anything, it's needed only to
-  // get the local path to the downloaded file
-  return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
-}
-
-def get_test_conf_property(String file_path, String device, String property) {
-  // Get the requested device property data from test_config.json file
-  def device_data = readJSON file: file_path
-  def property_data = "${device_data['addresses'][device][property]}"
-  println "Got device '${device}' property '${property}' value: '${property_data}'"
-  return property_data
 }
 
 def ghaf_robot_test(String tags) {
@@ -267,23 +245,12 @@ pipeline {
           steps {
             deleteDir()
             script {
-              if (params.USE_FLAKE_PINNED_CI_TEST) {
-                def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
-                println("Using flake-pinned ci-test-automation source: ${pinned_src}")
-                sh """
-                  if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
-                    echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
-                    exit 1
-                  fi
-                  cp -r "${pinned_src}/." .
-                  chmod -R u+w .
-                """
-              } else {
-                checkout scmGit(
-                  branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
-                  userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
-                )
-              }
+              utils.checkout_ci_test_sources(
+                CI_TEST_PINNED_SOURCE_FILE,
+                params.USE_FLAKE_PINNED_CI_TEST,
+                params.CI_TEST_REPO_BRANCH,
+                params.CI_TEST_REPO_URL
+              )
             }
           }
         }
@@ -300,11 +267,11 @@ pipeline {
               """
               // Determine mount commands
               if(env.TARGET.contains("microchip-icicle-")) {
-                def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
+                def muxport = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
                 env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
                 env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
               } else {
-                def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
+                def serial = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
                 env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
                 env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
               }
@@ -318,14 +285,14 @@ pipeline {
               def img_path
               if (params.OCI_IMAGE_REF) {
                 def pullResult = readJSON(
-                  text: sh_ret_out("oras pull --format json -o '${TMP_IMG_DIR}' '${params.OCI_IMAGE_REF}'")
+                  text: utils.run_cmd("oras pull --format json -o '${TMP_IMG_DIR}' '${params.OCI_IMAGE_REF}'")
                 )
                 img_path = pullResult.files?.find { it.mediaType == IMAGE_MEDIA_TYPE }?.path
                 if (!img_path) {
                   error("Unable to derive image file from OCI image '${params.OCI_IMAGE_REF}'")
                 }
               } else {
-                img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
+                img_path = utils.run_wget(params.IMG_URL, TMP_IMG_DIR)
               }
               println "Downloaded image to workspace: ${img_path}"
               if (params.USE_LEGACY_DD_FLASH) {
@@ -353,7 +320,7 @@ pipeline {
               // Mount the target disk
               sh "${env.MOUNT_CMD}"
               // Read the device name
-              def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
+              def dev = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
               println "Checking that flash target '$dev' is connected..."
               sh """
                 if /run/wrappers/bin/sudo test -f ${dev}; then
@@ -397,11 +364,11 @@ pipeline {
                   error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
                 }
                 println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-                def flashScriptPath = sh_ret_out(
+                def flashScriptPath = utils.run_cmd(
                   "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
                 )
                 // flash-script validates /dev/sdX format; resolve the by-id symlink.
-                def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
+                def resolved_dev = utils.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
                 sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
               }
               // Unmount
@@ -471,19 +438,7 @@ pipeline {
       post {
         always {
           script {
-            if (env.ROBOT_EXECUTED != null) {
-              def test_artifacts = '' +
-                'Robot-Framework/test-suites/**/*.html, ' +
-                'Robot-Framework/test-suites/**/*.xml, ' +
-                'Robot-Framework/test-suites/**/*.png, ' +
-                'Robot-Framework/test-suites/**/*.jpeg, ' +
-                'Robot-Framework/test-suites/**/*.mp4, ' +
-                'Robot-Framework/test-suites/**/*.mkv, ' +
-                'Robot-Framework/test-suites/**/*.wav, ' +
-                'Robot-Framework/test-suites/**/*.txt'
-              archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
-            }
-            sh "rm -rf ${TMP_IMG_DIR} || true"
+            utils.archive_robot_artifacts(TMP_IMG_DIR, env.ROBOT_EXECUTED != null)
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 
+@Library('ghafInfra') _
+
 import groovy.transform.Field
 
 // SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
@@ -117,7 +119,7 @@ def init() {
     env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
     env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
   }
-  def flashTarget = derive_target_name(params.IMG_URL, env.OCI_TARGET)
+  def flashTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
   def deviceMap = [
     "orin-agx"           : [name: 'OrinAGX1'],
     "orin-agx-64"        : [name: 'OrinAGX64'],
@@ -128,7 +130,7 @@ def init() {
     "x1-sec-boot"        : [name: 'X1-Secure-Boot']
   ]
   if (flashTarget) {
-    def deviceInfo = derive_device_info(flashTarget, params.SECUREBOOT)
+    def deviceInfo = utils.derive_device_info(flashTarget, params.SECUREBOOT)
     if (deviceInfo) {
       env.DEVICE_NAME = deviceInfo.name
       env.DEVICE_TAG = deviceInfo.tag
@@ -176,63 +178,6 @@ def run_wget(String url, String to_dir) {
   // Re-run wget: this will not re-download anything, it's needed only to
   // get the local path to the downloaded file
   return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
-}
-
-def derive_target_name(String imgUrl, String ociTarget) {
-  def normalizedTarget = ociTarget?.trim()
-  if (normalizedTarget) {
-    return normalizedTarget
-  }
-  if (!imgUrl) {
-    return null
-  }
-  def match = imgUrl =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
-  if (match) {
-    return match.group(1)
-  }
-  return null
-}
-
-@NonCPS
-def derive_device_info(String target, boolean secureboot) {
-  if (target.contains("nvidia-jetson-orin-agx64")) {
-    return [name: 'OrinAGX64', tag: 'orin-agx-64']
-  }
-  if (target.contains("nvidia-jetson-orin-agx")) {
-    return [name: 'OrinAGX1', tag: 'orin-agx']
-  }
-  if (target.contains("nvidia-jetson-orin-nx")) {
-    return [name: 'OrinNX1', tag: 'orin-nx']
-  }
-  if (target.contains("lenovo-x1")) {
-    if (secureboot && !target.contains("installer")) {
-      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
-    }
-    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
-  }
-  if (target.contains("dell-latitude-7330")) {
-    return [name: 'Dell7330', tag: 'dell-7330']
-  }
-  if (target.contains("system76-darp11-b")) {
-    return [name: 'DarterPRO', tag: 'darter-pro']
-  }
-  return null
-}
-
-def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
-  def normalizedFlakeRef = explicitFlakeRef?.trim()
-  if (normalizedFlakeRef) {
-    return normalizedFlakeRef
-  }
-  def normalizedOciFlakeRef = ociFlakeRef?.trim()
-  if (normalizedOciFlakeRef) {
-    return normalizedOciFlakeRef
-  }
-  def match = imgUrl =~ /commit_([a-f0-9]{40})/
-  if (match) {
-    return "git+https://github.com/tiiuae/ghaf?rev=${match[0][1]}"
-  }
-  return null
 }
 
 def get_test_conf_property(String file_path, String device, String property) {
@@ -346,7 +291,7 @@ pipeline {
           steps {
             script {
               env.TARGET = env.DEVICE_TAG
-              def explicitTarget = derive_target_name(params.IMG_URL, env.OCI_TARGET)
+              def explicitTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
               if (explicitTarget) {
                 env.TARGET = explicitTarget
               } else {
@@ -456,7 +401,7 @@ pipeline {
                 if (env.FLASH_INPUT_PATH.endsWith('.raw')) {
                   error("flash-script does not support '.raw' images. Enable USE_LEGACY_DD_FLASH to flash '${env.FLASH_INPUT_PATH}' with dd.")
                 }
-                def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+                def ghafFlakeRef = utils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
                 if (!ghafFlakeRef) {
                   if (params.OCI_IMAGE_REF) {
                     error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -265,16 +265,9 @@ pipeline {
                 echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}
               """
-              // Determine mount commands
-              if(env.TARGET.contains("microchip-icicle-")) {
-                def muxport = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
-                env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
-                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
-              } else {
-                def serial = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
-                env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
-                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
-              }
+              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TARGET, env.DEVICE_NAME)
+              env.MOUNT_CMD = mountCommands.mount_cmd
+              env.UNMOUNT_CMD = mountCommands.unmount_cmd
             }
           }
         }
@@ -317,23 +310,7 @@ pipeline {
           when { expression { params && (params.IMG_URL || params.OCI_IMAGE_REF) } }
           steps {
             script {
-              // Mount the target disk
-              sh "${env.MOUNT_CMD}"
-              // Read the device name
-              def dev = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
-              println "Checking that flash target '$dev' is connected..."
-              sh """
-                if /run/wrappers/bin/sudo test -f ${dev}; then
-                  echo "dev ${dev} found as regular file, removing the file and trying re-mount"
-                  ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
-                fi
-                if ! /run/wrappers/bin/sudo test -L ${dev}; then
-                  echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
-                  echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
-                  echo "Aborting flashing ${env.DEVICE_NAME}"
-                  exit 1
-                fi
-              """
+              def dev = utils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
               if (params.USE_LEGACY_DD_FLASH) {
                 // Wipe possible ZFS leftovers, more details here:
                 // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
@@ -373,12 +350,7 @@ pipeline {
               }
               // Unmount
               sh "${env.UNMOUNT_CMD}"
-              sh """
-                if /run/wrappers/bin/sudo test -L ${dev}; then
-                  echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
-                  exit 1
-                fi
-              """
+              utils.assert_flash_target_unmounted(dev)
               currentBuild.description = "${currentBuild.description}<br>✅ Device flashed"
             }
           }

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -106,7 +106,6 @@ properties([
 ////////////////////////////////////////////////////////////////////////////////
 
 def init() {
-  println(params)
   if(!params || params.RELOAD_ONLY) {
     return 'built-in'
   }
@@ -120,45 +119,26 @@ def init() {
     env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
   }
   def flashTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
-  def deviceMap = [
-    "orin-agx"           : [name: 'OrinAGX1'],
-    "orin-agx-64"        : [name: 'OrinAGX64'],
-    "orin-nx"            : [name: 'OrinNX1'],
-    "dell-7330"          : [name: 'Dell7330'],
-    "darter-pro"         : [name: 'DarterPRO'],
-    "lenovo-x1"          : [name: 'LenovoX1-1'],
-    "x1-sec-boot"        : [name: 'X1-Secure-Boot']
-  ]
+  def deviceInfo = null
   if (flashTarget) {
-    def deviceInfo = utils.derive_device_info(flashTarget, params.SECUREBOOT)
-    if (deviceInfo) {
-      env.DEVICE_NAME = deviceInfo.name
-      env.DEVICE_TAG = deviceInfo.tag
+    deviceInfo = utils.derive_device_info(flashTarget, params.SECUREBOOT)
+    if (!deviceInfo) {
+      error("Unable to parse device config for target '${flashTarget}'")
     }
   }
-  if ((params.IMG_URL || params.OCI_IMAGE_REF) && params.DEVICE_TAG) {
-    env.DEVICE_TAG = params.DEVICE_TAG
-    env.DEVICE_NAME = deviceMap[env.DEVICE_TAG].name
+  if (params.DEVICE_TAG) {
+    def deviceName = utils.device_name_from_tag(params.DEVICE_TAG)
+    if (!deviceName) {
+      error("Unknown DEVICE_TAG '${params.DEVICE_TAG}'")
+    }
+    deviceInfo = [name: deviceName, tag: params.DEVICE_TAG]
   }
-  if (!env.DEVICE_TAG || env.DEVICE_TAG == null) {
+  if (!deviceInfo) {
     error("DEVICE_TAG is not defined and could not be derived from IMG_URL '${params.IMG_URL}', OCI_IMAGE_REF '${params.OCI_IMAGE_REF}', or explicit DEVICE_TAG")
   }
-  if ((!params.IMG_URL && !params.OCI_IMAGE_REF) || params.DEVICE_TAG) {
-    env.DEVICE_NAME = deviceMap[env.DEVICE_TAG].name
-  }
-  def label = env.DEVICE_TAG
-  if (params.TESTAGENT_HOST) {
-    label = "${params.TESTAGENT_HOST}-${env.DEVICE_TAG}"
-  }
-  println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
-  println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
-  currentBuild.description = "${label}"
-
-  if (env.DEVICE_TAG == "x1-sec-boot") {
-    env.DEVICE_BOOT_TAG = "lenovo-x1"
-  } else {
-    env.DEVICE_BOOT_TAG = env.DEVICE_TAG
-  }
+  env.DEVICE_NAME = deviceInfo.name
+  env.DEVICE_TAG = deviceInfo.tag
+  def label = params.TESTAGENT_HOST ? "${params.TESTAGENT_HOST}-${env.DEVICE_TAG}" : env.DEVICE_TAG
   def testagent_nodes = nodesByLabel(label: label, offline: false)
   if (!testagent_nodes) {
     error("No test agents online")
@@ -263,6 +243,26 @@ pipeline {
     stage('Run on test agent') {
       agent { label "${env.TEST_AGENT_LABEL}" }
       stages {
+        stage('Resolve target') {
+          steps {
+            script {
+              def explicitTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
+              def jobSelector = params.JOB_SELECTOR?.trim()
+              if (explicitTarget) {
+                env.TARGET = explicitTarget
+              } else if (jobSelector) {
+                env.TARGET = jobSelector
+              } else {
+                env.TARGET = env.DEVICE_TAG
+              }
+              env.DEVICE_BOOT_TAG = utils.boot_tag_for(env.DEVICE_TAG)
+              currentBuild.description = "${env.TEST_AGENT_LABEL}"
+              println("Using TARGET: ${env.TARGET}")
+              println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
+              println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
+            }
+          }
+        }
         stage('Checkout') {
           steps {
             deleteDir()
@@ -290,18 +290,6 @@ pipeline {
         stage('Setup') {
           steps {
             script {
-              env.TARGET = env.DEVICE_TAG
-              def explicitTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
-              if (explicitTarget) {
-                env.TARGET = explicitTarget
-              } else {
-                def sel = params.JOB_SELECTOR
-                if (!sel) {
-                  env.TARGET = env.DEVICE_TAG
-                } else {
-                  env.TARGET = sel
-                }
-              }
               env.TEST_CONFIG_DIR = 'Robot-Framework/config'
               sh """
                 mkdir -p ${TEST_CONFIG_DIR}

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -1,5 +1,7 @@
 #!/usr/bin/env groovy
 
+@Library('ghafInfra') _
+
 import groovy.transform.Field
 
 // SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
@@ -63,7 +65,7 @@ def init() {
   if (!ociImageRef && !imgUrl) {
     error("Missing OCI_IMAGE_REF or IMG_URL parameter")
   }
-  env.TARGET = derive_target_name(imgUrl, env.OCI_TARGET)
+  env.TARGET = utils.derive_target_name(imgUrl, env.OCI_TARGET)
   if (!env.TARGET) {
     if (ociImageRef) {
       error("Unable to derive target name from OCI image '${ociImageRef}'")
@@ -72,7 +74,7 @@ def init() {
   }
   println("Using TARGET: ${env.TARGET}")
 
-  def deviceInfo = derive_device_info(env.TARGET, params.SECUREBOOT)
+  def deviceInfo = utils.derive_device_info(env.TARGET, params.SECUREBOOT)
   if (!deviceInfo) {
     error("Unable to parse device config for target '${env.TARGET}'")
   }
@@ -188,63 +190,6 @@ def parse_oci_reference(String reference) {
     tag: null,
     digest: null,
   ]
-}
-
-def derive_target_name(String imgUrl, String ociTarget) {
-  def normalizedTarget = ociTarget?.trim()
-  if (normalizedTarget) {
-    return normalizedTarget
-  }
-  if (!imgUrl) {
-    return null
-  }
-  def match = imgUrl =~ /commit_[0-9a-f]{5,40}\/([^\/]+)/
-  if (match) {
-    return match.group(1)
-  }
-  return null
-}
-
-@NonCPS
-def derive_device_info(String target, boolean secureboot) {
-  if (target.contains("nvidia-jetson-orin-agx64")) {
-    return [name: 'OrinAGX64', tag: 'orin-agx-64']
-  }
-  if (target.contains("nvidia-jetson-orin-agx")) {
-    return [name: 'OrinAGX1', tag: 'orin-agx']
-  }
-  if (target.contains("nvidia-jetson-orin-nx")) {
-    return [name: 'OrinNX1', tag: 'orin-nx']
-  }
-  if (target.contains("lenovo-x1")) {
-    if (secureboot && !target.contains("installer")) {
-      return [name: 'X1-Secure-Boot', tag: 'x1-sec-boot']
-    }
-    return [name: 'LenovoX1-1', tag: 'lenovo-x1']
-  }
-  if (target.contains("dell-latitude-7330")) {
-    return [name: 'Dell7330', tag: 'dell-7330']
-  }
-  if (target.contains("system76-darp11-b")) {
-    return [name: 'DarterPRO', tag: 'darter-pro']
-  }
-  return null
-}
-
-def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFlakeRef) {
-  def normalizedFlakeRef = explicitFlakeRef?.trim()
-  if (normalizedFlakeRef) {
-    return normalizedFlakeRef
-  }
-  def normalizedOciFlakeRef = ociFlakeRef?.trim()
-  if (normalizedOciFlakeRef) {
-    return normalizedOciFlakeRef
-  }
-  def match = imgUrl =~ /commit_([a-f0-9]{40})/
-  if (match) {
-    return "git+https://github.com/tiiuae/ghaf?rev=${match[0][1]}"
-  }
-  return null
 }
 
 def get_test_conf_property(String file_path, String device, String property) {
@@ -487,7 +432,7 @@ pipeline {
                   exit 1
                 fi
               """
-              def ghafFlakeRef = resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+              def ghafFlakeRef = utils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
               if (!ghafFlakeRef) {
                 if (params.OCI_IMAGE_REF) {
                   error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'")

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -356,33 +356,10 @@ pipeline {
         stage('Flash') {
           steps {
             script {
-              // Determine mount commands
-              if(env.TARGET.contains("microchip-icicle-")) {
-                def muxport = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
-                env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
-                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
-              } else {
-                def serial = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
-                env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
-                env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
-              }
-              // Mount the target disk
-              sh "${env.MOUNT_CMD}"
-              // Read the device name
-              def dev = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
-              println "Checking that flash target '$dev' is connected..."
-              sh """
-                if /run/wrappers/bin/sudo test -f ${dev}; then
-                  echo "dev ${dev} found as regular file, removing the file and trying re-mount"
-                  ${env.UNMOUNT_CMD}; /run/wrappers/bin/sudo rm ${dev}; ${env.MOUNT_CMD}
-                fi
-                if ! /run/wrappers/bin/sudo test -L ${dev}; then
-                  echo "Symlink ${dev} not found. Failed to connect target USB disk to test agent."
-                  echo "Check USB cables. Maybe need to reboot test agent or Acroname USB hub."
-                  echo "Aborting flashing ${env.DEVICE_NAME}"
-                  exit 1
-                fi
-              """
+              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TARGET, env.DEVICE_NAME)
+              env.MOUNT_CMD = mountCommands.mount_cmd
+              env.UNMOUNT_CMD = mountCommands.unmount_cmd
+              def dev = utils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
               def ghafFlakeRef = utils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
               if (!ghafFlakeRef) {
                 if (params.OCI_IMAGE_REF) {
@@ -400,12 +377,7 @@ pipeline {
               sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
               // Unmount
               sh "${env.UNMOUNT_CMD}"
-              sh """
-                if /run/wrappers/bin/sudo test -L ${dev}; then
-                  echo "Symlink ${dev} was found. Failed to unmount target USB disk from test agent."
-                  exit 1
-                fi
-              """
+              utils.assert_flash_target_unmounted(dev)
             }
           }
         }

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -56,7 +56,7 @@ def init() {
   env.OCI_IMAGE_REVISION = ''
   if (ociImageRef) {
     def annotations = readJSON(
-      text: sh_ret_out("oras manifest fetch --format json '${ociImageRef}'")
+      text: utils.run_cmd("oras manifest fetch --format json '${ociImageRef}'")
     ).content?.annotations ?: [:]
     env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
     env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
@@ -89,24 +89,10 @@ def init() {
   return label
 }
 
-def sh_ret_out(String cmd) {
-  // Run cmd returning stdout
-  return sh(script: cmd, returnStdout:true).trim()
-}
-
 def oras_pull_json(String reference, String outputDir) {
   return readJSON(
-    text: sh_ret_out("oras pull --format json -o '${outputDir}' '${reference}'")
+    text: utils.run_cmd("oras pull --format json -o '${outputDir}' '${reference}'")
   )
-}
-
-def run_wget(String url, String to_dir) {
-  // Download `url` setting the directory prefix `to_dir` preserving
-  // the hierarchy of directories locally.
-  sh "wget --show-progress --progress=dot:giga --force-directories --timestamping -P ${to_dir} ${url}"
-  // Re-run wget: this will not re-download anything, it's needed only to
-  // get the local path to the downloaded file
-  return sh_ret_out("wget --force-directories --timestamping -P ${to_dir} ${url} 2>&1 | grep -Po '${to_dir}[^’]+'")
 }
 
 @NonCPS
@@ -153,14 +139,6 @@ def parse_oci_reference(String reference) {
     tag: null,
     digest: null,
   ]
-}
-
-def get_test_conf_property(String file_path, String device, String property) {
-  // Get the requested device property data from test_config.json file
-  def device_data = readJSON file: file_path
-  def property_data = "${device_data['addresses'][device][property]}"
-  println "Got device '${device}' property '${property}' value: '${property_data}'"
-  return property_data
 }
 
 def automated_test_tags(String testname) {
@@ -285,23 +263,12 @@ pipeline {
           steps {
             deleteDir()
             script {
-              if (params.USE_FLAKE_PINNED_CI_TEST) {
-                def pinned_src = sh_ret_out("cat ${CI_TEST_PINNED_SOURCE_FILE}")
-                println("Using flake-pinned ci-test-automation source: ${pinned_src}")
-                sh """
-                  if [ ! -d "${pinned_src}/Robot-Framework/test-suites" ]; then
-                    echo "ERROR: invalid ci-test-automation source path '${pinned_src}'"
-                    exit 1
-                  fi
-                  cp -r "${pinned_src}/." .
-                  chmod -R u+w .
-                """
-              } else {
-                checkout scmGit(
-                  branches: [[name: "${params.CI_TEST_REPO_BRANCH}"]],
-                  userRemoteConfigs: [[url: "${params.CI_TEST_REPO_URL}"]]
-                )
-              }
+              utils.checkout_ci_test_sources(
+                CI_TEST_PINNED_SOURCE_FILE,
+                params.USE_FLAKE_PINNED_CI_TEST,
+                params.CI_TEST_REPO_BRANCH,
+                params.CI_TEST_REPO_URL
+              )
             }
           }
         }
@@ -326,7 +293,7 @@ pipeline {
               def sig_path
               if (params.OCI_IMAGE_REF) {
                 def discovery = readJSON(
-                  text: sh_ret_out("oras discover --format json '${params.OCI_IMAGE_REF}'")
+                  text: utils.run_cmd("oras discover --format json '${params.OCI_IMAGE_REF}'")
                 )
                 def referrer = discovery.referrers?.find { it.artifactType == IN_TOTO_MEDIA_TYPE }
                 def provenanceRef = referrer?.reference
@@ -349,8 +316,8 @@ pipeline {
                 def provenance_url = "${artifacts_url}/${target}/attestations/provenance.json"
                 def signature_url = "${provenance_url}.sig"
                 println("provenance_url: ${provenance_url}")
-                provenance_path = run_wget(provenance_url, TMP_IMG_DIR)
-                sig_path = run_wget(signature_url, TMP_IMG_DIR)
+                provenance_path = utils.run_wget(provenance_url, TMP_IMG_DIR)
+                sig_path = utils.run_wget(signature_url, TMP_IMG_DIR)
               }
               sh "policy-checker ${provenance_path} --sig ${sig_path} --policy /etc/jenkins/provenance-trust-policy.yaml"
             }
@@ -369,13 +336,13 @@ pipeline {
                   error("Unable to derive image files from OCI image '${params.OCI_IMAGE_REF}'")
                 }
               } else {
-                img_path = run_wget(params.IMG_URL, TMP_IMG_DIR)
+                img_path = utils.run_wget(params.IMG_URL, TMP_IMG_DIR)
                 def split = split_img_url(params.IMG_URL)
                 def artifacts_url = split["artifacts_url"]
                 def img_relpath = split["img_relpath"]
                 def target = split["target_name"]
                 def sig_url = "${artifacts_url}/${target}/${img_relpath}.sig"
-                sig_path = run_wget(sig_url, TMP_IMG_DIR)
+                sig_path = utils.run_wget(sig_url, TMP_IMG_DIR)
               }
               println "Downloaded image to workspace: ${img_path}"
               println "Downloaded SLSA signature file to workspace: ${sig_path}"
@@ -391,18 +358,18 @@ pipeline {
             script {
               // Determine mount commands
               if(env.TARGET.contains("microchip-icicle-")) {
-                def muxport = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
+                def muxport = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usb_sd_mux_port')
                 env.MOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} host; sleep 10"
                 env.UNMOUNT_CMD = "/run/wrappers/bin/sudo usbsdmux ${muxport} dut"
               } else {
-                def serial = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
+                def serial = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'usbhub_serial')
                 env.MOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s ${serial}; sleep 10"
                 env.UNMOUNT_CMD = "/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s ${serial}; sleep 10"
               }
               // Mount the target disk
               sh "${env.MOUNT_CMD}"
               // Read the device name
-              def dev = get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
+              def dev = utils.get_test_conf_property(CONF_FILE_PATH, env.DEVICE_NAME, 'ext_drive_by-id')
               println "Checking that flash target '$dev' is connected..."
               sh """
                 if /run/wrappers/bin/sudo test -f ${dev}; then
@@ -425,11 +392,11 @@ pipeline {
               }
               env.GHAF_FLAKE_REF = ghafFlakeRef
               println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-              def flashScriptPath = sh_ret_out(
+              def flashScriptPath = utils.run_cmd(
                 "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
               )
               // flash-script validates /dev/sdX format; resolve the by-id symlink
-              def resolved_dev = sh_ret_out("/run/wrappers/bin/sudo readlink -f ${dev}")
+              def resolved_dev = utils.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
               sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
               // Unmount
               sh "${env.UNMOUNT_CMD}"
@@ -521,19 +488,7 @@ pipeline {
       post {
         always {
           script {
-            if (env.BOOT_PASSED != null) {
-              def test_artifacts = '' +
-                'Robot-Framework/test-suites/**/*.html, ' +
-                'Robot-Framework/test-suites/**/*.xml, ' +
-                'Robot-Framework/test-suites/**/*.png, ' +
-                'Robot-Framework/test-suites/**/*.jpeg, ' +
-                'Robot-Framework/test-suites/**/*.mp4, ' +
-                'Robot-Framework/test-suites/**/*.mkv, ' +
-                'Robot-Framework/test-suites/**/*.wav, ' +
-                'Robot-Framework/test-suites/**/*.txt'
-              archiveArtifacts allowEmptyArchive: true, artifacts: test_artifacts
-            }
-            sh "rm -rf ${TMP_IMG_DIR} || true"
+            utils.archive_robot_artifacts(TMP_IMG_DIR, env.BOOT_PASSED != null)
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -65,63 +65,26 @@ def init() {
   if (!ociImageRef && !imgUrl) {
     error("Missing OCI_IMAGE_REF or IMG_URL parameter")
   }
-  env.TARGET = utils.derive_target_name(imgUrl, env.OCI_TARGET)
-  if (!env.TARGET) {
+  // Resolve the target here as well for controller-side fail-fast validation and
+  // device/agent selection. The agent-side Resolve target stage repeats this so
+  // it can initialize runtime state after node allocation.
+  def target = utils.derive_target_name(imgUrl, env.OCI_TARGET)
+  if (!target) {
     if (ociImageRef) {
       error("Unable to derive target name from OCI image '${ociImageRef}'")
     }
     error("Unexpected IMG_URL: ${params.IMG_URL}")
   }
-  println("Using TARGET: ${env.TARGET}")
-
-  def deviceInfo = utils.derive_device_info(env.TARGET, params.SECUREBOOT)
+  def deviceInfo = utils.derive_device_info(target, params.SECUREBOOT)
   if (!deviceInfo) {
-    error("Unable to parse device config for target '${env.TARGET}'")
+    error("Unable to parse device config for target '${target}'")
   }
   env.DEVICE_NAME = deviceInfo.name
   env.DEVICE_TAG = deviceInfo.tag
-  println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
-  println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
-  // Determine additional test tags based on target
-  def tagFilters = []
-  if (env.TARGET.contains("lenovo-x1") || env.TARGET.contains("darp11-b")) {
-    if (env.TARGET.contains("storeDisk")) {
-      tagFilters.add('NOTexcl-storeDisk')
-    } else {
-      tagFilters.add('NOTstoreDisk-only')
-    }
-    if (env.TARGET.contains("installer")) {
-      tagFilters.add('NOTexcl-installer')
-    } else {
-      tagFilters.add('NOTinstaller-only')
-    }
-  }
-  if (env.TARGET.contains("lenovo-x1")) {
-    if (env.DEVICE_TAG == 'x1-sec-boot') {
-      tagFilters.add('NOTexcl-secboot')
-    } else {
-      tagFilters.add('NOTsecboot-only')
-    }
-  }
-  env.EXTRATAG = tagFilters.unique().join('')
-  if (env.EXTRATAG) {
-    println("Using additional test tags: ${tagFilters}")
-  } else {
-    println("No additional test tags are used")
-  }
-  if(params.containsKey('DESC')) {
-    currentBuild.description = "${params.DESC}"
-  } else {
-    currentBuild.description = "${env.TARGET}"
-  }
-  def testagent_nodes = nodesByLabel(label: env.DEVICE_TAG, offline: false)
+  def label = params.TESTAGENT_HOST ? "${params.TESTAGENT_HOST}-${env.DEVICE_TAG}" : env.DEVICE_TAG
+  def testagent_nodes = nodesByLabel(label: label, offline: false)
   if (!testagent_nodes) {
     error("No test agents online")
-  }
-  def label = env.DEVICE_TAG
-  if (params.TESTAGENT_HOST) {
-    println("Using specific TESTAGENT_HOST: ${TESTAGENT_HOST}")
-    label = "${params.TESTAGENT_HOST}-${env.DEVICE_TAG}"
   }
   return label
 }
@@ -200,6 +163,13 @@ def get_test_conf_property(String file_path, String device, String property) {
   return property_data
 }
 
+def automated_test_tags(String testname) {
+  if (testname.contains('turnoff')) {
+    return testname
+  }
+  return "${utils.boot_tag_for(env.DEVICE_TAG)}AND${testname}${env.EXTRATAG}"
+}
+
 def ghaf_robot_test(String testname='relayboot') {
   if (!env.DEVICE_TAG) {
     error("DEVICE_TAG not set")
@@ -207,16 +177,7 @@ def ghaf_robot_test(String testname='relayboot') {
   if (!env.DEVICE_NAME) {
     error("DEVICE_NAME not set")
   }
-  if (env.DEVICE_TAG == "x1-sec-boot") {
-    env.DEVICE_TEST_TAG = "lenovo-x1"
-  } else {
-    env.DEVICE_TEST_TAG = env.DEVICE_TAG
-  }
-  if (testname.contains('turnoff')) {
-    env.INCLUDE_TEST_TAGS = "${testname}"
-  } else {
-    env.INCLUDE_TEST_TAGS = "${env.DEVICE_TEST_TAG}AND${testname}${env.EXTRATAG}"
-  }
+  env.INCLUDE_TEST_TAGS = automated_test_tags(testname)
   dir("Robot-Framework/test-suites") {
     sh 'rm -f *.txt *.png *.jpeg *.mp4 *.mkv *.wav output.xml report.html log.html'
     // On failure, continue the pipeline execution
@@ -297,6 +258,29 @@ pipeline {
     stage('Run on test agent') {
       agent { label "${env.TEST_AGENT_LABEL}" }
       stages {
+        stage('Resolve target') {
+          steps {
+            script {
+              env.TARGET = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
+              if (!env.TARGET) {
+                if (params.OCI_IMAGE_REF) {
+                  error("Unable to derive target name from OCI image '${params.OCI_IMAGE_REF}'")
+                }
+                error("Unexpected IMG_URL: ${params.IMG_URL}")
+              }
+              env.EXTRATAG = utils.extra_tag_suffix(env.TARGET, env.DEVICE_TAG)
+              currentBuild.description = params.containsKey('DESC') ? "${params.DESC}" : "${env.TARGET}"
+              println("Using TARGET: ${env.TARGET}")
+              println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
+              println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
+              if (env.EXTRATAG) {
+                println("Using additional test tags: ${env.EXTRATAG}")
+              } else {
+                println("No additional test tags are used")
+              }
+            }
+          }
+        }
         stage('Checkout') {
           steps {
             deleteDir()


### PR DESCRIPTION
**Summary**:
- Consolidate duplicated helpers from ghaf-hw-test.groovy and ghaf-hw-test-manual.groovy into the shared library introduced in #1007
- Refactor hw-test init() to focus on controller-side validation and agent selection; move target/tag resolution to a dedicated Resolve target stage on the agent
- Extract flash-related logic (mount setup, target validation, unmount assertion) into shared helpers
- Deduplicate device metadata behind device_catalog() and hw-test trigger logic behind trigger_hw_test()
- Add missing @NonCPS to resolve_ghaf_flake_ref() and derive_target_name()

Tested: https://ci-dbg.vedenemo.dev/job/ghaf-manual/17/