### PR TITLE
Balance Nix builder jobs and cores

### DIFF
--- a/hosts/builders/hetz86-1/configuration.nix
+++ b/hosts/builders/hetz86-1/configuration.nix
@@ -11,7 +11,7 @@ let
 
   # Current host sizing: 96 vCPU, 251 GiB RAM, ~1760 GiB /nix disk.
   disk = tuning.mkDiskThresholds 1760;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 96;
     ramGiB = 251;
   };
@@ -56,8 +56,8 @@ in
     logs.enable = true;
   };
 
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 }

--- a/hosts/builders/hetz86-builder/configuration.nix
+++ b/hosts/builders/hetz86-builder/configuration.nix
@@ -5,8 +5,18 @@
   inputs,
   config,
   machines,
+  lib,
   ...
 }:
+let
+  tuning = import ../../lib/nix-tuning.nix { inherit lib; };
+
+  # Current hetzarm sizing: 80 vCPU, 250 GiB RAM.
+  armBuilder = tuning.mkBuildLimits {
+    cpus = 80;
+    ramGiB = 250;
+  };
+in
 {
   imports = [
     ./disk-config.nix
@@ -49,7 +59,7 @@
       {
         hostName = "hetzarm.vedenemo.dev";
         system = "aarch64-linux";
-        maxJobs = 40;
+        maxJobs = armBuilder.maxJobs;
         speedFactor = 1;
         supportedFeatures = [
           "nixos-test"

--- a/hosts/builders/hetz86-dbg-1/configuration.nix
+++ b/hosts/builders/hetz86-dbg-1/configuration.nix
@@ -11,7 +11,7 @@ let
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~337 GiB root disk.
   disk = tuning.mkDiskThresholds 337;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 30;
   };
@@ -53,8 +53,8 @@ in
     "ghaf-dbg"
   ];
   nix.settings.trusted-users = [ "@wheel" ];
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 

--- a/hosts/builders/hetz86-rel-2/configuration.nix
+++ b/hosts/builders/hetz86-rel-2/configuration.nix
@@ -11,7 +11,7 @@ let
 
   # Current host sizing: 96 vCPU, 251 GiB RAM, ~1760 GiB root (/nix) disk.
   disk = tuning.mkDiskThresholds 1760;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 96;
     ramGiB = 251;
   };
@@ -58,8 +58,8 @@ in
     logs.enable = true;
   };
 
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 

--- a/hosts/builders/hetzarm-dbg-1/configuration.nix
+++ b/hosts/builders/hetzarm-dbg-1/configuration.nix
@@ -12,7 +12,7 @@ let
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~300 GiB root disk.
   disk = tuning.mkDiskThresholds 300;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 30;
   };
@@ -55,8 +55,8 @@ in
     "ghaf-dbg"
   ];
   nix.settings.trusted-users = [ "@wheel" ];
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -12,7 +12,7 @@ let
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~300 GiB root disk.
   disk = tuning.mkDiskThresholds 300;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 30;
   };
@@ -61,8 +61,8 @@ in
   nix.settings.trusted-users = [
     "hetzarm-rel-1-builder"
   ];
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 

--- a/hosts/builders/hetzarm/configuration.nix
+++ b/hosts/builders/hetzarm/configuration.nix
@@ -11,7 +11,7 @@ let
 
   # Current host sizing: 80 vCPU, 250 GiB RAM, ~3520 GiB /nix disk.
   disk = tuning.mkDiskThresholds 3520;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 80;
     ramGiB = 250;
   };
@@ -66,8 +66,8 @@ in
     "@wheel"
     "hetz86-builder"
   ];
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 }

--- a/hosts/hetzci/casc/common.yaml
+++ b/hosts/hetzci/casc/common.yaml
@@ -5,7 +5,6 @@ appearance:
     theme: "darkSystem" # follow system theme
 
 jenkins:
-  numExecutors: 4
   markupFormatter:
     rawHtml:
       disableSyntaxHighlighting: false

--- a/hosts/hetzci/dbg/configuration.nix
+++ b/hosts/hetzci/dbg/configuration.nix
@@ -12,7 +12,7 @@ let
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~300 GiB root disk.
   controllerDisk = tuning.mkDiskThresholds 300;
