### PR TITLE
tasks: parallelize install-release

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -551,23 +551,6 @@ def _check_remote_sudo(host: DeployHost, yes: bool) -> None:
         )
 
 
-def _check_dynamic_ip(host: DeployHost, yes: bool) -> None:
-    """Warn when the target reports dynamic IP addresses."""
-    try:
-        host.run("ip a | grep dynamic")
-    except subprocess.CalledProcessError:
-        return
-
-    _warn_and_confirm(
-        f"Above address(es) on '{host.host}' use dynamic addressing. "
-        "This might cause issues if you assume the target host is reachable "
-        "from any such address also after kexec switch. "
-        "If you do, consider making the address temporarily static "
-        "before continuing.",
-        yes,
-    )
-
-
 ################################################################################
 # Release-install helpers
 ################################################################################
@@ -940,7 +923,6 @@ def _run_install(
     _assert_stateversion(alias, yes)
     _check_remote_user_alignment(target, host, user, yes)
     _check_remote_sudo(host, yes)
-    _check_dynamic_ip(host, yes)
 
     _log_status_info(f"[{alias}] install: building target system locally")
     c.run(_build_local_build_command(target))

--- a/tasks.py
+++ b/tasks.py
@@ -26,8 +26,11 @@
 
 """Misc dev and deployment helper tasks."""
 
+# pylint: disable=too-many-lines
+
 import getpass
 import json
+import logging
 import os
 import shlex
 import shutil
@@ -35,13 +38,15 @@ import socket
 import subprocess
 import sys
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any
+from tempfile import TemporaryDirectory, mkdtemp
+from typing import Any, TextIO
 
 from deploykit import DeployHost, HostKeyCheck
 from invoke.context import Context
@@ -55,6 +60,15 @@ from tabulate import tabulate
 ################################################################################
 
 ROOT, TARGETS = (None, None)
+THREAD_LOG_STREAM: ContextVar[TextIO | None] = ContextVar(
+    "thread_log_stream", default=None
+)
+LOGURU_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {message}"
+LOGURU_COLOR_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<level>{message}</level>"
+)
 
 REVISION_DELIM = "\x1f"  # ASCII unit separator — can't appear in commit metadata
 
@@ -116,7 +130,7 @@ class Targets:
 
     def _populate(self) -> None:
         """Populate the target dictionary from nix evaluation."""
