### PR TITLE
Increase socket timeout to 30s on pkcs11 router

### DIFF
--- a/scripts/select-pkcs11-node.sh
+++ b/scripts/select-pkcs11-node.sh
@@ -61,7 +61,7 @@ OBJECT="$1"
 YUBIHSM_PIN="${YUBIHSM_PIN:-$(cat /run/secrets/yubihsm-pin 2>/dev/null || true)}"
 
 # the default timeout for unreachable pkcs11 proxy is minutes, we want to exit much earlier than that
-SOCKET_TIMEOUT="${SOCKET_TIMEOUT:-5s}"
+SOCKET_TIMEOUT="${SOCKET_TIMEOUT:-30s}"
 
 if [[ -z $YUBIHSM_PIN ]]; then
   echo "Warning: YUBIHSM_PIN is empty. Connection to YubiHSMs will most likely fail." 1>&2


### PR DESCRIPTION
When nebula tunnel is waken from standby, it can take a while to start working.