### PR TITLE
Add fleetdm server nix configuration

### DIFF
--- a/hosts/ghaf-fleetdm/configuration.nix
+++ b/hosts/ghaf-fleetdm/configuration.nix
@@ -2,21 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   self,
-  pkgs,
   inputs,
   lib,
   ...
 }:
 {
   imports = [
-    ./disk-config.nix
-    ../hetzner-cloud.nix
     inputs.sops-nix.nixosModules.sops
     inputs.disko.nixosModules.disko
+    ./disk-config.nix
+    ../hetzner-cloud.nix
+    ./fleet.nix
   ]
   ++ (with self.nixosModules; [
     common
     service-openssh
+    service-nginx
     team-devenv
     user-vadikas
   ]);
@@ -24,11 +25,4 @@
   networking.hostName = "ghaf-fleetdm";
   system.stateVersion = lib.mkForce "25.05";
   sops.defaultSopsFile = ./secrets.yaml;
-
-  virtualisation.docker.enable = true;
-
-  environment.systemPackages = with pkgs; [
-    fleet
-    fleetctl
-  ];
 }

--- a/hosts/ghaf-fleetdm/fleet.nix
+++ b/hosts/ghaf-fleetdm/fleet.nix
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  config,
+  pkgs,
+  self,
+  ...
+}:
+
+let
+  domain = "fleetdm.vedenemo.dev";
+  fleetPort = 1337;
+  inherit (self.packages.${pkgs.stdenv.hostPlatform.system}) fleet fleetctl;
+in
+{
+  environment.systemPackages = [
+    fleet
+    fleetctl
+  ];
+
+  users.groups.fleet = { };
+
+  users.users.fleet = {
+    isSystemUser = true;
+    group = "fleet";
+    home = "/var/lib/fleet";
+    createHome = true;
+  };
+
+  sops.secrets."fleet-private-key" = {
+    owner = "fleet";
+    group = "fleet";
+    mode = "0400";
+  };
+
+  sops.templates."fleet-env" = {
+    owner = "fleet";
+    group = "fleet";
+    mode = "0400";
+    restartUnits = [ "fleetdm.service" ];
+
+    content = ''
+      FLEET_SERVER_PRIVATE_KEY=${config.sops.placeholder."fleet-private-key"}
+    '';
+  };
+
+  services.mysql = {
+    enable = true;
+    package = pkgs.mysql84;
+
+    ensureDatabases = [
+      "fleet"
+    ];
+
+    ensureUsers = [
+      {
+        name = "fleet";
+        ensurePermissions = {
+          "fleet.*" = "ALL PRIVILEGES";
+        };
+      }
+    ];
+  };
+
+  services.redis.servers.fleet = {
+    enable = true;
+    bind = "127.0.0.1";
+    port = 6379;
+  };
+
+  # Fleet configuration
+  environment.etc."fleet/fleet.yml".text = ''
+    mysql:
+      protocol: unix
+      address: /run/mysqld/mysqld.sock
+      database: fleet
+      username: fleet
+
+    redis:
+      address: 127.0.0.1:${toString config.services.redis.servers.fleet.port}
+      database: 0
+
+    server:
+      address: 127.0.0.1:${toString fleetPort}
+      tls: false
+      trusted_proxies: "header:X-Real-IP"
+
+    osquery:
+      status_log_plugin: filesystem
+      result_log_plugin: filesystem
+
+    filesystem:
+      status_log_file: /var/log/fleet/osqueryd.status.log
+      result_log_file: /var/log/fleet/osqueryd.results.log
+
+    vulnerabilities:
+      current_instance_checks: true
+      databases_path: /var/lib/fleet/vulndb
+  '';
+
+  # Prepare Fleet database
+  systemd.services.fleetdm-prepare-db = {
+    description = "Prepare FleetDM database";
+
+    after = [
+      "mysql.service"
+    ];
+
+    requires = [
+      "mysql.service"
+    ];
+
+    serviceConfig = {
+      Type = "oneshot";
+      User = "fleet";
+      Group = "fleet";
+      StateDirectory = "fleet";
+    };
+
+    script = ''
+      ${fleet}/bin/fleet prepare db --no-prompt --config /etc/fleet/fleet.yml
+    '';
+  };
+
+  # Fleet server
+  systemd.services.fleetdm = {
+    description = "FleetDM server";
+
+    wantedBy = [ "multi-user.target" ];
+
+    after = [
+      "network-online.target"
+      "mysql.service"
+      "redis-fleet.service"
+      "fleetdm-prepare-db.service"
+    ];
+
+    wants = [
+      "network-online.target"
+    ];
+
+    requires = [
+      "mysql.service"
+      "redis-fleet.service"
+      "fleetdm-prepare-db.service"
+    ];
+
+    serviceConfig = {
+      User = "fleet";
+      Group = "fleet";
+
+      EnvironmentFile = [ config.sops.templates."fleet-env".path ];
+
+      ExecStart = "${fleet}/bin/fleet serve --config /etc/fleet/fleet.yml";
+
+      Restart = "on-failure";
+      RestartSec = "5s";
+
+      StateDirectory = "fleet";
+      LogsDirectory = "fleet";
+      RuntimeDirectory = "fleet";
+
+      # hardening
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      PrivateDevices = true;
+      ProtectClock = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectKernelLogs = true;
+      ProtectControlGroups = true;
+      RestrictSUIDSGID = true;
+      LockPersonality = true;
+    };
+
+    restartTriggers = [
+      config.environment.etc."fleet/fleet.yml".source
+    ];
+  };
+
+  services.nginx.virtualHosts.${domain} = {
+    forceSSL = true;
+    enableACME = true;
+
+    locations."/" = {
+      proxyPass = "http://127.0.0.1:${toString fleetPort}";
+      proxyWebsockets = true;
+
+      extraConfig = ''
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 100m;
+      '';
+    };
+  };
+}