-  builderMaxJobs = tuning.mkMaxJobs {
+  builder = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 30;
   };
@@ -109,7 +109,7 @@ in
           {
             hostName = trustedBuilderHost machines.hetzarm-dbg-1.ip;
             system = "aarch64-linux";
-            maxJobs = builderMaxJobs;
+            maxJobs = builder.maxJobs;
           }
           // commonOptions
         )
@@ -117,7 +117,7 @@ in
           {
             hostName = trustedBuilderHost machines.hetz86-dbg-1.ip;
             system = "x86_64-linux";
-            maxJobs = builderMaxJobs;
+            maxJobs = builder.maxJobs;
           }
           // commonOptions
         )

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -42,6 +42,7 @@ let
     # YAML is a superset of JSON, ie. json is valid yaml
     builtins.toJSON {
       unclassified.location.url = "${cfg.url}";
+      jenkins.numExecutors = cfg.numExecutors;
       jenkins.nodes = # all permutations of device and host lists
         lib.mapCartesianProduct
           (
@@ -79,6 +80,11 @@ in
     url = lib.mkOption {
       type = lib.types.str;
       description = "Public URL of the jenkins instance";
+    };
+    numExecutors = lib.mkOption {
+      type = lib.types.ints.positive;
+      description = "Number of built-in Jenkins executors.";
+      default = 12;
     };
     extraCasc = lib.mkOption {
       type = lib.types.attrs;

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -15,11 +15,11 @@ let
   # Current release builder sizing:
   # - hetz86-rel-2: 96 vCPU, 251 GiB RAM
   # - hetzarm-rel-1: 16 vCPU, 30 GiB RAM
-  x86BuilderMaxJobs = tuning.mkMaxJobs {
+  x86Builder = tuning.mkBuildLimits {
     cpus = 96;
     ramGiB = 251;
   };
-  armBuilderMaxJobs = tuning.mkMaxJobs {
+  armBuilder = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 30;
   };
@@ -104,7 +104,7 @@ in
           // {
             hostName = trustedBuilderHost "hetz86-rel-2";
             system = "x86_64-linux";
-            maxJobs = x86BuilderMaxJobs;
+            maxJobs = x86Builder.maxJobs;
             speedFactor = 12;
             sshUser = "hetz86-rel-2-builder";
             sshKey = "/etc/ssh/certs/hetz86-rel-2-builder";
@@ -115,7 +115,7 @@ in
           // {
             hostName = trustedBuilderHost "hetzarm-rel-1";
             system = "aarch64-linux";
-            maxJobs = armBuilderMaxJobs;
+            maxJobs = armBuilder.maxJobs;
             speedFactor = 2;
             sshUser = "hetzarm-rel-1-builder";
             sshKey = "/etc/ssh/certs/hetzarm-rel-1-builder";

--- a/hosts/hetzci/remote-builders.nix
+++ b/hosts/hetzci/remote-builders.nix
@@ -13,11 +13,11 @@ let
   # Current shared builder sizing:
   # - hetz86-1: 96 vCPU, 251 GiB RAM
   # - hetzarm: 80 vCPU, 250 GiB RAM
-  x86BuilderMaxJobs = tuning.mkMaxJobs {
+  x86Builder = tuning.mkBuildLimits {
     cpus = 96;
     ramGiB = 251;
   };
-  armBuilderMaxJobs = tuning.mkMaxJobs {
+  armBuilder = tuning.mkBuildLimits {
     cpus = 80;
     ramGiB = 250;
   };
@@ -48,7 +48,7 @@ in
           {
             hostName = trustedBuilderHost "hetzarm.vedenemo.dev";
             system = "aarch64-linux";
-            maxJobs = armBuilderMaxJobs;
+            maxJobs = armBuilder.maxJobs;
           }
           // commonOptions
         )
@@ -56,7 +56,7 @@ in
           {
             hostName = trustedBuilderHost "hetz86-1.vedenemo.dev";
             system = "x86_64-linux";
-            maxJobs = x86BuilderMaxJobs;
+            maxJobs = x86Builder.maxJobs;
           }
           // commonOptions
         )

--- a/hosts/lib/nix-tuning.nix
+++ b/hosts/lib/nix-tuning.nix
@@ -5,7 +5,7 @@ let
   # Keep binary units explicit to avoid repeated literals in callers.
   gib = 1024 * 1024 * 1024;
 in
-{
+rec {
   # Exported for host modules that need byte conversion for custom values.
   inherit gib;
 
@@ -46,9 +46,29 @@ in
       maxFreeBytes = maxFreeGiB * gib;
     };
 
-  # Bound concurrent builds by both CPU and RAM:
-  # - cpu bound: at most half the cores used by concurrent jobs
-  # - ram bound: at most one job per 4 GiB RAM
-  # This is intentionally conservative to reduce OOM pressure and thrashing.
-  mkMaxJobs = { cpus, ramGiB }: lib.max 1 (lib.min (builtins.div cpus 2) (builtins.div ramGiB 4));
+  # Bound concurrent builds by both CPU and RAM, and pair that with the number
+  # of cores exposed to each derivation through NIX_BUILD_CORES.
+  #
+  # Start from a conservative job budget:
+  # - cpu bound: at most half the host CPUs as concurrent jobs
+  # - ram bound: roughly one job per 4 GiB RAM, rounded up
+  #
+  # Then choose a wider per-job core count while retaining enough job
+  # concurrency to keep the build graph fed. The aggregate CPU budget is capped
+  # at the host CPU count.
+  mkBuildLimits =
+    { cpus, ramGiB }:
+    let
+      ceilDiv = x: y: builtins.div (x + y - 1) y;
+      jobBudget = lib.max 1 (lib.min (builtins.div cpus 2) (builtins.div (ramGiB + 3) 4));
+      aggregateCoreBudget = lib.min cpus (jobBudget * 2);
+      minJobs = lib.min jobBudget (lib.max 1 (lib.max 4 (ceilDiv jobBudget 3)));
+      cores = lib.max 1 (builtins.div aggregateCoreBudget minJobs);
+      maxJobs = lib.max 1 (lib.min jobBudget (builtins.div aggregateCoreBudget cores));
+    in
+    {
+      inherit cores maxJobs;
+    };
+
+  mkMaxJobs = args: (mkBuildLimits args).maxJobs;
 }

--- a/hosts/uae/azureci/builders/az86-1/configuration.nix
+++ b/hosts/uae/azureci/builders/az86-1/configuration.nix
@@ -8,6 +8,15 @@
   lib,
   ...
 }:
+let
+  tuning = import ../../../../lib/nix-tuning.nix { inherit lib; };
+
+  # Current host sizing: 32 vCPU, 128 GiB RAM.
+  build = tuning.mkBuildLimits {
+    cpus = 32;
+    ramGiB = 128;
+  };
+in
 {
   imports = [
     ./disk-config.nix
@@ -59,4 +68,7 @@
     dmidecode
     jq
   ];
+
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
 }

--- a/hosts/uae/azureci/builders/hetzarm-1/configuration.nix
+++ b/hosts/uae/azureci/builders/hetzarm-1/configuration.nix
@@ -13,7 +13,7 @@ let
 
   # Current host sizing: 16 vCPU, 32 GiB RAM, ~1024 GiB /nix disk.
   disk = tuning.mkDiskThresholds 1024;
-  jobs = tuning.mkMaxJobs {
+  build = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 32;
   };
@@ -41,8 +41,8 @@ in
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  nix.settings.max-jobs = lib.mkForce jobs;
-  nix.settings.cores = lib.mkForce 2;
+  nix.settings.max-jobs = lib.mkForce build.maxJobs;
+  nix.settings.cores = lib.mkForce build.cores;
   nix.settings.min-free = lib.mkForce disk.minFreeBytes;
   nix.settings.max-free = lib.mkForce disk.maxFreeBytes;
 

--- a/hosts/uae/azureci/remote-builders.nix
+++ b/hosts/uae/azureci/remote-builders.nix
@@ -12,11 +12,11 @@ let
   # Current shared builder sizing:
   # - az86-1: 32 vCPU, 128 GiB RAM
   # - hetzarm-1: 16 vCPU, 32 GiB RAM
-  x86BuilderMaxJobs = tuning.mkMaxJobs {
+  x86Builder = tuning.mkBuildLimits {
     cpus = 32;
     ramGiB = 128;
   };
-  armBuilderMaxJobs = tuning.mkMaxJobs {
+  armBuilder = tuning.mkBuildLimits {
     cpus = 16;
     ramGiB = 32;
   };
@@ -47,7 +47,7 @@ in
           {
             hostName = "10.51.16.5";
             system = "x86_64-linux";
-            maxJobs = x86BuilderMaxJobs;
+            maxJobs = x86Builder.maxJobs;
           }
           // commonOptions
         )
@@ -55,7 +55,7 @@ in
           {
             hostName = "91.98.90.243";
             system = "aarch64-linux";
-            maxJobs = armBuilderMaxJobs;
+            maxJobs = armBuilder.maxJobs;
           }
           // commonOptions
         )


### PR DESCRIPTION
Calculate remote-builder `max-jobs` and `cores` from a shared sizing policy. The policy preserves the intended invariant for the configured host sizes: `max-jobs * cores <= vCPU`, but gives more `cores` to each build so the narrow build-graph phases can progress faster. 

The PR also raises Jenkins built-in executors from 4 to 12. This prevents Jenkins from throttling parallel branches before they reach the existing 12-slot `nix-build` lock and Nix builder limits

#### Why?

A build graph is the dependency graph of derivations. Some phases are wide: many independent packages can build in parallel, so high `max-jobs` helps. Other phases are narrow: only one or a few large derivations are ready to be built, often because later work is blocked on them.

In those narrow phases, running many concurrent jobs (`max-jobs`) is not useful because there are not enough independent jobs to fill the builder. Instead, giving each active build more `cores` can help, if those derivations support parallel compilation.

#### What the Values Mean

- `nix.settings.max-jobs`
  Builder-side daemon limit. This is the maximum number of build jobs the remote builder's Nix daemon will actually run concurrently.

- `buildMachines[*].maxJobs`
   Controller-side scheduling limit. This controls how many build jobs a controller may dispatch to a given remote builder.

- `nix.settings.cores`
  Per-build core count. This controls the `NIX_BUILD_CORES` value exposed to each build, allowing individual derivation build jobs to use that many `cores` when the build jobs support parallel builds.

- `hetzci.jenkins.numExecutors`
  Jenkins built-in executor count. This controls how many pipeline branches can run controller-local work concurrently, including the `nix build` steps before Nix/remote-builder throttling takes over.


#### Builder Daemon Limits

| Host | Old `max-jobs` | New `max-jobs` | Old `cores` | New `cores` |
|---|---:|---:|---:|---:|
| `hetzarm` | 40 | 16 | 2 | 5 |
| `hetz86-1` | 48 | 16 | 2 | 6 |
| `hetz86-rel-2` | 48 | 16 | 2 | 6 |
| `hetzarm-rel-1` | 7 | 4 | 2 | 4 |
| `hetzarm-dbg-1` | 7 | 4 | 2 | 4 |
| `hetz86-dbg-1` | 7 | 4 | 2 | 4 |
| `uae-azureci-az86-1` | auto | 6 | 0 | 5 |
| `uae-azureci-hetzarm-1` | 8 | 4 | 2 | 4 |


#### Controller `maxJobs` Limits

| Controller/config | Remote builders | Old `maxJobs` | New `maxJobs` |
|---|---|---:|---:|
| `hetzci-dbg` | arm / x86 | 7 / 7 | 4 / 4 |
| `hetzci-release` | x86 / arm | 48 / 7 | 16 / 4 |
| `hetzci-dev` | arm / x86 | 40 / 48 | 16 / 16 |
| `hetzci-prod` | arm / x86 | 40 / 48 | 16 / 16 |
| `hetzci-vm` | arm / x86 | 40 / 48 | 16 / 16 |
| `hetzci-vm-no-host-nix-store` | arm / x86 | 40 / 48 | 16 / 16 |
| `uae-azureci-prod` | az86 / arm | 16 / 8 | 6 / 4 |
| `hetz86-builder` | hetzarm | 40 | 16 |


#### Jenkins Controller Executors

| Config | Old built-in executors | New built-in executors |
|---|---:|---:|
| all `hetzci.jenkins` environments | 4 | 12 |

Tested in ci-dbg.
Tested in ci-release: https://ci-release.vedenemo.dev/job/ghaf-release-candidate/2/