### PR TITLE
Avoid Jenkins controller executor deadlock

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -253,6 +253,14 @@ def controller_workdir() {
   return "/var/lib/jenkins/ghaf-pipeline-workspaces/${tag}"
 }
 
+def build_tmpdir(String name) {
+  def component = safe_path_component(name)
+  if (!component || component == 'null') {
+    error("Cannot derive a unique build tmpdir for '${name}'")
+  }
+  return "${controller_workdir()}/tmp/${component}"
+}
+
 def clean_controller_workdir() {
   node('built-in') {
     sh "rm -rf '${controller_workdir()}'"
@@ -383,6 +391,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         signed: false,
         reason: null,
         signing_key: null,
+        signing_proxy: null,
       ],
       attestations: [
         provenance: [
@@ -530,7 +539,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           if (signing_possible) {
             if (it.get('uefisign', false) || it.get('uefisigniso', false)) {
               stage("Sign (UEFI) ${shortname}") {
-                def tmpdir = run_cmd("mktemp -d")
+                def tmpdir = build_tmpdir("uefisign-${shortname}")
                 def img_name = path_basename(manifest.image.path)
 
                 def signer = "uefisign"
@@ -538,24 +547,33 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
                   signer = "uefisign-simple"
                 }
 
-                lock('signing') {
-                  withRedundancyRouter("uefi-ghaf-db") { ctx ->
-                    sh """
-                      ${signer} /etc/jenkins/keys/secboot/DB.pem \
-                        "${ctx.uri}" \
-                        ${output}/${manifest.image.path} \
-                        ${tmpdir}
-                    """
-                    manifest.uefi.signing_key = ctx.uri
-                    manifest.uefi.signing_proxy = ctx.socket
-                  }
-                }
+                try {
+                  sh """
+                    rm -rf '${tmpdir}'
+                    mkdir -p '${tmpdir}'
+                  """
 
-                sh "mv ${tmpdir}/signed_${img_name} ${output}/${img_name}"
-                // replace original image with uefisigned one
-                manifest.image.path = img_name
-                manifest.uefi.signed = true;
-                manifest.uefi.reason = null
+                  lock('signing') {
+                    withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                      sh """
+                        ${signer} /etc/jenkins/keys/secboot/DB.pem \
+                          "${ctx.uri}" \
+                          ${output}/${manifest.image.path} \
+                          '${tmpdir}'
+                      """
+                      manifest.uefi.signing_key = ctx.uri
+                      manifest.uefi.signing_proxy = ctx.socket
+                    }
+                  }
+
+                  sh "mv '${tmpdir}/signed_${img_name}' '${output}/${img_name}'"
+                  // replace original image with uefisigned one
+                  manifest.image.path = img_name
+                  manifest.uefi.signed = true;
+                  manifest.uefi.reason = null
+                } finally {
+                  sh "rm -rf '${tmpdir}'"
+                }
               }
             }
             stage("Sign (SLSA) image ${shortname}") {

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -239,13 +239,42 @@ def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFla
   return null
 }
 
-def trigger_hw_test(
+@NonCPS
+def safe_path_component(String value) {
+  return value.replaceAll(/[^A-Za-z0-9_.-]/, '-')
+}
+
+def controller_workdir() {
+  def rawTag = env.BUILD_TAG ?: "${env.JOB_NAME}-${env.BUILD_NUMBER}"
+  def tag = safe_path_component(rawTag)
+  if (!tag || tag == 'null-null') {
+    error('Cannot derive a unique controller workdir for this build')
+  }
+  return "/var/lib/jenkins/ghaf-pipeline-workspaces/${tag}"
+}
+
+def clean_controller_workdir() {
+  node('built-in') {
+    sh "rm -rf '${controller_workdir()}'"
+  }
+}
+
+def with_controller_workspace(String workspace, Closure body) {
+  node('built-in') {
+    dir(workspace) {
+      body()
+    }
+  }
+}
+
+def run_hw_test(
   String shortname,
   String testset,
   String testagent_host,
   Map oci_result,
-  String output,
   boolean secureboot) {
+  // Keep the blocking downstream wait outside node('built-in') so ghaf-hw-test
+  // can acquire a controller executor for its own initialization stages.
   def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
   def test_params = [
     string(name: "TESTSET", value: testset),
@@ -264,6 +293,19 @@ def trigger_hw_test(
   def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
     parameters: test_params
   )
+  return [
+    absoluteUrl: job.absoluteUrl,
+    number: job.number,
+    result: job.result,
+  ]
+}
+
+def collect_hw_test_result(
+  String shortname,
+  String testset,
+  String output,
+  boolean secureboot,
+  Map job) {
   def logPrefix = secureboot ? "ghaf-hw-test log SB '${shortname}:" : "ghaf-hw-test log '${shortname}:"
   println(logPrefix)
   sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
@@ -372,207 +414,209 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
     }
 
     pipeline["${it.target}"] = {
-      // Build
-      stage("Build ${shortname}") {
-        sh "mkdir -v -p ${output}"
+      with_controller_workspace(ghaf_checkout) {
+        // Build
+        stage("Build ${shortname}") {
+          sh "mkdir -v -p ${output}"
 
-        manifest.build.ts_begin = run_cmd('date +%s')
-        lock(label: 'nix-build', quantity: 1) {
-          sh "nix build --fallback -v .#${it.target} --out-link ${output}/unsigned-output"
-        }
-        manifest.build.ts_finished = run_cmd('date +%s')
-      }
-      // Provenance
-      if (it.get('provenance', true)) {
-        stage("Provenance ${shortname}") {
-          def ext_params = """
-            {
-              "target": {
-                "name": "${it.target}",
-                "repository": "${target_repo}",
-                "ref": "${target_commit}"
-              },
-              "workflow": {
-                "name": "${host_name}",
-                "repository": "https://github.com/tiiuae/ghaf-infra",
-                "ref": "${host_revision}"
-              },
-              "job": "${env.JOB_NAME}",
-              "jobParams": ${JsonOutput.toJson(params)},
-              "buildRun": "${env.BUILD_ID}"
-            }
-          """
-          withEnv([
-            'PROVENANCE_BUILD_TYPE=https://github.com/tiiuae/ghaf-infra/blob/ea938e90/slsa/v1.0/L1/buildtype.md',
-            "PROVENANCE_BUILDER_ID=${env.JENKINS_URL}",
-            "PROVENANCE_INVOCATION_ID=${env.BUILD_URL}",
-            "PROVENANCE_TIMESTAMP_BEGIN=${manifest.build.ts_begin}",
-            "PROVENANCE_TIMESTAMP_FINISHED=${manifest.build.ts_finished}",
-            "PROVENANCE_EXTERNAL_PARAMS=${ext_params}"
-          ]) {
-            sh "mkdir -v -p ${output}/attestations"
-            sh """
-              attempt=1; max_attempts=5;
-              while ! provenance ${output}/unsigned-output --recursive --out ${output}/attestations/provenance.json; do
-                echo "provenance attempt=\$attempt failed"
-                if (( \$attempt >= \$max_attempts )); then
-                  exit 1
-                fi
-                attempt=\$(( \$attempt + 1 ))
-                sleep 30
-              done
-              echo "provenance attempt=\$attempt passed"
-            """
-            manifest.attestations.provenance.path = "attestations/provenance.json"
+          manifest.build.ts_begin = run_cmd('date +%s')
+          lock(label: 'nix-build', quantity: 1) {
+            sh "nix build --fallback -v .#${it.target} --out-link ${output}/unsigned-output"
           }
+          manifest.build.ts_finished = run_cmd('date +%s')
         }
-      }
-      // Build OTA pin
-      if (it.get('build_otapin', false)) {
-        stage("OTA Build ${shortname}") {
-          def ota_target = it.target.tokenize('.').last()
-          sh """
-            mkdir -v -p ${ota_target}; cd ${ota_target}
-            nixos-rebuild build --fallback --flake .#${ota_target}
-            mv result ${artifacts_local_dir}/otapin.${ota_target}
-            nix-store --add-root ${artifacts_local_dir}/otapin.${ota_target} \
-              -r ${artifacts_local_dir}/otapin.${ota_target}
-          """
-        }
-      }
-      // Run sbomnix
-      if (it.get('sbom', false)) {
-        stage("SBOM ${shortname}") {
-          def outdir = "${output}/attestations"
-          sh """
-            mkdir -v -p ${outdir}
-            sbomnix '${local_target_ref}' \
-              --csv ${outdir}/sbom.csv \
-              --cdx ${outdir}/sbom.cdx.json \
-              --spdx ${outdir}/sbom.spdx.json
-          """
-          manifest.attestations.sbom_csv.path = "attestations/sbom.csv"
-          manifest.attestations.sbom_cyclonedx.path = "attestations/sbom.cdx.json"
-          manifest.attestations.sbom_spdx.path = "attestations/sbom.spdx.json"
-        }
-      }
-      // Signing stages
-      // Skip signing stages only in vm, where the signing proxy is not configured.
-      if (signing_possible && it.get('provenance', true)) {
-        stage("Sign (SLSA) provenance ${shortname}") {
-          lock('signing') {
-            withRedundancyRouter("GhafInfraSignProv") { ctx ->
-              sh """
-                openssl pkeyutl -sign -rawin \
-                  -inkey "${ctx.uri}" \
-                  -out ${output}/attestations/provenance.json.sig \
-                  -in ${output}/attestations/provenance.json
-              """
-              manifest.attestations.provenance.signature.path = "attestations/provenance.json.sig"
-              manifest.attestations.provenance.signature.signing_key = ctx.uri
-              manifest.attestations.provenance.signature.signing_proxy = ctx.socket
-            }
-          }
-        }
-      }
-      if (!it.no_image) {
-        stage("Find image ${shortname}") {
-          def img_path = run_cmd("find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit")
-          if (!img_path) {
-            error("No image found!")
-          }
-          manifest.image.path = img_path - "${output}/"
-          manifest.image.role = image_role(manifest.image.path)
-        }
-        if (signing_possible) {
-          if (it.get('uefisign', false) || it.get('uefisigniso', false)) {
-            stage("Sign (UEFI) ${shortname}") {
-              def tmpdir = run_cmd("mktemp -d")
-              def img_name = path_basename(manifest.image.path)
-
-              def signer = "uefisign"
-              if (it.target.contains("nvidia-jetson-orin")) {
-                signer = "uefisign-simple"
+        // Provenance
+        if (it.get('provenance', true)) {
+          stage("Provenance ${shortname}") {
+            def ext_params = """
+              {
+                "target": {
+                  "name": "${it.target}",
+                  "repository": "${target_repo}",
+                  "ref": "${target_commit}"
+                },
+                "workflow": {
+                  "name": "${host_name}",
+                  "repository": "https://github.com/tiiuae/ghaf-infra",
+                  "ref": "${host_revision}"
+                },
+                "job": "${env.JOB_NAME}",
+                "jobParams": ${JsonOutput.toJson(params)},
+                "buildRun": "${env.BUILD_ID}"
               }
+            """
+            withEnv([
+              'PROVENANCE_BUILD_TYPE=https://github.com/tiiuae/ghaf-infra/blob/ea938e90/slsa/v1.0/L1/buildtype.md',
+              "PROVENANCE_BUILDER_ID=${env.JENKINS_URL}",
+              "PROVENANCE_INVOCATION_ID=${env.BUILD_URL}",
+              "PROVENANCE_TIMESTAMP_BEGIN=${manifest.build.ts_begin}",
+              "PROVENANCE_TIMESTAMP_FINISHED=${manifest.build.ts_finished}",
+              "PROVENANCE_EXTERNAL_PARAMS=${ext_params}"
+            ]) {
+              sh "mkdir -v -p ${output}/attestations"
+              sh """
+                attempt=1; max_attempts=5;
+                while ! provenance ${output}/unsigned-output --recursive --out ${output}/attestations/provenance.json; do
+                  echo "provenance attempt=\$attempt failed"
+                  if (( \$attempt >= \$max_attempts )); then
+                    exit 1
+                  fi
+                  attempt=\$(( \$attempt + 1 ))
+                  sleep 30
+                done
+                echo "provenance attempt=\$attempt passed"
+              """
+              manifest.attestations.provenance.path = "attestations/provenance.json"
+            }
+          }
+        }
+        // Build OTA pin
+        if (it.get('build_otapin', false)) {
+          stage("OTA Build ${shortname}") {
+            def ota_target = it.target.tokenize('.').last()
+            sh """
+              mkdir -v -p ${ota_target}; cd ${ota_target}
+              nixos-rebuild build --fallback --flake .#${ota_target}
+              mv result ${artifacts_local_dir}/otapin.${ota_target}
+              nix-store --add-root ${artifacts_local_dir}/otapin.${ota_target} \
+                -r ${artifacts_local_dir}/otapin.${ota_target}
+            """
+          }
+        }
+        // Run sbomnix
+        if (it.get('sbom', false)) {
+          stage("SBOM ${shortname}") {
+            def outdir = "${output}/attestations"
+            sh """
+              mkdir -v -p ${outdir}
+              sbomnix '${local_target_ref}' \
+                --csv ${outdir}/sbom.csv \
+                --cdx ${outdir}/sbom.cdx.json \
+                --spdx ${outdir}/sbom.spdx.json
+            """
+            manifest.attestations.sbom_csv.path = "attestations/sbom.csv"
+            manifest.attestations.sbom_cyclonedx.path = "attestations/sbom.cdx.json"
+            manifest.attestations.sbom_spdx.path = "attestations/sbom.spdx.json"
+          }
+        }
+        // Signing stages
+        // Skip signing stages only in vm, where the signing proxy is not configured.
+        if (signing_possible && it.get('provenance', true)) {
+          stage("Sign (SLSA) provenance ${shortname}") {
+            lock('signing') {
+              withRedundancyRouter("GhafInfraSignProv") { ctx ->
+                sh """
+                  openssl pkeyutl -sign -rawin \
+                    -inkey "${ctx.uri}" \
+                    -out ${output}/attestations/provenance.json.sig \
+                    -in ${output}/attestations/provenance.json
+                """
+                manifest.attestations.provenance.signature.path = "attestations/provenance.json.sig"
+                manifest.attestations.provenance.signature.signing_key = ctx.uri
+                manifest.attestations.provenance.signature.signing_proxy = ctx.socket
+              }
+            }
+          }
+        }
+        if (!it.no_image) {
+          stage("Find image ${shortname}") {
+            def img_path = run_cmd("find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit")
+            if (!img_path) {
+              error("No image found!")
+            }
+            manifest.image.path = img_path - "${output}/"
+            manifest.image.role = image_role(manifest.image.path)
+          }
+          if (signing_possible) {
+            if (it.get('uefisign', false) || it.get('uefisigniso', false)) {
+              stage("Sign (UEFI) ${shortname}") {
+                def tmpdir = run_cmd("mktemp -d")
+                def img_name = path_basename(manifest.image.path)
 
+                def signer = "uefisign"
+                if (it.target.contains("nvidia-jetson-orin")) {
+                  signer = "uefisign-simple"
+                }
+
+                lock('signing') {
+                  withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                    sh """
+                      ${signer} /etc/jenkins/keys/secboot/DB.pem \
+                        "${ctx.uri}" \
+                        ${output}/${manifest.image.path} \
+                        ${tmpdir}
+                    """
+                    manifest.uefi.signing_key = ctx.uri
+                    manifest.uefi.signing_proxy = ctx.socket
+                  }
+                }
+
+                sh "mv ${tmpdir}/signed_${img_name} ${output}/${img_name}"
+                // replace original image with uefisigned one
+                manifest.image.path = img_name
+                manifest.uefi.signed = true;
+                manifest.uefi.reason = null
+              }
+            }
+            stage("Sign (SLSA) image ${shortname}") {
               lock('signing') {
-                withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                def img_name = path_basename(manifest.image.path)
+                // sign the current main image be it unsigned or uefisigned
+                manifest.image.signature.path = "${img_name}.sig"
+                withRedundancyRouter("GhafInfraSignECP256") { ctx ->
                   sh """
-                    ${signer} /etc/jenkins/keys/secboot/DB.pem \
+                    openssl dgst -sha256 -sign \
                       "${ctx.uri}" \
-                      ${output}/${manifest.image.path} \
-                      ${tmpdir}
+                      -out ${output}/${manifest.image.signature.path} \
+                      ${output}/${manifest.image.path}
                   """
-                  manifest.uefi.signing_key = ctx.uri
-                  manifest.uefi.signing_proxy = ctx.socket
+                  manifest.image.signature.signing_key = ctx.uri
+                  manifest.image.signature.signing_proxy = ctx.socket
                 }
               }
-
-              sh "mv ${tmpdir}/signed_${img_name} ${output}/${img_name}"
-              // replace original image with uefisigned one
-              manifest.image.path = img_name
-              manifest.uefi.signed = true;
-              manifest.uefi.reason = null
             }
           }
-          stage("Sign (SLSA) image ${shortname}") {
-            lock('signing') {
-              def img_name = path_basename(manifest.image.path)
-              // sign the current main image be it unsigned or uefisigned
-              manifest.image.signature.path = "${img_name}.sig"
-              withRedundancyRouter("GhafInfraSignECP256") { ctx ->
+        }
+        // Link artifacts
+        stage("Link artifacts ${shortname}") {
+          if (manifest.image.path && !manifest.uefi.signed) {
+            def img_name = path_basename(manifest.image.path)
+            // make symlink from output root to original image if not using uefisigned
+            sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
+            manifest.image.path = img_name
+          }
+
+          writeFile(
+            file: "${output}/manifest.json",
+            text: JsonOutput.prettyPrint(JsonOutput.toJson(manifest))
+          )
+
+          if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
+            append_to_build_description(artifacts_href)
+          }
+        }
+        if (!it.no_image) {
+          stage("Publish OCI ${shortname}") {
+            if (sh(
+              script: 'command -v oci-publish >/dev/null 2>&1',
+              returnStatus: true
+            ) != 0) {
+              println("Skipping OCI publish ${shortname}: oci-publish is not installed")
+            } else {
+              withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
+                def job_name = env.JOB_BASE_NAME.replaceFirst('^ghaf-', '')
+                def target_name = it.target.replaceFirst('^packages\\.', '')
+                def oci_repository = "ghaf/${job_name}/${target_name}"
+                def oci_result_json = "${output}/oci-result.json"
                 sh """
-                  openssl dgst -sha256 -sign \
-                    "${ctx.uri}" \
-                    -out ${output}/${manifest.image.signature.path} \
-                    ${output}/${manifest.image.path}
+                  oci-publish target \
+                    -d '${output}' \
+                    -r '${oci_repository}' \
+                    -t '${immutable_tag}' \
+                    -o '${oci_result_json}'
                 """
-                manifest.image.signature.signing_key = ctx.uri
-                manifest.image.signature.signing_proxy = ctx.socket
+                oci_result = readJSON file: oci_result_json
               }
-            }
-          }
-        }
-      }
-      // Link artifacts
-      stage("Link artifacts ${shortname}") {
-        if (manifest.image.path && !manifest.uefi.signed) {
-          def img_name = path_basename(manifest.image.path)
-          // make symlink from output root to original image if not using uefisigned
-          sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
-          manifest.image.path = img_name
-        }
-
-        writeFile(
-          file: "${output}/manifest.json",
-          text: JsonOutput.prettyPrint(JsonOutput.toJson(manifest))
-        )
-
-        if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
-          append_to_build_description(artifacts_href)
-        }
-      }
-      if (!it.no_image) {
-        stage("Publish OCI ${shortname}") {
-          if (sh(
-            script: 'command -v oci-publish >/dev/null 2>&1',
-            returnStatus: true
-          ) != 0) {
-            println("Skipping OCI publish ${shortname}: oci-publish is not installed")
-          } else {
-            withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
-              def job_name = env.JOB_BASE_NAME.replaceFirst('^ghaf-', '')
-              def target_name = it.target.replaceFirst('^packages\\.', '')
-              def oci_repository = "ghaf/${job_name}/${target_name}"
-              def oci_result_json = "${output}/oci-result.json"
-              sh """
-                oci-publish target \
-                  -d '${output}' \
-                  -r '${oci_repository}' \
-                  -t '${immutable_tag}' \
-                  -o '${oci_result_json}'
-              """
-              oci_result = readJSON file: oci_result_json
             }
           }
         }
@@ -585,7 +629,10 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             Utils.markStageSkippedForConditional(testStageName)
             println("Skipping hardware tests for ${shortname}: CI_ENV is vm")
           } else {
-            trigger_hw_test(shortname, it.testset, testagent_host, oci_result, output, false)
+            def job = run_hw_test(shortname, it.testset, testagent_host, oci_result, false)
+            with_controller_workspace(ghaf_checkout) {
+              collect_hw_test_result(shortname, it.testset, output, false, job)
+            }
           }
         }
         // Run an additional secure boot test only when the target requests it and
@@ -594,7 +641,10 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         // regular test run cannot be replaced with a secure boot-only run.
         if (it.test_secboot && manifest.uefi.signed && env.CI_ENV == "prod") {
           stage("Test SB ${shortname}") {
-            trigger_hw_test(shortname, it.testset, testagent_host, oci_result, output, true)
+            def job = run_hw_test(shortname, it.testset, testagent_host, oci_result, true)
+            with_controller_workspace(ghaf_checkout) {
+              collect_hw_test_result(shortname, it.testset, output, true, job)
+            }
           }
         }
       }

--- a/hosts/hetzci/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/pipelines/ghaf-main.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
@@ -47,7 +46,7 @@ properties([
   githubProjectProperty(displayName: '', projectUrlStr: REPO_URL)
 ])
 pipeline {
-  agent { label 'built-in' }
+  agent none
   triggers {
     githubPush()
   }
@@ -60,8 +59,9 @@ pipeline {
     // before 'Reload only', otherwise this pipeline would never trigger
     // on githubPush().
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           checkout scmGit(
             branches: [[name: 'main']],
@@ -71,6 +71,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -81,8 +82,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             PIPELINE = utils.create_pipeline(TARGETS)
           }
@@ -91,11 +93,16 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def DEFAULT_REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 properties([
@@ -34,12 +33,13 @@ properties([
   ])
 ])
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -50,8 +50,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           checkout scmGit(
             branches: [[name: params.GITREF]],
@@ -61,8 +62,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             def TARGETS = []
             if (params.doc) {
@@ -141,11 +143,16 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
@@ -34,12 +33,13 @@ def TARGETS = [
 ]
 
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Set properties') {
+      agent { label 'built-in' }
       steps {
         script {
           properties([
@@ -71,6 +71,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -81,8 +82,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           checkout scmGit(
             branches: [[name: 'main']],
@@ -92,8 +94,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             if (params.SET_TESTAGENT_HOST && params.TESTAGENT_HOST) {
               PIPELINE = utils.create_pipeline(TARGETS, params.TESTAGENT_HOST)
@@ -106,13 +109,18 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            PIPELINE.each { key, value ->
-              value()
-            }
+        script {
+          PIPELINE.each { key, value ->
+            value()
           }
         }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-nightly-poweroff.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-poweroff.groovy
@@ -1,7 +1,10 @@
 #!/usr/bin/env groovy
 
 def poweroff(String device) {
-  def testagent_nodes = nodesByLabel(label: "$device", offline: false)
+  def testagent_nodes = null
+  node('built-in') {
+    testagent_nodes = nodesByLabel(label: "$device", offline: false)
+  }
   if (!testagent_nodes) {
     unstable("No '$device' test agents online")
     return
@@ -21,12 +24,13 @@ def poweroff(String device) {
 }
 
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Set properties') {
+      agent { label 'built-in' }
       steps {
         script {
           properties([
@@ -39,6 +43,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
@@ -64,12 +63,13 @@ def TARGETS = [
 ]
 
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
   stages {
     stage('Set properties') {
+      agent { label 'built-in' }
       steps {
         script {
           properties([
@@ -83,6 +83,7 @@ pipeline {
       }
     }
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -93,8 +94,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           checkout scmGit(
             branches: [[name: 'main']],
@@ -104,8 +106,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             PIPELINE = utils.create_pipeline(TARGETS)
           }
@@ -114,11 +117,16 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
@@ -45,12 +44,13 @@ properties([
 ])
 
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -61,8 +61,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             if (!params.GITHUB_PR_NUMBER) {
               error('Missing GITHUB_PR_NUMBER')
@@ -90,8 +91,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             if (params.SET_PR_STATUS) {
               utils.set_github_commit_status("Manual trigger: pending", "pending", env.TARGET_COMMIT)
@@ -110,26 +112,33 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
       }
     }
   }
   post {
+    always {
+      script {
+        utils.clean_controller_workdir()
+      }
+    }
     success {
       script {
         if (params.SET_PR_STATUS) {
-          utils.set_github_commit_status("Manual trigger: success", "success", env.TARGET_COMMIT)
+          node('built-in') {
+            utils.set_github_commit_status("Manual trigger: success", "success", env.TARGET_COMMIT)
+          }
         }
       }
     }
     unsuccessful {
       script {
         if (params.SET_PR_STATUS) {
-          utils.set_github_commit_status("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+          node('built-in') {
+            utils.set_github_commit_status("Manual trigger: failure", "failure", env.TARGET_COMMIT)
+          }
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def TARGETS = [
@@ -59,12 +58,13 @@ properties([
 ])
 
 pipeline {
-  agent { label 'built-in' }
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -75,8 +75,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           // https://www.jenkins.io/doc/pipeline/steps/params/scmgit/#scmgit
           // https://github.com/KostyaSha/github-integration-plugin/blob/master/docs/Configuration.adoc
@@ -117,8 +118,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             utils.set_github_commit_status("Pending", "pending", env.TARGET_COMMIT)
             def merge_commit = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
@@ -133,23 +135,30 @@ pipeline {
     }
     stage('Build') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
       }
     }
   }
   post {
+    always {
+      script {
+        utils.clean_controller_workdir()
+      }
+    }
     success {
       script {
-        utils.set_github_commit_status("Successful", "success", env.TARGET_COMMIT)
+        node('built-in') {
+          utils.set_github_commit_status("Successful", "success", env.TARGET_COMMIT)
+        }
       }
     }
     unsuccessful {
       script {
-        utils.set_github_commit_status("Failure", "failure", env.TARGET_COMMIT)
+        node('built-in') {
+          utils.set_github_commit_status("Failure", "failure", env.TARGET_COMMIT)
+        }
       }
     }
   }

--- a/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
+++ b/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
@@ -3,7 +3,6 @@
 @Library('ghafInfra') _
 
 def REPO_URL = 'https://github.com/tiiuae/ghaf/'
-def WORKDIR  = 'checkout'
 def PIPELINE = [:]
 
 def ALL_RELEASE_TARGETS = [
@@ -85,7 +84,7 @@ properties([
   ])
 ])
 pipeline {
-  agent { label 'built-in' }
+  agent none
   triggers {
     githubPush()
   }
@@ -94,6 +93,7 @@ pipeline {
   }
   stages {
     stage('Reload only') {
+      agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
       steps {
         script {
@@ -104,8 +104,9 @@ pipeline {
       }
     }
     stage('Checkout') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           deleteDir()
           checkout scmGit(
             branches: [[name: params.GITREF]],
@@ -115,8 +116,9 @@ pipeline {
       }
     }
     stage('Setup') {
+      agent { label 'built-in' }
       steps {
-        dir(WORKDIR) {
+        dir(utils.controller_workdir()) {
           script {
             if (params.RELEASE_TARGETS_SET.contains('All targets')) {
               println('All release targets selected')
@@ -136,11 +138,16 @@ pipeline {
     }
     stage('Build and test') {
       steps {
-        dir(WORKDIR) {
-          script {
-            parallel PIPELINE
-          }
+        script {
+          parallel PIPELINE
         }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
       }
     }
   }


### PR DESCRIPTION
Fix Jenkins controller executor deadlocks when build pipelines trigger `ghaf-hw-test`, and make UEFI-signing scratch cleanup robust so failed or  aborted runs do not leave large temporary images behind.

Previously, build branches held a `built-in` executor while waiting for the downstream hardware-test job. If enough branches reached that wait at once, all controller executors could be occupied by waiting parent jobs, while `ghaf-hw-test` builds were queued waiting for the same controller executors.

This PR changes the build pipelines to:
  - use `agent none` at the top level
  - allocate `built-in` only for stages that actually need controller workspace access
  - run the blocking `build(job: "ghaf-hw-test", wait: true)` outside `node('built-in')`
  - collect downstream logs/artifacts afterward inside a short controller workspace block
  - use and clean a per-build controller workdir, since `agent none` no longer gives the whole build one reserved Jenkins workspace
  -  move UEFI-signing scratch into a per-build controller workdir and clean it in a `finally` block so failed or aborted runs do not leave large temporary images behind


Tested in ci-dbg and ci-release.
