### PR TITLE
Robots: Switch to systemd-boot bootloader

### DIFF
--- a/hosts/hetzner-robot.nix
+++ b/hosts/hetzner-robot.nix
@@ -34,9 +34,8 @@
     networkConfig.DHCP = "ipv4";
   };
 
-  boot.loader.grub = {
-    efiSupport = true;
-    efiInstallAsRemovable = true;
+  boot.loader = {
+    systemd-boot.enable = true;
   };
 
   environment.systemPackages = with pkgs; [

--- a/hosts/hetzner-robot.nix
+++ b/hosts/hetzner-robot.nix
@@ -34,9 +34,9 @@
     networkConfig.DHCP = "ipv4";
   };
 
-  boot.loader.grub = {
-    efiSupport = true;
-    efiInstallAsRemovable = true;
+  boot.loader = {
+    systemd-boot.enable = true;
+    systemd-boot.configurationLimit = 5;
   };
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
Booting with grub didn't work, but they were fallbacking to old systemd-boot bootloader anyway. Now we explicitly use systemd-boot, and more importantly keep systemd-boot setup updated with new kernels and bootloader versions.

Note that manual onetime actions might be needed on the host with old grub boot loader installation when migrating to a revision with systemd-boot loader.
Tested on hetz86-builder, and there old /boot/EFI/BOOT/BOOTX64.EFI had to be temporarily renamed for the migratory deployment to pass.