### PR TITLE
jenkins: allow manual hw-test to override derived device tag

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -120,10 +120,10 @@ def init() {
   }
   def flashTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
   def deviceInfo = null
-  if (flashTarget) {
+  if (flashTarget && !params.DEVICE_TAG) {
     deviceInfo = utils.derive_device_info(flashTarget, params.SECUREBOOT)
     if (!deviceInfo) {
-      error("Unable to parse device config for target '${flashTarget}'")
+      error("Could not derive DEVICE_TAG from target '${flashTarget}' and DEVICE_TAG is not defined")
     }
   }
   if (params.DEVICE_TAG) {


### PR DESCRIPTION
After https://github.com/tiiuae/ghaf-infra/pull/1012, `ghaf-hw-test-manual` no longer works with the generic `intel-laptop-debug` image.

When flashing, the device is usually derived from the image name. That does not work for generic images so device tag is used to determine the device.

Generic image & no device tag https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5733/ => fails
Generic image with device tag https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/5734/ => works