-        logger.debug("Reading targets")
+        _log_debug("Reading targets")
         self.target_dict = OrderedDict(
             {
                 name: TargetHost(
@@ -132,11 +146,11 @@ class Targets:
 
     def get(self, alias: str) -> TargetHost:
         """Get one host, exiting cleanly on unknown aliases."""
-        logger.debug(f"Reading target '{alias}'")
+        _log_debug(f"Reading target '{alias}'")
         if not self.populated:
             self._populate()
         if alias not in self.target_dict:
-            logger.error(f"Unknown alias '{alias}'")
+            _log_error(f"Unknown alias '{alias}'")
             sys.exit(1)
         return self.target_dict[alias]
 
@@ -158,6 +172,53 @@ class Targets:
 ################################################################################
 
 
+class _ContextLoguruHandler(logging.Handler):
+    """Forward stdlib log records through loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit one formatted log record."""
+        try:
+            level = record.levelname
+            message = record.getMessage()
+            command_prefix = getattr(record, "command_prefix", "")
+            if command_prefix:
+                message = f"[{command_prefix}] {message}"
+            getattr(_active_logger().opt(exception=record.exc_info), level.lower())(
+                message
+            )
+        except RecursionError:
+            raise
+        # Logging handlers are expected to swallow formatting/write errors and
+        # delegate them to handleError instead of crashing the caller.
+        # pylint: disable=broad-exception-caught
+        except Exception:
+            self.handleError(record)
+
+
+def _configure_context_stream_logger(logger_obj: logging.Logger) -> None:
+    """Replace logger stream handlers with a loguru bridge handler."""
+    if any(
+        isinstance(handler, _ContextLoguruHandler) for handler in logger_obj.handlers
+    ):
+        return
+
+    handler_level = logger_obj.level
+
+    logger_obj.handlers = [
+        handler
+        for handler in logger_obj.handlers
+        if not isinstance(handler, logging.StreamHandler)
+    ]
+
+    handler = _ContextLoguruHandler()
+    handler.setLevel(handler_level)
+    logger_obj.addHandler(handler)
+
+
+_configure_context_stream_logger(logging.getLogger("deploykit.command"))
+_configure_context_stream_logger(logging.getLogger("deploykit.main"))
+
+
 def _run_checked(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     """Run a local command and require success."""
     return subprocess.run(cmd, check=True, text=True, **kwargs)
@@ -169,9 +230,83 @@ def _run_json(cmd: list[str]) -> Any:
         proc = _run_checked(cmd, capture_output=True)
     except subprocess.CalledProcessError as err:
         detail = (err.stderr or "").strip() or str(err)
-        logger.error(f"Command failed: {shlex.join(cmd)}\n{detail}")
+        _log_error(f"Command failed: {shlex.join(cmd)}\n{detail}")
         sys.exit(1)
     return json.loads(proc.stdout)
+
+
+def _current_output_stream() -> TextIO:
+    """Return the thread-local output stream when configured."""
+    stream = THREAD_LOG_STREAM.get()
+    return sys.stdout if stream is None else stream
+
+
+def _stderr_loguru_sink(message: str) -> None:
+    """Write colored loguru messages to the active stderr stream."""
+    sys.stderr.write(message)
+    sys.stderr.flush()
+
+
+def _stderr_supports_color() -> bool:
+    """Return True when stderr is an interactive stream that can render ANSI."""
+    return bool(
+        getattr(sys.stderr, "isatty", None)
+        and sys.stderr.isatty()
+        and os.environ.get("NO_COLOR") is None
+    )
+
+
+def _thread_loguru_sink(message: str) -> None:
+    """Write plain loguru messages to the thread-local stream."""
+    stream = THREAD_LOG_STREAM.get()
+    if stream is None:
+        return
+    stream.write(message)
+    stream.flush()
+
+
+def _active_logger() -> Any:
+    """Return the logger instance for the current execution context."""
+    if THREAD_LOG_STREAM.get() is None:
+        return logger
+    return logger.bind(thread_local_stream=True)
+
+
+def _log_message(level: str, message: str) -> None:
+    """Log via loguru using the configured thread-aware sink."""
+    getattr(_active_logger(), level)(message)
+
+
+def _log_info(message: str) -> None:
+    """Log an informational message."""
+    _log_message("info", message)
+
+
+def _log_status_info(message: str) -> None:
+    """Log a high-level status message and mirror it to stderr when thread-local."""
+    _log_info(message)
+    if THREAD_LOG_STREAM.get() is not None:
+        logger.info(message)
+
+
+def _log_debug(message: str) -> None:
+    """Log a debug message."""
+    _log_message("debug", message)
+
+
+def _log_warning(message: str) -> None:
+    """Log a warning message."""
+    _log_message("warning", message)
+
+
+def _log_error(message: str) -> None:
+    """Log an error message."""
+    _log_message("error", message)
+
+
+def _print_output(message: str = "", *, end: str = "\n") -> None:
+    """Print to the thread-local stream when configured."""
+    print(message, end=end, file=_current_output_stream(), flush=True)
 
 
 def _confirm(prompt: str, yes: bool) -> bool:
@@ -183,7 +318,9 @@ def _confirm(prompt: str, yes: bool) -> bool:
 
 def _warn_and_confirm(message: str, yes: bool) -> None:
     """Log a warning and ask the operator to continue."""
-    logger.warning(message)
+    _log_warning(message)
+    if THREAD_LOG_STREAM.get() is not None:
+        logger.warning(message)
     if not _confirm("Still continue? [y/N] ", yes):
         sys.exit(1)
 
@@ -251,6 +388,14 @@ def _clone_context(c: Context) -> Context:
     return Context(config=c.config.clone())
 
 
+def _clone_context_for_stream(c: Context, stream: TextIO) -> Context:
+    """Return a fresh invoke context that writes command output to `stream`."""
+    clone = _clone_context(c)
+    clone.config.run.out_stream = stream
+    clone.config.run.err_stream = stream
+    return clone
+
+
 def _get_deploy_host(alias: str, user: str | None = None) -> DeployHost:
     """Return DeployHost object, given `alias`."""
     hostname = TARGETS.get(alias).hostname
@@ -271,7 +416,7 @@ def _decrypt_host_key(target: TargetHost, tmpdir: str, yes: bool) -> None:
     """Run sops to extract `nixosconfig` secret `ssh_host_ed25519_key`."""
 
     if target.secretspath is None:
-        logger.error(
+        _log_error(
             f"Missing sops secret path for '{target.nixosconfig}'; cannot decrypt host key"
         )
         sys.exit(1)
@@ -340,7 +485,7 @@ def _assert_stateversion(alias: str, yes: bool) -> None:
     try:
         ret.check_returncode()
     except subprocess.CalledProcessError:
-        logger.error(ret.stderr)
+        _log_error(ret.stderr)
         sys.exit(1)
 
     version_data = json.loads(ret.stdout)
@@ -366,7 +511,7 @@ def _check_remote_user_alignment(
     try:
         remote_user = _remote_stdout(host, "whoami")
     except subprocess.CalledProcessError:
-        logger.error("No ssh access to the remote host")
+        _log_error("No ssh access to the remote host")
         sys.exit(1)
 
     local_user = getpass.getuser()
@@ -435,6 +580,7 @@ def _generate_release_ssh_ca(tmpdir: Path) -> Path:
     _run_checked(
         ["ssh-keygen", "-f", f"{ca}", "-C", "", "-N", ""],
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     return ca
 
@@ -446,29 +592,45 @@ def _generate_signed_user_key(ca: Path, tmpdir: Path, user: str) -> Path:
     _run_checked(
         ["ssh-keygen", "-f", f"{key}", "-C", "", "-N", ""],
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     _run_checked(
         ["ssh-keygen", "-s", f"{ca}", "-I", "", "-n", f"{user}", f"{key}.pub"],
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
     return key
 
 
-def _install_release_host(c: Context, alias: str, copy_dir: str) -> None:
-    """Install one release host using its own invoke context."""
-    succeeded = False
-    try:
-        install(_clone_context(c), alias, yes=True, copy_dir=copy_dir)
-        succeeded = True
-    finally:
-        if succeeded:
-            logger.info(f"[{alias}] parallel install: finished")
-        else:
-            logger.error(f"[{alias}] parallel install: failed")
+def _new_install_log_path(alias: str, prefix: str = "install-logs-") -> Path:
+    """
+    Return a fresh per-host log file path for one install workflow.
+
+    The parent temporary directory is intentionally left on disk so operators can
+    inspect install logs after success or failure; callers do not clean it up.
+    """
+    return Path(mkdtemp(prefix=prefix)) / f"{alias}.log"
 
 
-def _release_install_error_summary(err: Exception | SystemExit) -> str:
-    """Return a compact single-line summary for one release-install failure."""
+def _announce_install_log_path(alias: str, log_path: Path) -> None:
+    """Log where one install writes its detailed output."""
+    logger.info(f"Writing install log for '{alias}' to {log_path}")
+
+
+@contextmanager
+def _thread_log_to_file(log_path: Path) -> Iterator[TextIO]:
+    """Route thread-local log and print output to `log_path`."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "w", encoding="utf-8") as stream:
+        token = THREAD_LOG_STREAM.set(stream)
+        try:
+            yield stream
+        finally:
+            THREAD_LOG_STREAM.reset(token)
+
+
+def _install_error_summary(err: Exception | SystemExit) -> str:
+    """Return a compact single-line summary for one install failure."""
     detail = next((line.strip() for line in str(err).splitlines() if line.strip()), "")
     return f"{type(err).__name__}: {detail}" if detail else type(err).__name__
 
@@ -479,7 +641,7 @@ def _install_release_hosts(c: Context, tmpdir: Path) -> None:
         *((alias, str(tmpdir / "builder")) for alias in RELEASE_BUILDER_ALIASES),
         (RELEASE_CONTROLLER_ALIAS, str(tmpdir / "controller")),
     ]
-    logger.info(f"Installing {len(jobs)} release host(s) in parallel")
+    _log_info(f"Installing {len(jobs)} release host(s) in parallel")
 
     # Populate shared target metadata before worker threads start touching the
     # lazy TARGETS cache.
@@ -489,7 +651,9 @@ def _install_release_hosts(c: Context, tmpdir: Path) -> None:
     failures: list[str] = []
     with ThreadPoolExecutor(max_workers=len(jobs)) as executor:
         future_to_alias = {
-            executor.submit(_install_release_host, c, alias, copy_dir): alias
+            executor.submit(
+                install, _clone_context(c), alias, yes=True, copy_dir=copy_dir
+            ): alias
             for alias, copy_dir in jobs
         }
         for future in as_completed(future_to_alias):
@@ -501,8 +665,8 @@ def _install_release_hosts(c: Context, tmpdir: Path) -> None:
             # pylint: disable=broad-exception-caught
             except (Exception, SystemExit) as err:
                 failures.append(alias)
-                detail = _release_install_error_summary(err)
-                logger.error(f"Release install failed for '{alias}': {detail}")
+                detail = _install_error_summary(err)
+                _log_error(f"Release install failed for '{alias}': {detail}")
 
     if failures:
         raise RuntimeError(
@@ -514,7 +678,7 @@ def _deploy_release_testagent(c: Context, host: DeployHost) -> bool:
     """Deploy the release testagent without reinstalling it."""
     port = host.port or 22
     if not _can_connect(host.host, port, timeout=RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC):
-        logger.info(
+        _log_status_info(
             "Failed deploying 'testagent-release'. "
             "The release environment is otherwise up, but you should manually deploy "
             "the testagent-release, then connect it to the release Jenkins instance. "
@@ -528,7 +692,7 @@ def _deploy_release_testagent(c: Context, host: DeployHost) -> bool:
     if deploy.ok:
         return True
 
-    logger.info(
+    _log_status_info(
         "Failed deploying 'testagent-release'. "
         "The release environment is otherwise up, but you should manually deploy "
         "the testagent-release, then connect it to the release Jenkins instance. "
@@ -570,14 +734,11 @@ def _wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
     """Wait for `host`:`port`."""
     while True:
         time.sleep(1)
-        sys.stdout.write(".")
-        sys.stdout.flush()
         if _can_connect(host, port):
             if not shutdown:
                 break
         elif shutdown:
             break
-    print("")
 
 
 def _git_revision_info(revisions: Iterable[str] | None = None) -> dict[str, list[str]]:
@@ -640,7 +801,7 @@ def alias_list(_c: Context) -> None:
     for alias, host in TARGETS.all().items():
         table_rows.append([alias, host.nixosconfig, host.hostname])
     table = tabulate(table_rows, headers="firstrow", tablefmt="fancy_outline")
-    print(f"\nCurrent ghaf-infra targets:\n\n{table}")
+    _print_output(f"\nCurrent ghaf-infra targets:\n\n{table}")
 
 
 @task
@@ -674,9 +835,9 @@ def print_keys(_c: Context, alias: str) -> None:
         _decrypt_host_key(target, tmpdir, yes=False)
         pub_key = Path(tmpdir) / "etc/ssh/ssh_host_ed25519_key.pub"
         pub_data = pub_key.read_text(encoding="utf-8")
-        print("###### Public keys ######")
-        print(pub_data)
-        print("###### Age keys ######")
+        _print_output("###### Public keys ######")
+        _print_output(pub_data)
+        _print_output("###### Age keys ######")
         _run_checked(["ssh-to-age"], input=pub_data)
 
 
@@ -699,17 +860,26 @@ def install_release(c: Context) -> None:
         _install_release_hosts(c, tmpdir)
 
     host = _get_deploy_host(RELEASE_TESTAGENT_ALIAS)
-    if not _deploy_release_testagent(c, host):
-        return
-    if _connect_release_testagent(host):
-        return
-    logger.info(
-        "Failed connecting 'testagent-release' to the installed release environment. "
-        "The release environment is otherwise up, but you need to manually connect "
-        "the testagent to the release Jenkins instance. "
-        f"Hint: is the testagent at '{host.host}' accessible over SSH? "
-        "Perhaps you need to connect a VPN?"
-    )
+    log_path = _new_install_log_path(RELEASE_TESTAGENT_ALIAS, "install-release-logs-")
+    _announce_install_log_path(RELEASE_TESTAGENT_ALIAS, log_path)
+    with _thread_log_to_file(log_path) as stream:
+        logged_context = _clone_context_for_stream(c, stream)
+        _log_status_info(f"[{RELEASE_TESTAGENT_ALIAS}] deploy: starting")
+        if not _deploy_release_testagent(logged_context, host):
+            return
+        _log_status_info(
+            f"[{RELEASE_TESTAGENT_ALIAS}] connect: attaching to {RELEASE_TESTAGENT_URL}"
+        )
+        if _connect_release_testagent(host):
+            _log_status_info(f"[{RELEASE_TESTAGENT_ALIAS}] connect: finished")
+            return
+        _log_status_info(
+            "Failed connecting 'testagent-release' to the installed release environment. "
+            "The release environment is otherwise up, but you need to manually connect "
+            "the testagent to the release Jenkins instance. "
+            f"Hint: is the testagent at '{host.host}' accessible over SSH? "
+            "Perhaps you need to connect a VPN?"
+        )
 
 
 @task
@@ -730,20 +900,53 @@ def install(
     Example usage:
     inv install hetzci-release --yes
     """
-    logger.info(f"Installing '{alias}'")
+    log_path = _new_install_log_path(alias)
+    _announce_install_log_path(alias, log_path)
+    try:
+        with _thread_log_to_file(log_path) as stream:
+            _run_install(
+                _clone_context_for_stream(c, stream),
+                alias,
+                user=user,
+                yes=yes,
+                copy_dir=copy_dir,
+            )
+    # Top-level installs should still surface a concise terminal summary while
+    # keeping the detailed command output in the host log file.
+    except (Exception, SystemExit) as err:
+        detail = _install_error_summary(err)
+        _log_error(f"Install failed for '{alias}': {detail}")
+        _log_error(f"See detailed install log: {log_path}")
+        raise
+
+
+def _run_install(
+    c: Context,
+    alias: str,
+    user: str | None = None,
+    yes: bool = False,
+    copy_dir: str | None = None,
+) -> None:
+    """Execute the install workflow; see `install` for the user-facing docs."""
+    _log_status_info(f"[{alias}] install: starting")
     if not _confirm(f"Install configuration '{alias}'? [y/N] ", yes):
+        _log_status_info(f"[{alias}] install: cancelled")
         return
 
     target = TARGETS.resolve_secrets(alias)
     host = _get_deploy_host(alias, user)
 
+    _log_status_info(f"[{alias}] install: validating target and remote access")
     _assert_stateversion(alias, yes)
     _check_remote_user_alignment(target, host, user, yes)
     _check_remote_sudo(host, yes)
     _check_dynamic_ip(host, yes)
+
+    _log_status_info(f"[{alias}] install: building target system locally")
     c.run(_build_local_build_command(target))
 
     with TemporaryDirectory() as tmpdir:
+        _log_status_info(f"[{alias}] install: preparing installer files")
         if copy_dir:
             shutil.copytree(Path(copy_dir), Path(tmpdir), dirs_exist_ok=True)
         _decrypt_host_key(target, tmpdir, yes)
@@ -754,13 +957,15 @@ def install(
             target,
             kexec_url=KEXEC_IMAGES.get(alias),
         )
-        logger.warning(command)
+        _log_status_info(f"[{alias}] install: running nixos-anywhere")
+        _log_warning(command)
         c.run(command)
 
-    print(f"Wait for {host.host} to start", end="")
-    sys.stdout.flush()
+    _log_status_info(f"[{alias}] install: waiting for SSH on {host.host}")
     _wait_for_port(host.host, 22)
+    _log_status_info(f"[{alias}] install: rebooting to finalize")
     reboot(c, alias)
+    _log_status_info(f"[{alias}] install: finished")
 
 
 @task
@@ -774,13 +979,11 @@ def reboot(_c: Context, alias: str) -> None:
     host = _get_deploy_host(alias)
     host.run("sudo reboot &")
 
-    print(f"Wait for {host.host} to shutdown", end="")
-    sys.stdout.flush()
+    _log_status_info(f"[{alias}] reboot: waiting for {host.host} to shut down")
     port = host.port or 22
     _wait_for_port(host.host, port, shutdown=True)
 
-    print(f"Wait for {host.host} to start", end="")
-    sys.stdout.flush()
+    _log_status_info(f"[{alias}] reboot: waiting for {host.host} to start")
     _wait_for_port(host.host, port)
 
 
@@ -798,7 +1001,7 @@ def print_revision(_c: Context, alias: str = "") -> None:
     git_info_def = ["", "", ""]
     target_aliases = [alias] if alias else list(TARGETS.all().keys())
     max_workers = min(32, len(target_aliases))
-    logger.info(f"Probing {len(target_aliases)} host(s) (up to 5s each)")
+    _log_info(f"Probing {len(target_aliases)} host(s) (up to 5s each)")
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         deployed_revisions = list(executor.map(_read_deployed_revision, target_aliases))
 
@@ -818,7 +1021,7 @@ def print_revision(_c: Context, alias: str = "") -> None:
 
     table_rows.sort(reverse=True, key=lambda row: row[2])  # sort by git_date
     table = tabulate(table_rows, headers=header_row, tablefmt="fancy_outline")
-    print(f"\nCurrently deployed revision(s):\n\n{table}")
+    _print_output(f"\nCurrently deployed revision(s):\n\n{table}")
 
 
 ################################################################################
@@ -828,8 +1031,21 @@ def print_revision(_c: Context, alias: str = "") -> None:
 
 def init() -> None:
     """Module initialization."""
-    logger.remove(0)
-    logger.add(sys.stderr, level="INFO")
+    logger.remove()
+    logger.add(
+        _stderr_loguru_sink,
+        level="INFO",
+        format=LOGURU_COLOR_FORMAT,
+        colorize=_stderr_supports_color(),
+        filter=lambda record: not record["extra"].get("thread_local_stream", False),
+    )
+    logger.add(
+        _thread_loguru_sink,
+        level="INFO",
+        format=LOGURU_FORMAT,
+        colorize=False,
+        filter=lambda record: record["extra"].get("thread_local_stream", False),
+    )
 
     global ROOT, TARGETS  # pylint: disable=global-statement
     ROOT = Path(__file__).parent.resolve()

--- a/tasks.py
+++ b/tasks.py
@@ -37,7 +37,7 @@ import sys
 import time
 from collections.abc import Iterable
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -245,6 +245,11 @@ def _build_nixos_anywhere_command(
     return shlex.join(cmd)
 
 
+def _clone_context(c: Context) -> Context:
+    """Return a fresh invoke context with cloned configuration."""
+    return Context(config=c.config.clone())
+
+
 def _get_deploy_host(alias: str, user: str | None = None) -> DeployHost:
     """Return DeployHost object, given `alias`."""
     hostname = TARGETS.get(alias).hostname
@@ -448,11 +453,60 @@ def _generate_signed_user_key(ca: Path, tmpdir: Path, user: str) -> Path:
     return key
 
 
+def _install_release_host(c: Context, alias: str, copy_dir: str) -> None:
+    """Install one release host using its own invoke context."""
+    succeeded = False
+    try:
+        install(_clone_context(c), alias, yes=True, copy_dir=copy_dir)
+        succeeded = True
+    finally:
+        if succeeded:
+            logger.info(f"[{alias}] parallel install: finished")
+        else:
+            logger.error(f"[{alias}] parallel install: failed")
+
+
+def _release_install_error_summary(err: Exception | SystemExit) -> str:
+    """Return a compact single-line summary for one release-install failure."""
+    detail = next((line.strip() for line in str(err).splitlines() if line.strip()), "")
+    return f"{type(err).__name__}: {detail}" if detail else type(err).__name__
+
+
 def _install_release_hosts(c: Context, tmpdir: Path) -> None:
-    """Install release builders and controller using the public install task."""
-    for alias in RELEASE_BUILDER_ALIASES:
-        install(c, alias, yes=True, copy_dir=str(tmpdir / "builder"))
-    install(c, RELEASE_CONTROLLER_ALIAS, yes=True, copy_dir=str(tmpdir / "controller"))
+    """Install all release hosts using the public install task."""
+    jobs = [
+        *((alias, str(tmpdir / "builder")) for alias in RELEASE_BUILDER_ALIASES),
+        (RELEASE_CONTROLLER_ALIAS, str(tmpdir / "controller")),
+    ]
+    logger.info(f"Installing {len(jobs)} release host(s) in parallel")
+
+    # Populate shared target metadata before worker threads start touching the
+    # lazy TARGETS cache.
+    for alias, _copy_dir in jobs:
+        TARGETS.resolve_secrets(alias)
+
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=len(jobs)) as executor:
+        future_to_alias = {
+            executor.submit(_install_release_host, c, alias, copy_dir): alias
+            for alias, copy_dir in jobs
+        }
+        for future in as_completed(future_to_alias):
+            alias = future_to_alias[future]
+            try:
+                future.result()
+            # Worker installs may raise SystemExit via helper guards; keep going so
+            # all parallel host failures are surfaced before the task aborts.
+            # pylint: disable=broad-exception-caught
+            except (Exception, SystemExit) as err:
+                failures.append(alias)
+                detail = _release_install_error_summary(err)
+                logger.error(f"Release install failed for '{alias}': {detail}")
+
+    if failures:
+        raise RuntimeError(
+            f"Release install failed on {len(failures)} host(s): {', '.join(failures)}"
+        )
 
 
 def _deploy_release_testagent(c: Context, host: DeployHost) -> bool:

--- a/tasks.py
+++ b/tasks.py
@@ -83,6 +83,7 @@ RELEASE_TESTAGENT_ALIAS = "testagent-release"
 RELEASE_TESTAGENT_URL = "https://ci-release.vedenemo.dev"
 RELEASE_CONNECT_ATTEMPTS = 3
 RELEASE_CONNECT_SLEEP_SEC = 5
+RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC = 5
 
 
 ################################################################################
@@ -511,6 +512,18 @@ def _install_release_hosts(c: Context, tmpdir: Path) -> None:
 
 def _deploy_release_testagent(c: Context, host: DeployHost) -> bool:
     """Deploy the release testagent without reinstalling it."""
+    port = host.port or 22
+    if not _can_connect(host.host, port, timeout=RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC):
+        logger.info(
+            "Failed deploying 'testagent-release'. "
+            "The release environment is otherwise up, but you should manually deploy "
+            "the testagent-release, then connect it to the release Jenkins instance. "
+            f"Hint: could not reach '{host.host}:{port}' over TCP within "
+            f"{RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC}s. "
+            "Perhaps you need to connect a VPN?"
+        )
+        return False
+
     deploy = c.run(f"deploy -s --targets .#{RELEASE_TESTAGENT_ALIAS}", warn=True)
     if deploy.ok:
         return True
@@ -544,19 +557,26 @@ def _connect_release_testagent(host: DeployHost) -> bool:
 ################################################################################
 
 
+def _can_connect(host: str, port: int, timeout: int | float = 1) -> bool:
+    """Return True when a TCP connection can be established within `timeout`."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 def _wait_for_port(host: str, port: int, shutdown: bool = False) -> None:
     """Wait for `host`:`port`."""
     while True:
         time.sleep(1)
         sys.stdout.write(".")
         sys.stdout.flush()
-        try:
-            with socket.create_connection((host, port), timeout=1):
-                if not shutdown:
-                    break
-        except OSError:
-            if shutdown:
+        if _can_connect(host, port):
+            if not shutdown:
                 break
+        elif shutdown:
+            break
     print("")
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=protected-access, too-few-public-methods, wrong-import-position
+# pylint: disable=missing-function-docstring, protected-access, too-few-public-methods, wrong-import-position
 
 """Tests for extracted helper logic in tasks.py."""
 
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 import sys
 from collections import OrderedDict
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,6 +18,15 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import tasks
+
+
+def _expected_release_jobs(tmp_path: Path) -> list[tuple[str, str]]:
+    """Return the expected release-install job tuples for one temp dir."""
+    return [
+        ("hetz86-rel-2", str(tmp_path / "builder")),
+        ("hetzarm-rel-1", str(tmp_path / "builder")),
+        ("hetzci-release", str(tmp_path / "controller")),
+    ]
 
 
 def test_confirm_respects_yes_without_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -134,6 +144,201 @@ def test_generate_signed_user_key_runs_expected_commands(
         ["ssh-keygen", "-f", str(key), "-C", "", "-N", ""],
         ["ssh-keygen", "-s", str(ca), "-I", "", "-n", "builder-user", f"{key}.pub"],
     ]
+
+
+def test_install_release_hosts_parallelizes_all_release_hosts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """All release hosts should be dispatched through the parallel install phase."""
+    submitted: list[tuple[str, str]] = []
+    install_calls: list[tuple[object, str, bool, str | None]] = []
+    clone_calls: list[object] = []
+    infos: list[str] = []
+    prepare_calls: list[str] = []
+    call_order: list[tuple[str, str]] = []
+
+    class FakeFuture:
+        """Minimal future stub that runs the task when awaited."""
+
+        def __init__(self, callback: Callable[[], None]) -> None:
+            self._callback = callback
+
+        def result(self) -> None:
+            self._callback()
+
+    class FakeExecutor:
+        """Minimal executor stub for deterministic release-install tests."""
+
+        def __init__(self, *, max_workers: int) -> None:
+            assert max_workers == len(_expected_release_jobs(tmp_path))
+
+        def __enter__(self) -> "FakeExecutor":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def submit(self, func: Callable[..., None], *args: object) -> FakeFuture:
+            submitted.append((args[1], args[2]))
+            return FakeFuture(lambda: func(*args))
+
+    def fake_clone_context(context: object) -> str:
+        clone_calls.append(context)
+        return f"host-context-{len(clone_calls)}"
+
+    def fake_resolve_secrets(alias: str) -> object:
+        prepare_calls.append(alias)
+        call_order.append(("resolve", alias))
+        return object()
+
+    def fake_install(
+        context: object,
+        alias: str,
+        *,
+        yes: bool,
+        copy_dir: str | None = None,
+    ) -> None:
+        install_calls.append((context, alias, yes, copy_dir))
+        call_order.append(("install", alias))
+
+    def fake_log_info(message: str) -> None:
+        infos.append(message)
+
+    monkeypatch.setattr(tasks, "ThreadPoolExecutor", FakeExecutor)
+    monkeypatch.setattr(
+        tasks, "as_completed", lambda submitted_futures: submitted_futures
+    )
+    monkeypatch.setattr(
+        tasks, "TARGETS", SimpleNamespace(resolve_secrets=fake_resolve_secrets)
+    )
+    monkeypatch.setattr(tasks, "_clone_context", fake_clone_context)
+    monkeypatch.setattr(tasks, "install", fake_install)
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+
+    root_context = object()
+    tasks._install_release_hosts(root_context, tmp_path)
+
+    assert prepare_calls == [
+        alias for alias, _copy_dir in _expected_release_jobs(tmp_path)
+    ]
+    assert submitted == _expected_release_jobs(tmp_path)
+    assert clone_calls == [root_context, root_context, root_context]
+    assert install_calls == [
+        (
+            "host-context-1",
+            "hetz86-rel-2",
+            True,
+            str(tmp_path / "builder"),
+        ),
+        (
+            "host-context-2",
+            "hetzarm-rel-1",
+            True,
+            str(tmp_path / "builder"),
+        ),
+        (
+            "host-context-3",
+            "hetzci-release",
+            True,
+            str(tmp_path / "controller"),
+        ),
+    ]
+    assert call_order[:3] == [
+        ("resolve", "hetz86-rel-2"),
+        ("resolve", "hetzarm-rel-1"),
+        ("resolve", "hetzci-release"),
+    ]
+    assert any(
+        "[hetz86-rel-2] parallel install: finished" in message for message in infos
+    )
+    assert any(
+        "[hetzarm-rel-1] parallel install: finished" in message for message in infos
+    )
+    assert any(
+        "[hetzci-release] parallel install: finished" in message for message in infos
+    )
+
+
+def test_install_release_hosts_reports_all_parallel_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Parallel release install should log every failing host before exiting."""
+    errors: list[str] = []
+
+    class FakeFuture:
+        """Minimal future stub that runs the task when awaited."""
+
+        def __init__(self, callback: Callable[[], None]) -> None:
+            self._callback = callback
+
+        def result(self) -> None:
+            self._callback()
+
+    class FakeExecutor:
+        """Minimal executor stub for failure aggregation tests."""
+
+        def __init__(self, *, max_workers: int) -> None:
+            assert max_workers == len(_expected_release_jobs(tmp_path))
+
+        def __enter__(self) -> "FakeExecutor":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def submit(self, func: Callable[..., None], *args: object) -> FakeFuture:
+            return FakeFuture(lambda: func(*args))
+
+    def fake_install(
+        _context: object,
+        alias: str,
+        *,
+        yes: bool,
+        copy_dir: str | None = None,
+    ) -> None:
+        assert yes
+        assert copy_dir is not None
+        if alias == "hetz86-rel-2":
+            raise SystemExit(1)
+        if alias == "hetzci-release":
+            raise subprocess.CalledProcessError(2, "nixos-anywhere")
+
+    def identity_as_completed(submitted_futures: object) -> object:
+        return submitted_futures
+
+    def same_context(context: object) -> object:
+        return context
+
+    def fake_log_error(message: str) -> None:
+        errors.append(message)
+
+    monkeypatch.setattr(tasks, "ThreadPoolExecutor", FakeExecutor)
+    monkeypatch.setattr(tasks, "as_completed", identity_as_completed)
+    monkeypatch.setattr(
+        tasks, "TARGETS", SimpleNamespace(resolve_secrets=lambda _alias: object())
+    )
+    monkeypatch.setattr(tasks, "_clone_context", same_context)
+    monkeypatch.setattr(tasks, "install", fake_install)
+    monkeypatch.setattr(tasks.logger, "error", fake_log_error)
+
+    with pytest.raises(
+        RuntimeError, match="2 host\\(s\\): hetz86-rel-2, hetzci-release"
+    ):
+        tasks._install_release_hosts(object(), tmp_path)
+
+    assert any(
+        "[hetz86-rel-2] parallel install: failed" in message for message in errors
+    )
+    assert any(
+        "[hetzci-release] parallel install: failed" in message for message in errors
+    )
+    assert any(
+        "hetz86-rel-2" in message and "SystemExit: 1" in message for message in errors
+    )
+    assert any(
+        "hetzci-release" in message and "CalledProcessError:" in message
+        for message in errors
+    )
 
 
 def test_build_nixos_anywhere_command_is_shell_safe(tmp_path: Path) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -5,6 +5,9 @@
 
 """Tests for extracted helper logic in tasks.py."""
 
+import io
+import logging
+import re
 import shlex
 import subprocess
 import sys
@@ -20,13 +23,24 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import tasks
 
 
-def _expected_release_jobs(tmp_path: Path) -> list[tuple[str, str]]:
-    """Return the expected release-install job tuples for one temp dir."""
-    return [
-        ("hetz86-rel-2", str(tmp_path / "builder")),
-        ("hetzarm-rel-1", str(tmp_path / "builder")),
-        ("hetzci-release", str(tmp_path / "controller")),
-    ]
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI color codes from text."""
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
+def _assert_loguru_line(line: str, level: str, message: str) -> None:
+    """Assert that one line matches the configured loguru output format."""
+    padded_level = f"{level:<8}"
+    pattern = (
+        r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| "
+        f"{re.escape(padded_level)}"
+        r" \| "
+        f"{re.escape(message)}"
+    )
+    assert re.fullmatch(pattern, line)
 
 
 def test_confirm_respects_yes_without_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -145,14 +159,277 @@ def test_generate_signed_user_key_runs_expected_commands(
         ["ssh-keygen", "-s", str(ca), "-I", "", "-n", "builder-user", f"{key}.pub"],
     ]
 
+
+def test_announce_install_log_path_reports_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Install logging should announce the detailed log file path."""
+    outputs: list[str] = []
+    log_path = tmp_path / "logs/demo.log"
+
+    def fake_log_info(message: str) -> None:
+        outputs.append(message)
+
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+
+    tasks._announce_install_log_path("demo", log_path)
+
+    assert outputs == [f"Writing install log for 'demo' to {log_path}"]
+
+
+def test_context_stream_logger_routes_thread_local_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Context-aware handlers should prefer the thread-local stream."""
+    logger_name = "tasks.test-context-stream"
+    logger = logging.getLogger(logger_name)
+    logger.handlers = []
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    logger.addHandler(logging.StreamHandler(io.StringIO()))
+
+    tasks._configure_context_stream_logger(logger)
+
+    logger.info("outside")
+    outside_lines = capsys.readouterr().err.splitlines()
+    assert len(outside_lines) == 1
+    _assert_loguru_line(_strip_ansi(outside_lines[0]), "INFO", "outside")
+
+    thread_stream = io.StringIO()
+    token = tasks.THREAD_LOG_STREAM.set(thread_stream)
+    try:
+        logger.info("inside")
+    finally:
+        tasks.THREAD_LOG_STREAM.reset(token)
+
+    assert capsys.readouterr().err == ""
+    thread_lines = thread_stream.getvalue().splitlines()
+    assert len(thread_lines) == 1
+    assert "\x1b[" not in thread_lines[0]
+    _assert_loguru_line(thread_lines[0], "INFO", "inside")
+
+
+def test_context_stream_logger_preserves_command_prefix(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Bridged stdlib log records should keep deploykit-style host prefixes."""
+    logger_name = "tasks.test-command-prefix"
+    logger = logging.getLogger(logger_name)
+    logger.handlers = []
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    logger.addHandler(logging.StreamHandler(io.StringIO()))
+
+    tasks._configure_context_stream_logger(logger)
+
+    logger.info("$ ssh example", extra={"command_prefix": "demo-host"})
+
+    outside_lines = capsys.readouterr().err.splitlines()
+    assert len(outside_lines) == 1
+    _assert_loguru_line(
+        _strip_ansi(outside_lines[0]), "INFO", "[demo-host] $ ssh example"
+    )
+
+
+def test_init_disables_stderr_color_when_stream_is_not_a_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-interactive stderr output should stay free of ANSI escape codes."""
+
+    class FakeStderr(io.StringIO):
+        """String buffer that behaves like a redirected stderr stream."""
+
+        def isatty(self) -> bool:
+            return False
+
+    stderr = FakeStderr()
+    monkeypatch.setattr(tasks.sys, "stderr", stderr)
+    monkeypatch.setattr(tasks.os, "chdir", lambda _path: None)
+
+    tasks.init()
+    tasks._log_info("outside")
+
+    lines = stderr.getvalue().splitlines()
+    assert len(lines) == 1
+    assert "\x1b[" not in lines[0]
+    _assert_loguru_line(lines[0], "INFO", "outside")
+
+
+def test_log_status_info_logs_once_without_thread_local_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Status logs should not be duplicated during normal execution."""
+    outputs: list[str] = []
+
+    def fake_log_info(message: str) -> None:
+        outputs.append(message)
+
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+
+    tasks._log_status_info("outside")
+
+    assert outputs == ["outside"]
+
+
+def test_log_status_info_mirrors_thread_local_output_to_console(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Status logs should go to both the host log file and the console mirror."""
+    outputs: list[str] = []
+    message = "[demo] install: building target system locally"
+
+    def fake_log_info(log_message: str) -> None:
+        outputs.append(log_message)
+
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+
+    log_path = tmp_path / "logs/demo.log"
+    with tasks._thread_log_to_file(log_path):
+        tasks._log_status_info(message)
+
+    assert outputs == [message]
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    _assert_loguru_line(lines[0], "INFO", message)
+
+
+def test_warn_and_confirm_mirrors_thread_local_warning_to_console(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Prompt-triggering warnings should stay visible during logged installs."""
+
+    def fake_input(prompt: str) -> str:
+        print(prompt, end="")
+        return "n"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    log_path = tmp_path / "logs/demo.log"
+    with pytest.raises(SystemExit):
+        with tasks._thread_log_to_file(log_path):
+            tasks._warn_and_confirm("dynamic IP warning", yes=False)
+
+    captured = capsys.readouterr()
+    assert captured.out == "Still continue? [y/N] "
+    err_lines = captured.err.splitlines()
+    assert len(err_lines) == 1
+    _assert_loguru_line(_strip_ansi(err_lines[0]), "WARNING", "dynamic IP warning")
+
+    file_lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(file_lines) == 1
+    _assert_loguru_line(file_lines[0], "WARNING", "dynamic IP warning")
+
+
+def test_install_creates_detailed_log_and_runs_inner_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Single-host installs should always wrap the inner workflow in a log file."""
+    outputs: list[str] = []
+    clone_calls: list[tuple[object, str]] = []
+    run_calls: list[tuple[object, str, str | None, bool, str | None]] = []
+    log_dir = tmp_path / "install-logs"
+
+    def fake_log_info(message: str) -> None:
+        outputs.append(message)
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        assert prefix == "install-logs-"
+        return str(log_dir)
+
+    def fake_clone_context_for_stream(context: object, stream: object) -> str:
+        clone_calls.append((context, stream.name))
+        return "logged-context"
+
+    def fake_run_install(
+        context: object,
+        alias: str,
+        *,
+        user: str | None = None,
+        yes: bool = False,
+        copy_dir: str | None = None,
+    ) -> None:
+        run_calls.append((context, alias, user, yes, copy_dir))
+
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+    monkeypatch.setattr(tasks, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(
+        tasks, "_clone_context_for_stream", fake_clone_context_for_stream
+    )
+    monkeypatch.setattr(tasks, "_run_install", fake_run_install)
+
+    root_context = object()
+    tasks.install.body(
+        root_context,
+        "demo",
+        user="operator",
+        yes=True,
+        copy_dir="/tmp/copied",
+    )
+
+    log_path = log_dir / "demo.log"
+    assert outputs == [f"Writing install log for 'demo' to {log_path}"]
+    assert clone_calls == [(root_context, str(log_path))]
+    assert run_calls == [("logged-context", "demo", "operator", True, "/tmp/copied")]
+    assert log_path.exists()
+
+
+def test_install_reports_failure_with_log_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Single-host install failures should keep the traceback and print the log path."""
+    errors: list[str] = []
+    log_dir = tmp_path / "install-logs"
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        assert prefix == "install-logs-"
+        return str(log_dir)
+
+    def same_context(context: object, _stream: object) -> object:
+        return context
+
+    def fail_run_install(
+        _context: object,
+        _alias: str,
+        *,
+        user: str | None = None,
+        yes: bool = False,
+        copy_dir: str | None = None,
+    ) -> None:
+        raise subprocess.CalledProcessError(2, "nixos-anywhere")
+
+    def fake_log_error(message: str) -> None:
+        errors.append(message)
+
+    monkeypatch.setattr(tasks, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(tasks, "_clone_context_for_stream", same_context)
+    monkeypatch.setattr(tasks, "_run_install", fail_run_install)
+    monkeypatch.setattr(tasks.logger, "error", fake_log_error)
+
+    log_path = log_dir / "demo.log"
+    with pytest.raises(subprocess.CalledProcessError):
+        tasks.install.body(object(), "demo", yes=True)
+
+    assert len(errors) == 2
+    assert errors[0].startswith("Install failed for 'demo': CalledProcessError:")
+    assert errors[1] == f"See detailed install log: {log_path}"
+
+
 def test_install_release_hosts_parallelizes_all_release_hosts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """All release hosts should be dispatched through the parallel install phase."""
-    submitted: list[tuple[str, str]] = []
+    expected_jobs = [
+        ("hetz86-rel-2", str(tmp_path / "builder")),
+        ("hetzarm-rel-1", str(tmp_path / "builder")),
+        ("hetzci-release", str(tmp_path / "controller")),
+    ]
+    submitted: list[tuple[object, str, str]] = []
     install_calls: list[tuple[object, str, bool, str | None]] = []
     clone_calls: list[object] = []
-    infos: list[str] = []
     prepare_calls: list[str] = []
     call_order: list[tuple[str, str]] = []
 
@@ -169,7 +446,7 @@ def test_install_release_hosts_parallelizes_all_release_hosts(
         """Minimal executor stub for deterministic release-install tests."""
 
         def __init__(self, *, max_workers: int) -> None:
-            assert max_workers == len(_expected_release_jobs(tmp_path))
+            assert max_workers == len(expected_jobs)
 
         def __enter__(self) -> "FakeExecutor":
             return self
@@ -177,9 +454,11 @@ def test_install_release_hosts_parallelizes_all_release_hosts(
         def __exit__(self, *_args: object) -> None:
             pass
 
-        def submit(self, func: Callable[..., None], *args: object) -> FakeFuture:
-            submitted.append((args[1], args[2]))
-            return FakeFuture(lambda: func(*args))
+        def submit(
+            self, func: Callable[..., None], *args: object, **kwargs: object
+        ) -> FakeFuture:
+            submitted.append((args[0], args[1], kwargs["copy_dir"]))
+            return FakeFuture(lambda: func(*args, **kwargs))
 
     def fake_clone_context(context: object) -> str:
         clone_calls.append(context)
@@ -200,9 +479,6 @@ def test_install_release_hosts_parallelizes_all_release_hosts(
         install_calls.append((context, alias, yes, copy_dir))
         call_order.append(("install", alias))
 
-    def fake_log_info(message: str) -> None:
-        infos.append(message)
-
     monkeypatch.setattr(tasks, "ThreadPoolExecutor", FakeExecutor)
     monkeypatch.setattr(
         tasks, "as_completed", lambda submitted_futures: submitted_futures
@@ -212,15 +488,16 @@ def test_install_release_hosts_parallelizes_all_release_hosts(
     )
     monkeypatch.setattr(tasks, "_clone_context", fake_clone_context)
     monkeypatch.setattr(tasks, "install", fake_install)
-    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
 
     root_context = object()
     tasks._install_release_hosts(root_context, tmp_path)
 
-    assert prepare_calls == [
-        alias for alias, _copy_dir in _expected_release_jobs(tmp_path)
+    assert prepare_calls == [alias for alias, _copy_dir in expected_jobs]
+    assert submitted == [
+        ("host-context-1", "hetz86-rel-2", str(tmp_path / "builder")),
+        ("host-context-2", "hetzarm-rel-1", str(tmp_path / "builder")),
+        ("host-context-3", "hetzci-release", str(tmp_path / "controller")),
     ]
-    assert submitted == _expected_release_jobs(tmp_path)
     assert clone_calls == [root_context, root_context, root_context]
     assert install_calls == [
         (
@@ -247,15 +524,6 @@ def test_install_release_hosts_parallelizes_all_release_hosts(
         ("resolve", "hetzarm-rel-1"),
         ("resolve", "hetzci-release"),
     ]
-    assert any(
-        "[hetz86-rel-2] parallel install: finished" in message for message in infos
-    )
-    assert any(
-        "[hetzarm-rel-1] parallel install: finished" in message for message in infos
-    )
-    assert any(
-        "[hetzci-release] parallel install: finished" in message for message in infos
-    )
 
 
 def test_install_release_hosts_reports_all_parallel_failures(
@@ -277,7 +545,7 @@ def test_install_release_hosts_reports_all_parallel_failures(
         """Minimal executor stub for failure aggregation tests."""
 
         def __init__(self, *, max_workers: int) -> None:
-            assert max_workers == len(_expected_release_jobs(tmp_path))
+            assert max_workers == 3
 
         def __enter__(self) -> "FakeExecutor":
             return self
@@ -285,8 +553,10 @@ def test_install_release_hosts_reports_all_parallel_failures(
         def __exit__(self, *_args: object) -> None:
             pass
 
-        def submit(self, func: Callable[..., None], *args: object) -> FakeFuture:
-            return FakeFuture(lambda: func(*args))
+        def submit(
+            self, func: Callable[..., None], *args: object, **kwargs: object
+        ) -> FakeFuture:
+            return FakeFuture(lambda: func(*args, **kwargs))
 
     def fake_install(
         _context: object,
@@ -325,12 +595,6 @@ def test_install_release_hosts_reports_all_parallel_failures(
     ):
         tasks._install_release_hosts(object(), tmp_path)
 
-    assert any(
-        "[hetz86-rel-2] parallel install: failed" in message for message in errors
-    )
-    assert any(
-        "[hetzci-release] parallel install: failed" in message for message in errors
-    )
     assert any(
         "hetz86-rel-2" in message and "SystemExit: 1" in message for message in errors
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -145,7 +145,6 @@ def test_generate_signed_user_key_runs_expected_commands(
         ["ssh-keygen", "-s", str(ca), "-I", "", "-n", "builder-user", f"{key}.pub"],
     ]
 
-
 def test_install_release_hosts_parallelizes_all_release_hosts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -396,6 +395,44 @@ def test_connect_release_testagent_retries_until_success(
         tasks.RELEASE_CONNECT_SLEEP_SEC,
         tasks.RELEASE_CONNECT_SLEEP_SEC,
     ]
+
+
+def test_deploy_release_testagent_skips_unreachable_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release testagent deploy should fail fast when SSH is unreachable."""
+    infos: list[str] = []
+    probes: list[tuple[str, int, int | float]] = []
+
+    class FakeContext:
+        """Invoke-like context stub that must not run deploy on probe failure."""
+
+        def run(self, _command: str, *, warn: bool) -> SimpleNamespace:
+            raise AssertionError("deploy should not run when the SSH probe fails")
+
+    def fake_can_connect(host: str, port: int, timeout: int | float = 1) -> bool:
+        probes.append((host, port, timeout))
+        return False
+
+    def fake_log_info(message: str) -> None:
+        infos.append(message)
+
+    monkeypatch.setattr(tasks, "_can_connect", fake_can_connect)
+    monkeypatch.setattr(tasks.logger, "info", fake_log_info)
+
+    host = SimpleNamespace(host="172.18.16.32", port=None)
+
+    assert tasks._deploy_release_testagent(FakeContext(), host) is False
+    assert probes == [("172.18.16.32", 22, tasks.RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC)]
+    assert infos[0] == (
+        "Failed deploying 'testagent-release'. "
+        "The release environment is otherwise up, but you should manually deploy "
+        "the testagent-release, then connect it to the release Jenkins instance. "
+        "Hint: could not reach '172.18.16.32:22' over TCP within "
+        f"{tasks.RELEASE_DEPLOY_SSH_PROBE_TIMEOUT_SEC}s. "
+        "Perhaps you need to connect a VPN?"
+    )
+    assert len(infos) == 1
 
 
 def test_decrypt_host_key_respects_yes_on_sops_failure(


### PR DESCRIPTION
Parallelize the release host installs (`inv install-release`) and make the install output easier to follow.

- Parallelize builder + controller installs in `inv install-release` via ThreadPoolExecutor, aggregating per-host failures instead of aborting on the first error.
- Write each install's output to its own log file (kept on disk for inspection) via a thread-local loguru sink that also bridges deploykit's stdlib logging.
- TCP-probe `testagent-release` before deploy and fail fast with a VPN hint; share the probe with `_wait_for_port`.
- Drop the non-actionable dynamic-IP preflight warning (installs use pinned inventory IPs).

Perf improvement: with the changes from this PR the `inv install-release` run time goes from ~15 minutes down to ~7 minutes. Most of the time is now spent waiting for `hetz86-rel-2` to boot-up; the slow boot-up on that host  is due to a separate issue, and once fixed the now parallel `inv install-release` should become faster.

Tested both `inv install-release` and single-host `inv install`
Logs are now much more readable with detailed logs available in tmp files. Example log from `inv install-release`:
```
❯ inv install-release 
2026-04-22 14:45:56 | INFO     | Installing 3 release host(s) in parallel
2026-04-22 14:45:59 | INFO     | Writing install log for 'hetz86-rel-2' to /tmp/nix-shell.f4JLCG/install-logs-crkuv2e_/hetz86-rel-2.log
2026-04-22 14:45:59 | INFO     | Writing install log for 'hetzarm-rel-1' to /tmp/nix-shell.f4JLCG/install-logs-179_pvrb/hetzarm-rel-1.log
2026-04-22 14:45:59 | INFO     | [hetz86-rel-2] install: starting
2026-04-22 14:45:59 | INFO     | [hetzarm-rel-1] install: starting
2026-04-22 14:45:59 | INFO     | Writing install log for 'hetzci-release' to /tmp/nix-shell.f4JLCG/install-logs-dk5yv73t/hetzci-release.log
2026-04-22 14:45:59 | INFO     | [hetz86-rel-2] install: validating target and remote access
2026-04-22 14:45:59 | INFO     | [hetzarm-rel-1] install: validating target and remote access
2026-04-22 14:45:59 | INFO     | [hetzci-release] install: starting
2026-04-22 14:45:59 | INFO     | [hetzci-release] install: validating target and remote access
2026-04-22 14:46:00 | INFO     | [hetzci-release] install: building target system locally
2026-04-22 14:46:00 | INFO     | [hetz86-rel-2] install: building target system locally
2026-04-22 14:46:01 | INFO     | [hetzarm-rel-1] install: building target system locally
2026-04-22 14:46:11 | INFO     | [hetz86-rel-2] install: preparing installer files
2026-04-22 14:46:11 | INFO     | [hetz86-rel-2] install: running nixos-anywhere
2026-04-22 14:46:19 | INFO     | [hetzci-release] install: preparing installer files
2026-04-22 14:46:19 | INFO     | [hetzci-release] install: running nixos-anywhere
2026-04-22 14:46:20 | INFO     | [hetzarm-rel-1] install: preparing installer files
2026-04-22 14:46:20 | INFO     | [hetzarm-rel-1] install: running nixos-anywhere
2026-04-22 14:47:50 | INFO     | [hetzarm-rel-1] install: waiting for SSH on 46.62.196.166
2026-04-22 14:47:50 | INFO     | [hetzci-release] install: waiting for SSH on 95.217.210.252
2026-04-22 14:47:52 | INFO     | [hetz86-rel-2] install: waiting for SSH on 65.21.200.168
2026-04-22 14:48:12 | INFO     | [hetzci-release] install: rebooting to finalize
2026-04-22 14:48:12 | INFO     | [hetzci-release] reboot: waiting for 95.217.210.252 to shut down
2026-04-22 14:48:14 | INFO     | [hetzci-release] reboot: waiting for 95.217.210.252 to start
2026-04-22 14:48:18 | INFO     | [hetzarm-rel-1] install: rebooting to finalize
2026-04-22 14:48:18 | INFO     | [hetzarm-rel-1] reboot: waiting for 46.62.196.166 to shut down
2026-04-22 14:48:20 | INFO     | [hetzarm-rel-1] reboot: waiting for 46.62.196.166 to start
2026-04-22 14:48:37 | INFO     | [hetzci-release] install: finished
2026-04-22 14:48:45 | INFO     | [hetzarm-rel-1] install: finished
2026-04-22 14:50:19 | INFO     | [hetz86-rel-2] install: rebooting to finalize
2026-04-22 14:50:19 | INFO     | [hetz86-rel-2] reboot: waiting for 65.21.200.168 to shut down
2026-04-22 14:50:21 | INFO     | [hetz86-rel-2] reboot: waiting for 65.21.200.168 to start
2026-04-22 14:52:45 | INFO     | [hetz86-rel-2] install: finished
2026-04-22 14:52:45 | INFO     | Writing install log for 'testagent-release' to /tmp/nix-shell.f4JLCG/install-release-logs-nsdkv0yd/testagent-release.log
2026-04-22 14:52:45 | INFO     | [testagent-release] deploy: starting
2026-04-22 14:52:50 | INFO     | Failed deploying 'testagent-release'. The release environment is otherwise up, but you should manually deploy the testagent-release, then connect it to the release Jenkins instance. Hint: could not reach '172.18.16.32:22' over TCP within 5s. Perhaps you need to connect a VPN?
```