### PR TITLE
Implement signing redundancy router

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -210,6 +210,16 @@ def assert_flash_target_unmounted(String dev) {
   """
 }
 
+def withRedundancyRouter(String object, Closure body) {
+  def signingEnv = readJSON text: run_cmd("select-pkcs11-node ${object}")
+  withEnv([
+    "PKCS11_PROXY_SOCKET=${signingEnv.socket}" // overrides the socket with one that works
+  ]) {
+    println "Proceeding to sign with ${signingEnv}"
+    body(signingEnv) // signingEnv object is available for closure
+  }
+}
+
 @NonCPS
 // Why NonCPS? Jenkins CPS does not handle regex matchers reliably.
 // See: https://stackoverflow.com/a/48465528
@@ -286,7 +296,6 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
   def artifacts_local_dir = "/var/lib/jenkins/${artifacts}"
   def artifacts_href = "<a href=\"/${artifacts}\">📦 Artifacts</a>"
   def immutable_tag = "${env.CI_ENV}-${stamp}-${target_commit}"
-  def signingToken = "YubiHSM"
   def signing_possible = env.CI_ENV != 'vm'
   def ghaf_checkout = pwd()
 
@@ -325,6 +334,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         signature: [
           path: null,
           signing_key: null,
+          signing_proxy: null,
         ],
       ],
       uefi: [
@@ -338,6 +348,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           signature: [
             path: null,
             signing_key: null,
+            signing_proxy: null,
           ],
         ],
         sbom_csv: [
@@ -450,15 +461,18 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
       if (signing_possible && it.get('provenance', true)) {
         stage("Sign (SLSA) provenance ${shortname}") {
           lock('signing') {
-            sh """
-              openssl pkeyutl -sign -rawin \
-                -inkey 'pkcs11:token=${signingToken};object=GhafInfraSignProv' \
-                -out ${output}/attestations/provenance.json.sig \
-                -in ${output}/attestations/provenance.json
-            """
+            withRedundancyRouter("GhafInfraSignProv") { ctx ->
+              sh """
+                openssl pkeyutl -sign -rawin \
+                  -inkey "${ctx.uri}" \
+                  -out ${output}/attestations/provenance.json.sig \
+                  -in ${output}/attestations/provenance.json
+              """
+              manifest.attestations.provenance.signature.path = "attestations/provenance.json.sig"
+              manifest.attestations.provenance.signature.signing_key = ctx.uri
+              manifest.attestations.provenance.signature.signing_proxy = ctx.socket
+            }
           }
-          manifest.attestations.provenance.signature.path = "attestations/provenance.json.sig"
-          manifest.attestations.provenance.signature.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignProv"
         }
       }
       if (!it.no_image) {
@@ -482,12 +496,16 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
               }
 
               lock('signing') {
-                sh """
-                  ${signer} /etc/jenkins/keys/secboot/DB.pem \
-                    'pkcs11:token=${signingToken};object=uefi-ghaf-db' \
-                    ${output}/${manifest.image.path} \
-                    ${tmpdir}
-                """
+                withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                  sh """
+                    ${signer} /etc/jenkins/keys/secboot/DB.pem \
+                      "${ctx.uri}" \
+                      ${output}/${manifest.image.path} \
+                      ${tmpdir}
+                  """
+                  manifest.uefi.signing_key = ctx.uri
+                  manifest.uefi.signing_proxy = ctx.socket
+                }
               }
 
               sh "mv ${tmpdir}/signed_${img_name} ${output}/${img_name}"
@@ -495,22 +513,24 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
               manifest.image.path = img_name
               manifest.uefi.signed = true;
               manifest.uefi.reason = null
-              manifest.uefi.signing_key = "pkcs11:token=${signingToken};object=uefi-ghaf-db"
             }
           }
           stage("Sign (SLSA) image ${shortname}") {
             lock('signing') {
               def img_name = path_basename(manifest.image.path)
               // sign the current main image be it unsigned or uefisigned
-              sh """
-                openssl dgst -sha256 -sign \
-                  'pkcs11:token=${signingToken};object=GhafInfraSignECP256' \
-                  -out ${output}/${img_name}.sig \
-                  ${output}/${manifest.image.path}
-              """
+              manifest.image.signature.path = "${img_name}.sig"
+              withRedundancyRouter("GhafInfraSignECP256") { ctx ->
+                sh """
+                  openssl dgst -sha256 -sign \
+                    "${ctx.uri}" \
+                    -out ${output}/${manifest.image.signature.path} \
+                    ${output}/${manifest.image.path}
+                """
+                manifest.image.signature.signing_key = ctx.uri
+                manifest.image.signature.signing_proxy = ctx.socket
+              }
             }
-            manifest.image.signature.path = "${path_basename(manifest.image.path)}.sig"
-            manifest.image.signature.signing_key = "pkcs11:token=${signingToken};object=GhafInfraSignECP256"
           }
         }
       }

--- a/hosts/hetzci/signing.nix
+++ b/hosts/hetzci/signing.nix
@@ -33,6 +33,7 @@ let
   proxyEnv = {
     PKCS11_PROXY_MODULE = "${pkcs11-proxy}/lib/libpkcs11-proxy.so";
     PKCS11_PROXY_TLS_PSK_FILE = config.sops.secrets.tls-pks-file.path;
+    # the default socket to use when redundancy router is not used
     PKCS11_PROXY_SOCKET = "tls://nethsm-gateway.sumu.vedenemo.dev:2345";
     PKCS11_TLS_IDENTITY = config.networking.hostName;
     OPENSSL_CONF = toString (
@@ -74,6 +75,7 @@ let
     ])
     ++ (with self.packages.${pkgs.stdenv.hostPlatform.system}; [
       verify-signature
+      select-pkcs11-node
     ])
     ++ [
       systemd-sbsign

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -33,10 +33,27 @@
           ];
         text = builtins.readFile ./archive-ghaf-release.sh;
       };
+      select-pkcs11-node = pkgs.writeShellApplication {
+        name = "select-pkcs11-node";
+        runtimeInputs = (
+          with pkgs;
+          [
+            jq
+            gnutls
+          ]
+        );
+        # bash options would apply to the parent shell when sourcing
+        bashOptions = [ ];
+        text = builtins.readFile ./select-pkcs11-node.sh;
+      };
     in
     {
       packages = {
-        inherit verify-signature archive-ghaf-release;
+        inherit
+          verify-signature
+          archive-ghaf-release
+          select-pkcs11-node
+          ;
       };
     };
 }

--- a/scripts/select-pkcs11-node.sh
+++ b/scripts/select-pkcs11-node.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Detect whether this file is sourced or executed
+_sourced=0
+if [[ ${BASH_SOURCE[0]} != "$0" ]]; then
+  _sourced=1
+fi
+
+# Save caller's shell option state before changing it
+_old_shell_opts="$(set +o)"
+_old_shopt_opts="$(shopt -p)"
+
+cleanup_shell_state() {
+  local rc=$?
+  eval "$_old_shell_opts"
+  eval "$_old_shopt_opts"
+  trap - EXIT RETURN
+
+  if [[ $_sourced -eq 1 ]]; then
+    return "$rc"
+  else
+    exit "$rc"
+  fi
+}
+
+if [[ $_sourced -eq 1 ]]; then
+  trap cleanup_shell_state RETURN
+else
+  trap cleanup_shell_state EXIT
+fi
+
+set -e
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") OBJECT
+
+Finds the first pkcs11 signing node that works.
+
+This script can either be sourced to populate the environment,
+or executed normally to return json stdout for further processing.
+
+Options:
+  OBJECT: The key that should be found on the node to consider it healthy
+
+Environment:
+  YUBIHSM_PIN: set to the pin of YubiHSM. When not specified, it's read from /run/secrets
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  # shellcheck disable=SC2317
+  return 1 2>/dev/null || exit 1
+fi
+
+OBJECT="$1"
+YUBIHSM_PIN="${YUBIHSM_PIN:-$(cat /run/secrets/yubihsm-pin 2>/dev/null || true)}"
+
+# the default timeout for unreachable pkcs11 proxy is minutes, we want to exit much earlier than that
+SOCKET_TIMEOUT="${SOCKET_TIMEOUT:-5s}"
+
+if [[ -z $YUBIHSM_PIN ]]; then
+  echo "Warning: YUBIHSM_PIN is empty. Connection to YubiHSMs will most likely fail." 1>&2
+fi
+
+# tokens are tried in this order
+PKCS11_TOKENS=(
+  "NetHSM"
+  "YubiHSM"
+)
+
+# sockets are tried in this order
+PKCS11_SOCKETS=(
+  "tls://nethsm-gateway.sumu.vedenemo.dev:2345"
+  "tls://uae-nethsm-gateway.sumu.vedenemo.dev:2345"
+)
+
+for token in "${PKCS11_TOKENS[@]}"; do
+  for socket in "${PKCS11_SOCKETS[@]}"; do
+    uri="pkcs11:token=$token;object=$OBJECT"
+
+    echo "[>] Checking $token on $socket" 1>&2
+    if GNUTLS_PIN="$YUBIHSM_PIN" \
+      PKCS11_PROXY_SOCKET="$socket" \
+      timeout "$SOCKET_TIMEOUT" \
+      p11tool \
+      --provider "$PKCS11_PROXY_MODULE" \
+      --login \
+      --list-all \
+      "$uri" >/dev/null; then
+
+      echo "Success!" 1>&2
+
+      if [[ $_sourced -eq 1 ]]; then
+        export PKCS11_PROXY_SOCKET="$socket"
+        export PKCS11_TOKEN="$token"
+        export PKCS11_URI="$uri"
+        echo "Exported into environment:"
+        echo "> PKCS11_PROXY_SOCKET=$socket"
+        echo "> PKCS11_TOKEN=$token"
+        echo "> PKCS11_URI=$socket"
+        return 0
+      else
+        jq -n \
+          --arg socket "$socket" \
+          --arg token "$token" \
+          --arg uri "$uri" \
+          '{
+            socket: $socket,
+            token: $token,
+            uri: $uri
+          }'
+        exit 0
+      fi
+    else
+      rc=$?
+      echo "Error! Exit code $rc" 1>&2
+    fi
+  done
+done
+
+# shellcheck disable=SC2317
+return 1 2>/dev/null || exit 1


### PR DESCRIPTION
Adds a PKCS11 signing redundancy router for the CI signing pipeline. Signing now selects the first healthy signing proxy/token combination for each requested key object instead of assuming one fixed token and socket. A node is considered "healthy" if p11tool can find the requested key object. The socket and key that were used are then recorded into the manifest.

The router prefers signing nodes in the following order:
- Tampere NetHSM
- Masdar NetHSM
- Tampere YubiHSM
- Masdar YubiHSM

The tunnel into Masdar is not functional at the moment so that part was left untested, but in theory it should work.

Note that as of now, the public keys used in the pipelines are hardcoded still to be the Tampere YubiHSM (coming from ghaf-infra-pki).

Tested at https://ci-dbg.vedenemo.dev/job/ghaf-manual/5/