--- a/hosts/ghaf-fleetdm/secrets.yaml
+++ b/hosts/ghaf-fleetdm/secrets.yaml
@@ -1,4 +1,5 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:wxr6LLA6hmmRHFntI7XHzhyxCKwGvaOgYY7aluaSONwPYpC0QPgHFjJBkkZxO3ioKrsZkn3tkrN+pTcHAp+AhxQLe2Hw8MBtdI0Rgt1Q9HcZMmZ6sl/24TtArbX/ucmEW53uuNB4sbulCjQUBOBCMR5ePG2whoxsRkQZQATDv3YrXIdg3h4jiZXPvtfzMcVrOOzx/gXagcY0CpwrKmpkeI8G4w/pkQj28VPGukHdnpR6LZieHuGqS74fBniCX3v2RKR5BIjGlQCambSXPB1cSCI9VoNV+unb5VAl4uNzEm21XTKDyS4y40qjzh820A0/rGi1oXxMpEfGIXlm1leaoWUmUAvrJoMpkvRnLa/wnYs2TGXJjsNhTzF0NbGpdYQEftxyE/wYKNWEMF8t11hGmo30NIfzk8jZ6L5teiTgXCMYu3aUnU1uUUIPBf6e6jYHcxVCCMwWe1y5+wpIb18B21ctXVTfZiYAVwq7ZXRmPx3P1f/Zbn8Ri9PwtnabaaD0Ia0N3VPW3vTqcSMd49vhyxtG5S9RGdv9vq4e,iv:kzgoKvELpzbCbARG+5bvmTtlV7NwrarSH8GdTvkp4TI=,tag:VgFCobBQrSY7TbQbHBZyQA==,type:str]
+fleet-private-key: ENC[AES256_GCM,data:rL4L8TpGnK5pHJxkJMT9heMeuReevwgPV3+9tJS0WATUY709S0XPK0LPxJM=,iv:nmkHNv684oMSiB3ICDGKZX4DtAfCFc/pzwSAkN0NNNA=,tag:RgOAS+UjR7V2VTOs9BYLFA==,type:str]
 sops:
     age:
         - recipient: age1ejte8fz7wdrnxcuzst5j66arkmwgvm67sj2hdhnvq7q0t0z5lsnqcyr97t
