### PR TITLE
Stop superseded ghaf-main builds

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -354,7 +354,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
   // Evaluate
   stage("Eval") {
     lock('evaluator') {
-      sh 'nix flake show --all-systems | ansi2txt'
+      sh 'bash -o pipefail -c "nix flake show --all-systems | ansi2txt"'
     }
   }
   targets.each { target_config ->


### PR DESCRIPTION
Fix `ghaf-main` superseded builds continuing after Jenkins has already requested an abort.

Fix:
- Run the Eval-stage `nix flake show --all-systems | ansi2txt` command with `pipefail`, so an interrupted `nix` process is not hidden by a successful `ansi2txt` exit.

Tested in ci-vm.

#### Why?
Some `ghaf-main` builds were marked superseded by newer builds but kept running until manually stopped. Jenkins did send the interrupt, but the Eval shell pipeline could mask the interrupted `nix` exit status and allow the pipeline to continue.


