### PR TITLE
Grafana monitoring for ghaf-registry

### DIFF
--- a/hosts/ghaf-monitoring/configuration.nix
+++ b/hosts/ghaf-monitoring/configuration.nix
@@ -31,6 +31,7 @@ let
       ghaf-auth
       ghaf-monitoring
       ghaf-lighthouse
+      ghaf-registry
       hetzci-dev
       hetzci-prod
       hetzci-release
@@ -414,6 +415,20 @@ in
             machine_name = name;
           };
         }) hetznerCloudHosts;
+      }
+      {
+        job_name = "zot";
+        metrics_path = "/metrics";
+        scheme = "https";
+        tls_config.server_name = "registry.vedenemo.dev";
+        static_configs = [
+          {
+            targets = [ "${machines.ghaf-registry.internal_ip}:443" ];
+            labels = {
+              machine_name = "ghaf-registry";
+            };
+          }
+        ];
       }
       {
         # scrape nebula metrics if host has nebula ip address defined

--- a/hosts/ghaf-monitoring/provision/alert-rules/up.json
+++ b/hosts/ghaf-monitoring/provision/alert-rules/up.json
@@ -12,7 +12,7 @@
       "datasourceUid": "prometheus",
       "model": {
         "editorMode": "code",
-        "expr": "up{machine_name!~\"hetzci-release|hetz86-rel-2|hetzarm-rel-1\", job!~\"nebula|relay-board\"}",
+        "expr": "up{machine_name!~\"hetzci-release|hetz86-rel-2|hetzarm-rel-1\", job!~\"nebula|relay-board|zot\"}",
         "instant": true,
         "intervalMs": 1000,
         "legendFormat": "__auto",

--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -4,6 +4,7 @@
   pkgs,
   self,
   lib,
+  machines,
   inputs,
   config,
   ...
@@ -144,6 +145,11 @@ in
   system.stateVersion = lib.mkForce "25.11";
   networking.hostName = "ghaf-registry";
 
+  services.monitoring = {
+    metrics.enable = true;
+    logs.enable = true;
+  };
+
   sops = {
     secrets = {
       auth-client-secret.owner = "zot";
@@ -174,6 +180,14 @@ in
         proxy_max_temp_file_size 0;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+      '';
+    };
+
+    locations."= /metrics" = {
+      proxyPass = "http://127.0.0.1:${toString zotPort}/metrics";
+      extraConfig = ''
+        allow ${machines.ghaf-monitoring.internal_ip};
+        deny all;
       '';
     };
   };


### PR DESCRIPTION
Adds monitoring of the usual system metrics.

Also does preparations for monitoring zot metrics, but leaves endpoint authentication and new dashboard to a followup PR.