### PR TITLE
Extend client_body_timeout in registry nginx config

### DIFF
--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -180,6 +180,7 @@ in
         proxy_max_temp_file_size 0;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+        client_body_timeout 3600s;
       '';
     };
 


### PR DESCRIPTION
Attempt to fix the upload failures we're seeing under heavy load.

```
http2: Transport: cannot retry err [stream error: stream ID 17; PROTOCOL_ERROR; received from peer] 
after Request.Body was written; define Request.GetBody to avoid this error
```

Current nginx config does not set client_body_timeout; nginx therefore uses its default 60s.

The failed upload duration in Zot was 1m1s, and nginx recorded 408, so this points to nginx closing stalled/slow request-body reads.

So the likely cause is nginx timing out while reading the large client request body after a 60s stall. Under high publish concurrency, Jenkins/ORAS upload streams can stall long enough for nginx’s default client_body_timeout to fire. Zot then sees a truncated body as unexpected EOF, and ORAS reports the HTTP/2 stream PROTOCOL_ERROR because the request body was already written and cannot be retried.

---

time will tell if this actually fixes our issues.