### PR TITLE
Add cosign wrapper

### DIFF
--- a/hosts/hetzci/signing.nix
+++ b/hosts/hetzci/signing.nix
@@ -76,6 +76,7 @@ let
     ++ (with self.packages.${pkgs.stdenv.hostPlatform.system}; [
       verify-signature
       select-pkcs11-node
+      run-cosign
     ])
     ++ [
       systemd-sbsign

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -35,16 +35,21 @@
       };
       select-pkcs11-node = pkgs.writeShellApplication {
         name = "select-pkcs11-node";
-        runtimeInputs = (
-          with pkgs;
-          [
-            jq
-            gnutls
-          ]
-        );
+        runtimeInputs = with pkgs; [
+          jq
+          gnutls
+        ];
         # bash options would apply to the parent shell when sourcing
         bashOptions = [ ];
         text = builtins.readFile ./select-pkcs11-node.sh;
+      };
+
+      run-cosign = pkgs.writeShellApplication {
+        name = "run-cosign";
+        runtimeInputs = with pkgs; [
+          cosign
+        ];
+        text = builtins.readFile ./run-cosign.sh;
       };
     in
     {
@@ -53,6 +58,7 @@
           verify-signature
           archive-ghaf-release
           select-pkcs11-node
+          run-cosign
           ;
       };
     };

--- a/scripts/run-cosign.sh
+++ b/scripts/run-cosign.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+OCI_REGISTRY=${OCI_REGISTRY:-"registry.vedenemo.dev"}
+OCI_USERNAME=${OCI_USERNAME:-"jenkins"}
+
+if [[ -z ${OCI_PASSWORD:-} ]]; then
+  echo "OCI_PASSWORD is empty, cannot sign without credentials!"
+  exit 1
+fi
+
+if [[ -z ${COSIGN_PKCS11_MODULE_PATH:-} ]]; then
+  COSIGN_PKCS11_MODULE_PATH="${PKCS11_PROXY_MODULE:-}"
+fi
+export COSIGN_PKCS11_MODULE_PATH
+
+COSIGN_PKCS11_PIN="${YUBIHSM_PIN:-$(cat /run/secrets/yubihsm-pin 2>/dev/null || true)}"
+export COSIGN_PKCS11_PIN
+
+DOCKER_CONFIG="$(mktemp -d)"
+export DOCKER_CONFIG
+
+trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+
+printf '%s' "$OCI_PASSWORD" | cosign login "$OCI_REGISTRY" \
+  --username "$OCI_USERNAME" \
+  --password-stdin
+
+cosign sign --yes "$@"


### PR DESCRIPTION
Cosign wrapper which creates a temporary authenticated session and runs the signing command with passed arguments and uses our configured PKCS11_PROXY_MODULE, making it also compatible with the redundancy router.

Not used anywhere yet since we are missing the keys and certificates.