### PR TITLE
Refactor UAE environment

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -35,7 +35,7 @@ keys:
   - &ghaf-registry age1j6xlgk93a9nwwtaqdxfqfp52x0kt9jkwj3r2zmdg8eres72s0y7qvf5r90
   - &ghaf-fleetdm age1ejte8fz7wdrnxcuzst5j66arkmwgvm67sj2hdhnvq7q0t0z5lsnqcyr97t
   - &nethsm-gateway age177v8xccs46774faav3tu36kfap0r04z0ukxh2t5293rwk5evrsaqd98j0p
-  - &uae-lab-node1 age1ugtdwk3vgnug0xjcme3ft8a5rk2htd207z83dgp5gzk52ajf94dqerju4w
+  - &uae-lab-node1 age1k0ujgggnrh2k9f6c4w2vnt6z6vg7m8ulk6e25vrzqa2ntvhu3e7ql7t5yv
   - &uae-nethsm-gateway age1yqpkn74zacvyujqadz5cm90e6tz8ws2kphladkyvtfrv65x5autqe9404a
   - &uae-azureci-prod age13jsxg67hfnk7pqrf0tsnqrdxs8ktly4ke2vqwsx0c0lqytlwd98s58rkna
   - &uae-azureci-az86-1 age1rcwsekkzc2x35kv3qcg6dvgjsl28nxhes4e9g8l5gue54tx2qp7s53wclg

--- a/docs/nebula.md
+++ b/docs/nebula.md
@@ -147,6 +147,7 @@ Nebula firewall rules defined in `services/nebula/default.nix`.
 | `testagent` | Test agent machines |
 | `scraper` | Metrics scraping (ghaf-monitoring) |
 | `uae-lab` | UAE lab nodes |
+| `uae-masdar` | UAE masdar nodes |
 
 The `scraper` group is used in an inbound firewall rule that allows
 ghaf-monitoring to scrape Prometheus node-exporter metrics (port 9100/tcp)

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -257,8 +257,8 @@
     module = ./uae/lab/node1/configuration.nix;
     system = "x86_64-linux";
     machine = {
-      ip = "172.19.16.37";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGKZYL60TIQDoLwUwuZvzOdw/yikC181su5Cm1LAplcj";
+      ip = "172.31.107.42";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINXec/ZGWCbBTaSi4dYOhVMWt/BUlSaIuvU/k9Ciap3P";
     };
   };
 
@@ -307,7 +307,7 @@
     system = "aarch64-linux";
     machine = {
       ip = "91.98.90.243";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBM3zxG++iSjFGkQ6Kqghwm5mcbo+KM4vAzH1Cqftoew";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDP8yHa00zzjb+KSLB/pSZTKsAiU4vW1V75dqS1/6TqZ";
     };
   };
 

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -267,7 +267,7 @@
     system = "x86_64-linux";
     machine = {
       ip = "172.31.141.51";
-      nebula_ip = "10.42.42.33";
+      nebula_ip = "10.42.42.35";
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ69aPBjri8UJi1KbVDEUYW5YeHzAkQ86acQNHzqyrD0";
     };
   };