@@ -37,7 +38,7 @@ sops:
             NDV1c2VEc1hIclpjbG5tdFpHR1pOeFkKvddVF4HOLcFyg8T5hK+YA4FKMH0NBaf3
             YQOwOgZurUX3BP+AZ55U4uFaCm2vw0NieZ0v00/5mjtMtRMeUGFbmg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-10-31T12:38:12Z"
-    mac: ENC[AES256_GCM,data:Ym2/LIIl+xf6Q+0OkvUWG0yxtnt5Kt8njkRJ0IctVWxOMjz9n4hs9bEGWuz6DnY4bKQKdNkR5ZYX1PSjodDdhRpu7xTHzq1rqeow1VqCBe7FNPVJ93mdCwwONG1dC27fQz5roIDFOruGzPrx+jsrtDyUUIcegpUtErb4t+DpJyU=,iv:o/fxZkQBedSSbIjRh58wBmZgDLajD31BG4Q9kAiNzQA=,tag:todPKi4a1byebzpl7pGKVQ==,type:str]
+    lastmodified: "2026-05-21T08:32:22Z"
+    mac: ENC[AES256_GCM,data:SUmjBD9b4fQlrrNSjAJWhpCTyMVy+hDwApiBhmc8KBiSzDHJ15qe+fosCcj6rOf1y6TM7oR4r3IJCMd6/vv477mHrQOG439ZUKZeZpO5lVZPlPVuxSQiX7CyD1dsqkAR7BcDN2yZG7/5uNNrjlgAkRnbbehA1MvWD+8JJXu54CU=,iv:gFbFP5m4Gpuk57yJ7AYZ2CMML9kGGwKp5GoJLL1PLjg=,tag:FAWL4zAaxaHjBC4H8oB6cA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.10.2
+    version: 3.12.1

--- a/hosts/testagent/credentials.yaml
+++ b/hosts/testagent/credentials.yaml
@@ -7,8 +7,8 @@ wifi-ssid: ENC[AES256_GCM,data:lQGD6S2mqOS3h08M0D3SGtyN,iv:W6eZN/KMo1R6cUyhC4QaB
 wifi-password: ENC[AES256_GCM,data:UB5yvZypdBt3GE73irSR9Q==,iv:HNRBkoGAdlOC4Sy/C3wMBX2oPCJm7FZKmW+Wyw0Mim8=,tag:IysEBTZmdSzYYLl8ZyJBTw==,type:str]
 pi-login: ENC[AES256_GCM,data:0x3F1w==,iv:IveF1lzHkUQMSqnZwUmku+TwMgVpBc5be+/hk4L4kms=,tag:J+6P9memt/i9ssKlp7c0Rw==,type:str]
 pi-pass: ENC[AES256_GCM,data:1rtAJu/pT5xmJ/U9fQ==,iv:/xN7ThszgI+4+OFKm99Uvsy1n8F4/llBt1JRcPNQPfM=,tag:cCQRZd7VxdDvdd7HjhWN/Q==,type:str]
-fleetdm_enroll_secret: ENC[AES256_GCM,data:yqBWdRldOEoM8mPYbHU9f/ksxpQcBRpauAxXp9krJ70=,iv:B33q2ceJOe33ai55Ukapw1ywRdw0HqZM81VzzJigkZk=,tag:gsI7mfHHeEdnSwbgJyjdOw==,type:str]
-fleetdm_api_token: ENC[AES256_GCM,data:Iw36m9bhsm0HS0a2HQhdUGfI3gcSgZeUqg5Ywwv4wtN0eR6zArg93My/Mgu7a9wXYKAceYpJxLnw6WpnieHyEYykef5c539TVYyufVBQhbWOQhgutw/rbQ==,iv:WAdwTm0XEiz8IF5DWTmqttPxFhDrL7HQwovXO98HZew=,tag:GmEkKWkMfIFKo15u+KDCMg==,type:str]
+fleetdm_enroll_secret: ENC[AES256_GCM,data:Dh8uDdufaxyxEjJYOqykQlrxidNm15gUg90zoQ079i4=,iv:3ez2KwdP2DzdmcgDWGKHXjjlaysG1UqwMnC1a4H3fkE=,tag:Zb8yb9q3OhZSkZQdiwtf7A==,type:str]
+fleetdm_api_token: ENC[AES256_GCM,data:FBTssuNtVBRLOW4jxRjRmK+wpfTkDx3Atamq0TG6dzbY6bbbusXyNZVEZqK7n1k4DuWoZNl319vrHWFLC8OE1N+HXmIXBSUxVWIVasfoS7KLoWQ/lXQlCg==,iv:DWJjPZj1mcpe3nCG9WnWwDOgALcBQclazleiiv0RFkE=,tag:A2MNibWdG3FlcwdYA8nlkA==,type:str]
 sops:
     age:
         - recipient: age1qjhxuh80tg2vq32kmwu2ne4vqvd8q2up7css30x0yefkrhq9jd0sxju3fa
@@ -83,7 +83,7 @@ sops:
             QlBjVU9DS1NLSW5QUVI3bjJJcXR2SmMKaZFkW3Ph6y9RUj6yHdO+WPnf2fUFQdlw
             IpZf3pBoUrAn/ty2bBCwAPwReWCAPhpKUwRkZbQ3VKMRnsepse0eTw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-16T12:54:23Z"
-    mac: ENC[AES256_GCM,data:NlsDfXK6vPn14R/dnU0BAz0Kj2TaoqGzYRWH/T3qc1ZPmz8/T1p/XhV4E2+Iz+LedlLWG8KQCNiNYFgWSuvfpZBh9TuSyeFNj8vstdhgJIOFPoZH9u8c87iIzn+w41k5CHdnpzzkRPnYe0AExDxQS9KbLioRU4UwOJE1ZOMAG/s=,iv:RjE/YJrWYOqPXYAid/q+2rChOu+JL4lImmOOq1+4v9M=,tag:u+DTviMiRL5qCBRKDNyt8A==,type:str]
+    lastmodified: "2026-05-22T09:21:41Z"
+    mac: ENC[AES256_GCM,data:dj/3VAI1OTgRBGPnOsagCLB6Z2ZZVFDtt+S7kuhb3y7ff5YurYqKajebVN5N/dhzCh9P9ToX+YYmvsyj1JHuJmL85+U+2SGxbLJu6ELQ0Xxk1FGEhKzqTwUB+oURgkPjdYNpx8N7VlbpwZHp6BXDYPufpsku7L1mssrhyTsgHDg=,iv:ToBnpNMzGRuF8pMnVa7Cj049Ae5bPH0mAEWmPGMPfRc=,tag:k3ap5+jj3rHNMzLM/m6LpA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -20,6 +20,13 @@
         softhsm2 = pkgs.callPackage ../pkgs/softhsm2 { };
         zot = pkgs.callPackage ../pkgs/zot { };
 
+        # Vendored in as nixos-25.11 has outdated package,
+        # which doesn't include the frontend assets
+        fleet = pkgs.callPackage ../pkgs/fleet { };
+        fleetctl = pkgs.fleetctl.override {
+          inherit (self'.packages) fleet;
+        };
+
         # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
         # https://github.com/NixOS/nixpkgs/pull/313643
         brainstem = pkgs.callPackage ../pkgs/brainstem {

--- a/pkgs/fleet/default.nix
+++ b/pkgs/fleet/default.nix
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2003-2026 Eelco Dolstra and the Nixpkgs/NixOS contributors
+# SPDX-License-Identifier: MIT
+
+# source: https://github.com/NixOS/nixpkgs/blob/160fe83114ba8af24cb13cd7b4eeca3f157217b9/pkgs/by-name/fl/fleet/package.nix
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  yarn,
+  fixup-yarn-lock,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs_24,
+  fetchYarnDeps,
+  buildGoModule,
+  go-bindata,
+  versionCheckHook,
+}:
+let
+  pname = "fleet";
+  version = "4.82.2";
+  src = fetchFromGitHub {
+    owner = "fleetdm";
+    repo = "fleet";
+    tag = "fleet-v${version}";
+    hash = "sha256-Cbn7phhaDcpYm3nV8nLb/2QVQl9mhsRfHa6GG59MNcA=";
+  };
+  yarn_24 = yarn.overrideAttrs (_: {
+    buildInputs = [ nodejs_24 ];
+  });
+  yarnConfigHook_24 = yarnConfigHook.overrideAttrs (_: {
+    propagatedBuildInputs = [
+      yarn_24
+      fixup-yarn-lock
+    ];
+  });
+
+  frontend = stdenvNoCC.mkDerivation {
+    pname = "${pname}-frontend";
+    inherit version src;
+
+    nativeBuildInputs = [
+      yarnConfigHook_24
+      yarnBuildHook
+      nodejs_24
+    ];
+
+    yarnOfflineCache = fetchYarnDeps {
+      yarnLock = src + "/yarn.lock";
+      hash = "sha256-2gTV42OVgeH35rOrOgXiop+DGWtq2PpHqKY4mFblbAs=";
+    };
+
+    NODE_ENV = "production";
+    yarnBuildScript = "webpack";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/assets
+      cp -r assets/* $out/assets/
+
+      mkdir -p $out/frontend/templates
+      cp frontend/templates/react.tmpl $out/frontend/templates/react.tmpl
+
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule (finalAttrs: {
+  inherit pname version src;
+
+  vendorHash = "sha256-hgo+j2+gE0ArGRRvxC/0jcpv0Bp3hvBRO7Wl+9xl8io=";
+
+  subPackages = [
+    "cmd/fleet"
+  ];
+
+  ldflags = [
+    "-X github.com/fleetdm/fleet/v4/server/version.appName=fleet"
+    "-X github.com/fleetdm/fleet/v4/server/version.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ go-bindata ];
+
+  preBuild = ''
+    cp -r ${frontend}/assets/* assets
+    cp -r ${frontend}/frontend/templates/react.tmpl frontend/templates/react.tmpl
+
+    go-bindata -pkg=bindata -tags full \
+      -o=server/bindata/generated.go \
+      frontend/templates/ assets/... server/mail/templates
+  '';
+
+  tags = [ "full" ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru = {
+    inherit frontend;
+  };
+
+  meta = {
+    homepage = "https://github.com/fleetdm/fleet";
+    changelog = "https://github.com/fleetdm/fleet/releases/tag/fleet-v${finalAttrs.version}";
+    description = "CLI tool to launch Fleet server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      asauzeau
+      lesuisse
+      bddvlpr
+    ];
+    mainProgram = "fleet";
+  };
+})


### PR DESCRIPTION
Adds fleetdm server configured in nix. It should match the default docker-compose stack from upstream fleetdm, just re-implemented using systemd services and no docker.
- Mysql
- Redis
- Fleetdm
- Nginx

The api key and enrollment token has changed as result. Those secrets have been updated.

Fleet package was vendored in from nixpkgs-unstable, as the version from our pinned nixpkgs is outdated, and does not include the frontend assets necessary to run the web interface. This can be removed once we update to nixos 26.05.