--- a/hosts/uae/azureci/remote-builders.nix
+++ b/hosts/uae/azureci/remote-builders.nix
@@ -45,7 +45,7 @@ in
       [
         (
           {
-            hostName = "az86-1.uaenorth.cloudapp.azure.com";
+            hostName = "10.51.16.5";
             system = "x86_64-linux";
             maxJobs = x86BuilderMaxJobs;
           }
@@ -65,14 +65,14 @@ in
   programs.ssh = {
     # Known builder host public keys, these go to /root/.ssh/known_hosts
     knownHosts = {
-      "az86-1.uaenorth.cloudapp.azure.com".publicKey = machines.uae-azureci-az86-1.publicKey;
+      "10.51.16.5".publicKey = machines.uae-azureci-az86-1.publicKey;
       "91.98.90.243".publicKey = machines.uae-azureci-hetzarm-1.publicKey;
     };
 
     # Custom options to /etc/ssh/ssh_config
     extraConfig = lib.mkAfter ''
-      Host az86-1.uaenorth.cloudapp.azure.com
-      Hostname az86-1.uaenorth.cloudapp.azure.com
+      Host 10.51.16.5
+      Hostname 10.51.16.5
       User uae-remote-build
       IdentityFile ${config.sops.secrets.azureci_builder_ssh_key.path}
 

--- a/hosts/uae/lab/node1/disk-config.nix
+++ b/hosts/uae/lab/node1/disk-config.nix
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   disko.devices.disk.os = {
-    device = "/dev/disk/by-id/nvme-KINGSTON_SNV3S2000G_50026B768715E152";
+    device = "/dev/disk/by-id/nvme-Samsung_SSD_970_EVO_Plus_2TB_S4J4NX0R830938M";
     type = "disk";
     content = {
       type = "gpt";

--- a/hosts/uae/lab/node1/secrets.yaml
+++ b/hosts/uae/lab/node1/secrets.yaml
@@ -1,34 +1,34 @@
-ssh_host_ed25519_key: ENC[AES256_GCM,data:hTtlO+8JHSIkxkdFDoA8zYMPqqEFHVaHc/OJKNZflNCUX6T77zC/10sba8mhgZKThyb9Pt1seMWV/PDlrui9PQUkBsQKWlMe6xcHxg2vpXdhbvi+TUUjho1aTolzJZcpbt0RcG295z4u7usQuC+6dHRIGMIw5RW+vDRWd8S5Y5k9F2z9b4x/vgngiu8LgXveZI/ET2uVMMm+poh2f3l4uxPVxawDNHEnN/vg6lOXCUKdCM2IlQpo3T3c+FigFGtd19+3QYQfOiqY4lxmcTCGHs0yJYRv0p8RydEssLhsYNk+lKaMGfHpO1yjeP9Wba6wYo3mrDMDkJ+S4qgr7b9DsluHS5JXblRZ9IboRHsUzD95Bd0eHzWouVWKKX+mpoV1WiElr6vxb9r8uSFXId6uqSyTsUu6XRUfuMdlpH9UADQp1E6eQmX7TZjbAK8KTdI9TIUp3MyHvjcSXuq2j1OGNK/JZtr8oG24108CZcEU7+3dAaBrKAr4SbWH+L2ztUx7krEnpVrt0pylZ8T4YLrujJYG0t8/faFXob/M,iv:1lEeJN1cB9T9vjsAHeWt3P9SlRSZpswrUem36lh5vjk=,tag:UYdsI2u7wSaUj4G4SsiFmA==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:lGx32yb58Y7TFaJylj1AsqeHw0Upd+hF7cMwJ+7VmjZ0mQQ3tq+8bSxcVv4aZl2UJTwiR1cafL8HNEti/VAH20j889nCliVLz84PzRyfo9jWJSS43J3Emu3sBLnLeZXZtejxLeF2FaPC801au1IQMDFTXYPk975vrPZg0xGw1i010iEaRB0YuapRruh7lwo51oNlFohAcdmPZHUrIUqt7eBOBKw3fs42a/hnXqCVFjmN+ZZVK/XKw2PwIFmZwFLMfrtCrD82Ury/CZc2g9iusy72L0OWCIVm4oEakUj5ljdGYeIKmY/XqS91TxgSYBTukqQF3i5Hiko7seyp42uNa2jTJPElCb6OLxJBIZkXXYm8B0AqglK8I/6hLLSzO1wRcb4ZNKDn02+1DMZ6FuMRB5nUftobLsMXOt/siftqNEmA/CdPIw/OJFRlyEzBkWmqtPKJ6lr4AvI7o9tWZWVdh0+lmULvzNBukS1T6avxmndGBs1qBz4P7JiN122ROowxpSfGM2HDvyVTmMatNi18JotlpwDvNNXp/nmF,iv:95gpuUFXenvfeaqBfvJdP8OeocnqDXeU90SOPSyXev4=,tag:+AKVpl0RGqnVrur9HLxvqw==,type:str]
 sops:
     age:
         - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UG45VWt4bGVuRGVHY0Vq
-            N2xtb2ZqN0xMN293ZmUyUjQ5bUw1ZGYvWGlnCkJ1bU0vZlMyY1c1TXc5QnM2Zlc4
-            VGsvOTNKK0s1R0E1TlhuaC9FMFZ6c1UKLS0tIHNiNTgrWlh1STdwTEhWQkdZeCt1
-            MTN2dmVhLytDTTR5akFQUjRqTnUvSnMKdmzYqhtckrU6MM2hO2vRZHg1wQBMULMT
-            /ToJNdD9dnGRsHVwhwxytIa0QVCdwM1VMvjpWby2SUdbYF5APq4Kag==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPakQ2bVBjTlY3bDcwcmEw
+            dS80YWYveVE1OGV1czkwUE5zYmlXQ2xOSnlZCmdiTHdVVUxrTSs2bG12N3lGbGpS
+            Y2NZejRMeDc3cnNveE1NQW81dHUvNW8KLS0tIEdMNnhLb29mU1JQZnIwSU1ST0JF
+            bklsNzd0SmZSQUNJTUV0aVJuVEthdGcKkn+6p6sXYdvYirvdHg+3k725FzS0DenD
+            SZ0KpkViZnsIyg/03zdIgX1cqHBrKjAIRgiALTG1D0WCIv9gYhKenA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIQVpxa1VpK3l1N3h3Rk9C
-            ZjV4UmxydDBxOTNIdGwrYUJOcGkwcFhFZVdrCmpMemh5Mm5za2ZQSDlhUGNiWitB
-            bkt3R3MwWG9oYzI1M1NWWDVVRE4xdzgKLS0tIHRmTCtYT3d5UFphMUVLeEoxUGxO
-            VVFKTkVGSVdBcU9qSXp1Q3VrOGZUczAK+gIDENq2nsNgUvE9DmH2lDemzOeQu54I
-            BOLrL17cd2VejVhcE9EUUweuLQsA/RJInz4SzhvbztkoCoqpiZROcw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTZjBUc3ZucHVGam10UlBM
+            MDlxRnM1NUR6anhJQ0d3STk3TnBPTTAzU25nCk9sb24rc2R4Y0w1L05OdnlWT0ZB
+            MGxsQmF6WUE2ZFlXaEZtMnUveE5FR1UKLS0tIFNZM1ZCejVzbndnSUNBRXBpblA2
+            bmxTNWlCZFovZkt2Q0s2VnJIRVV6VnMKeon29YJDmdGM4OImpFpSlereU1GK4AGC
+            RM2s3YshXMrkV4U+lb+vF3cZSdZL4t/mvOone7zBycWI6frYpcL5Ow==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1ugtdwk3vgnug0xjcme3ft8a5rk2htd207z83dgp5gzk52ajf94dqerju4w
+        - recipient: age1k0ujgggnrh2k9f6c4w2vnt6z6vg7m8ulk6e25vrzqa2ntvhu3e7ql7t5yv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3aVNhM0gzWDMvWGZwVXNW
-            QlN4Smo5cE5iTFA1bzNRZEpSN0JJcmlWU1hJCk1PUXBRQmFkZVpWM1p2d2QxeWlC
-            Yno1dWJzRzloYk12MVVxTDFzVGRCdjgKLS0tIHc5MHR4RThDZXVqM3didmdLd1pW
-            RXdhdnF4Si9rejJOcGJjd2hhcGtpaE0KQtN/PHrIDr/2Uys/PikTnE6tUbqCWrPJ
-            9OlT1cgxRsde04cTrIeIaRf2dYPBEkdCZqAo+pqK/voioWdNbC9N4g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuL0p2M2hlWFFBVU5XQ3lq
+            dEtRbWJHVS8rYWZDN0ZFOG9sUVJ3ZFo2aFNJCkdxSEMrbHdtZDBoNkErbzQ1RUpn
+            ckkvN3FlU21UN1RldHlIWkNZSGpyRDAKLS0tIHdMNm1VQ2dNdEYvTlJyMlM0UXF6
+            bGZ5cDZmVTFDTW1JVkFjbTR6RmVtK3cKUN1IztuXkv8JKcmmI+2sqCymA2XBW+gQ
+            Fc+EO0n+lEXL032JsDB9MImt532QpIY8BtGeHx5Iabr1diiQ8gSAKA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-17T08:41:17Z"
-    mac: ENC[AES256_GCM,data:QXOVXdwPvDhbt3TtsPrutasl+VSWJhR7dVhFfW45BgBHJbWqm7Z6pnM6zCIF1QVynzc9T1gtOlKhVSS3JDfpDj28SuvVsCP5V1jB8+meHKYrq+o2S6VMlzYXumlfGnc9sUDUjo0qcProrX1FdEplhev9NbYgyIeP+9c8ESWuDn8=,iv:35HbmZsN0x5LzSFgST8uhJXafXKPymiq6a2tAkj7LKc=,tag:FfZU4LHiNGZrjHUNTcnjNg==,type:str]
+    lastmodified: "2026-04-28T08:12:03Z"
+    mac: ENC[AES256_GCM,data:kLD7YuYM49YPo8GXq8j5EfQIzKc0ghkeeqtzNj0XZ3KnXRxV+qdeKPv1ycDFj2lU41iwqj/hLylHQRD5TJYe64trJRgcBXXsuBy7Fdlaw0bosk78w3SDpMexN/6/P4ZsK7Uef5CEv4nWop14CyPF94wuK7NIaI2ZlREvhJqD710=,iv:TLqNubujY+eRShHhDqQDOAvYr+/tqtw7UmKwX4znxoA=,tag:n54DtuXqvExWcHlKTKibCQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/hosts/uae/nethsm-gateway/secrets.yaml
+++ b/hosts/uae/nethsm-gateway/secrets.yaml
@@ -1,6 +1,6 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:ir8256L7/Eelv0jPugu+pgv70/fBeZffyqyqSJriHrJMT5fXjGsiJ7e6YrbgqwpfYe0VvNtUv1n7nD6MDxZXbpqd9f4MeTVsdnEKzHkLVkuYMRGhrqqvFLDIQttTAM5eiWsUix7XZMYDsYyXXF+OTPijsq7HOZdgbVJnPFtvtqvea3udkCpRDZztPSaURmh6SK32pw0HfnLaJ9WEsXAIz/per3Z3Qxt8brvcoXsW4RzoViswclKjWegQIsw2Z9gRyy3+k3F3SIrFMOe2BvskQNG53XaCrYyQ9ecxmI3iAkiGA59+cYC28vt1fIfCpgZpRzAp8L51eqvzI8hT/YmjGOZXel3eqbx6gYb0DiJ+xFiyjTmTEVSaOvgo1svksje7iWYviyAMVvkO45A2AIu/MoAaepzmO2f5ppBlrjaBcfsiMwYPOg1s28l/SAswA7++KA8ksZm8A8cotmv/unrlhyOvrLNHmLAYLbm6QYKIMeLNuvVXwuzmwws2CXTWQleSY7m4aHSr8u6xJ7LThEuBT1rE0gN7ajXV/+C6lC+XUflxoRI=,iv:8hGlwPtevyKNE4claSG6iHGNKtTCpvmkdbOQOw+kBEc=,tag:tnkyOTXzwG/MM7a7Yb23Ow==,type:str]
-nebula-cert: ENC[AES256_GCM,data:vTiY73OS1plXhkCbrzd6YeGdcyx+66tIDXMi4RQjsEzYAMrGtyQAYBfQbEBJpWD+GRbhlEPhPWfcGw14HB4mF69FcE9bBu5fkiGM3P7O9NgIB40ghn7mRZhoVBt0cJ7S3Coap5WsJl5a5bWlnOQEjmj1DdQIVbLfmiA3KqgvhM9oOsD012qTRguHgu/9WXl/A07OFE+uot2RadXj2cW8dAn5S66JjQJwl0SrDV2JkkTn5ddF8cdazrWcEyTajaWbWib/FjWbawToK4QgiWZhPbgF2ktZhIdExtsYJfnVhdMzDrkUmj72+A+jZyGLpDlfOUIq82Kqif276uKBff66U8H8h9aO6E9tcsuq8+kwcFRp4DSFZIEqG8EG7Sbwwpu6FAz6fGetHCwqCoYIBc9lPFY42vbmNYQ7O3P7QvI+49hEQZS0eXCY8X+n2d3u269Trd+egrHhreVoOOYNeRCYtnDB7jrt,iv:dCDelBFdUFMquVEmaJ2wwtpcwx2+wvzaVY6rLTzLuCI=,tag:xJYeQQa3wB6SejNmW5Z1DA==,type:str]
-nebula-key: ENC[AES256_GCM,data:7c3ac3Wul/kYoUN1GjBTj+d06udmwumy2WHGu8YTfOkXBRs0TVIamaNfTjs1W3VWk5tUoUCAjpNiPQ5qy/NPLn/NC+CF8gmZcnf5LeFy9DQKgy+fWfpNDt4W/VreJ1p7XQB/HfywoSPRuHeR/aC9mKRPpR9SOpw6JvJNVsvl3Q==,iv:13tzkQCNqhO1czLbP5ipSox5HhvMeZm5ZzaXTk4vInc=,tag:mRQ2/yTZDv4wwo3d1BfGaw==,type:str]
+nebula-cert: ENC[AES256_GCM,data:fx0GCcVZYuFqfGeNXWuw0ZA6DzM8JIN2rUFVRxfHOkYW6zQvNdCeayfB4OFHagklQwsmgW5aoYcAki/Yng/XmQkngpI/cetxZ1exBean8IFdYqMINECFeNkbrSlUf2bF0coOK1kElrEmmOncNXqYNwR26LFXGIPMY7achpUdwmr8ybPraiJUkgH4l1nPSxTzLhVEH18oRuvgIru78gM05OviBGwT8KwCnd9oH9kpqwJuRl8+BX0c6Y5M4rRCvyvxcnw0wbx2MIIMFRAqu9uuYWcSC4XJmw6acsYjTCtIicU+ALvwln2l/4yGjW6JTvGmJrv3hDfWVnbOr08LViNXjSMj2zqgNSRVZTsUCavkApOJVdXstZIBVK3QBN8v8bzV+QeBaSbmipSCdHUSLjkkusp4ZoQmhZiwtVscTK5YeDWLYMoWc6TEyDb5QnPkSm9as4Bu6YqdKZ79FtLx/u4KxJY=,iv:n6DnCXCwEwe0PU2nCt8VYtij6CMvyyxWVbboJ+aK10E=,tag:f0HOMUw0Ueb/zzqlM5ot+Q==,type:str]
+nebula-key: ENC[AES256_GCM,data:bmSZIrO8Psl256v55ttSh51xOzYpl0gXhKygguQXzfRvLB69w3CKcDWhOvLxlPksZ2sSHUXXGvyAU8tx07PtDkkPSvO/JQL5w3vErIxTvoqOLlwfdhuoksWl5OFwOPMlRi4hmpn/v3HzoDBYgKDDoLpuCp1IHbmbwXIdiJuVyA==,iv:vjmolyN+gpgj1ZZJDNTK1FgeLUUzGGobhjPlab8AzTA=,tag:3AD5JgZytMxIS6Awu3heQA==,type:str]
 loki_password: ENC[AES256_GCM,data:FmMlFkHxC6eV8Bq5OaPrXKt/cw==,iv:5q1Iu9HNpkM66od49F/ziYEv4gPd+tKFCz2/UZd2xWA=,tag:tyrDSuXf2cR/q9fs0O15fw==,type:str]
 nethsm-metrics-credentials: ENC[AES256_GCM,data:edKuAskQp6qd+QyUZLYJly1Qh3lLV+mwybKJc1P7Zv9BHb8j1NSOvyLGo5/GkCLAQic9,iv:lJKM8U7hSSrgM8yq6GbaeeI3N+LtVmGa+I9cWmSvQF8=,tag:cPUn06CYOeOAjqZyrgyXoA==,type:str]
 nethsm-operator-password: ENC[AES256_GCM,data:OBd08zuNzVqDug==,iv:hzmBScNrMhXqQvoAEZpyPwurRxeoGwRcKYYeEVXn6LM=,tag:f2+qSGpBkGxJrwpv8TMJkA==,type:str]
@@ -53,7 +53,7 @@ sops:
             MnRxeTNuSjVoNzZ3TTJMV25PVVFFOGcKixtTzebv8V0aQtcQAWDyyOtYUe28poII
             oMR3rCLlZpRWDlNxB4HqMhQ5xRJM0Imy5rCr8d+Dm+PiA4jj4w+LxA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-17T08:13:24Z"
-    mac: ENC[AES256_GCM,data:Mz919H7Afo8scL98/TuGUbA3G0Jzaj4BgLSFYJ6M69+SoVLsZBcDlmEWcAARriruZeJqvVY91Lwbc9lpJLXUVdZdxp0GpnHzAfhSvNjz7Jf9B+JwrimSyzew40O4U+ouI4+lrw9+mF+ePstwaZXZPUkHPMRtmqG7af48UWxuzvk=,iv:ACLQwxgqfTAk/4lAkZ7+8BXrGdDPSKsco1Vcs9fcGuo=,tag:zco4ivaD7qLNLxOxU874Bg==,type:str]
+    lastmodified: "2026-04-28T06:42:01Z"
+    mac: ENC[AES256_GCM,data:EhZf6BFS3lH1YcmZQCv+wXXbX14l1hTIT9lu4KQL+2Bfsa2CK32vOlEBOcwZW5v7whBGTpwRJ4hZ8K/p17qwNiSLamZPbeaceGez0jX7NWEOpyxZG28rYQE35xlv6rNOQhlPBe0/8eIBcolJvhu4OCHpvzdXoc9iM1VIhz6UpYg=,iv:VIhTMgWNvVdsg4muCg59AKfjSFAngfdAH7oiLCJkfK8=,tag:Rgy3L4n5/xUEGOzXV1YRng==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1


### PR DESCRIPTION
Fix the mismatch ssh keys on UAE hosts uae-azureci-arm-1 and uae-lab-node1 on machines.nix.
Disk id and IP on node1 has been updated after redeploying the hosts.
Configure builder to use VPC private IP to avoid routing traffic through internet.