### PR TITLE
ci: harden pipeline git checkouts

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -40,10 +40,202 @@ def checkout_ci_test_sources(
     """
     return
   }
+  // CI test sources may be pinned to a branch, tag, commit, or GitHub synthetic PR ref.
+  checkout_remote_ref(ci_test_repo_url, ci_test_repo_branch, true)
+}
+
+@NonCPS
+def shell_quote(String value) {
+  if (value == null) {
+    return "''"
+  }
+  return "'${value.replace("'", "'\"'\"'")}'"
+}
+
+@NonCPS
+def looks_like_hex_ref(String value) {
+  return value ==~ /(?i)[0-9a-f]{7,40}/
+}
+
+@NonCPS
+def trim_prefix(String value, String prefix) {
+  return value.startsWith(prefix) ? value.substring(prefix.length()) : value
+}
+
+def remote_ref_exists(String repoUrl, String scope, String refName) {
+  def quotedRepo = shell_quote(repoUrl)
+  def quotedRef = shell_quote(refName)
+  return sh(
+    script: "git ls-remote --exit-code --${scope} --refs ${quotedRepo} ${quotedRef} >/dev/null 2>&1",
+    returnStatus: true
+  ) == 0
+}
+
+def with_checkout_retry(String repoUrl, String requestedRef, Closure body) {
+  retry(3) {
+    echo "Preparing clean checkout of '${requestedRef}' from ${repoUrl}"
+    deleteDir()
+    body()
+  }
+}
+
+@NonCPS
+def git_clone_extension(Map args = [:]) {
+  def extension = [
+    $class: 'CloneOption',
+    shallow: args.get('shallow', false),
+    noTags: args.get('noTags', true),
+    timeout: args.get('timeout', 30),
+    honorRefspec: args.get('honorRefspec', true),
+  ]
+  if (args.containsKey('depth') && args.depth != null) {
+    extension.depth = args.depth
+  }
+  return extension
+}
+
+def checkout_named_branch(String repoUrl, String branchName) {
+  def refspec = "+refs/heads/${branchName}:refs/remotes/origin/${branchName}"
   checkout scmGit(
-    branches: [[name: ci_test_repo_branch]],
-    userRemoteConfigs: [[url: ci_test_repo_url]]
+    branches: [[name: "origin/${branchName}"]],
+    userRemoteConfigs: [[
+      url: repoUrl,
+      name: 'origin',
+      refspec: refspec,
+    ]],
+    extensions: [
+      git_clone_extension(shallow: true, noTags: true, timeout: 30, depth: 50, honorRefspec: true),
+    ],
   )
+}
+
+def checkout_named_tag(String repoUrl, String tagName) {
+  def refspec = "+refs/tags/${tagName}:refs/tags/${tagName}"
+  checkout scmGit(
+    branches: [[name: "refs/tags/${tagName}"]],
+    userRemoteConfigs: [[
+      url: repoUrl,
+      name: 'origin',
+      refspec: refspec,
+    ]],
+    extensions: [
+      git_clone_extension(shallow: false, noTags: false, timeout: 30, honorRefspec: true),
+    ],
+  )
+}
+
+def checkout_exact_ref(String repoUrl, String remoteRef, String localRef) {
+  def refspec = "+${remoteRef}:${localRef}"
+  checkout scmGit(
+    branches: [[name: localRef]],
+    userRemoteConfigs: [[
+      url: repoUrl,
+      name: 'origin',
+      refspec: refspec,
+    ]],
+    extensions: [
+      git_clone_extension(shallow: false, noTags: true, timeout: 30, honorRefspec: true),
+    ],
+  )
+}
+
+def checkout_flexible_ref(String repoUrl, String requestedRef) {
+  // Commit SHAs and other unresolved refs need the git plugin's broader ref discovery path.
+  checkout scmGit(
+    branches: [[name: requestedRef]],
+    userRemoteConfigs: [[url: repoUrl]],
+    extensions: [
+      git_clone_extension(shallow: false, noTags: false, timeout: 30, honorRefspec: false),
+    ],
+  )
+}
+
+def checkout_remote_ref(String repoUrl, String requestedRef, boolean allowSyntheticRefs = false) {
+  def normalizedRef = requestedRef?.trim()
+  if (!normalizedRef) {
+    error("Missing git reference for repository '${repoUrl}'")
+  }
+  if (normalizedRef.startsWith('refs/pull/') && !allowSyntheticRefs) {
+    error(
+      "GitHub pull refs like '${normalizedRef}' are not supported here. " +
+      "Use a branch, tag, or commit ref, or use a PR-specific pipeline " +
+      "that propagates the pull ref downstream."
+    )
+  }
+
+  with_checkout_retry(repoUrl, normalizedRef) {
+    if (normalizedRef.startsWith('refs/heads/')) {
+      def branchName = trim_prefix(normalizedRef, 'refs/heads/')
+      echo "Checking out branch ref '${normalizedRef}' from ${repoUrl}"
+      checkout_named_branch(repoUrl, branchName)
+      return
+    }
+
+    if (normalizedRef.startsWith('refs/tags/')) {
+      def tagName = trim_prefix(normalizedRef, 'refs/tags/')
+      echo "Checking out tag ref '${normalizedRef}' from ${repoUrl}"
+      checkout_named_tag(repoUrl, tagName)
+      return
+    }
+
+    if (normalizedRef.startsWith('refs/pull/')) {
+      echo "Checking out exact ref '${normalizedRef}' from ${repoUrl}"
+      checkout_exact_ref(repoUrl, normalizedRef, 'refs/remotes/origin/selected-ref')
+      return
+    }
+
+    def branchName = normalizedRef
+    branchName = trim_prefix(branchName, 'refs/remotes/origin/')
+    branchName = trim_prefix(branchName, 'remotes/origin/')
+    branchName = trim_prefix(branchName, 'origin/')
+    if (remote_ref_exists(repoUrl, 'heads', "refs/heads/${branchName}")) {
+      echo "Checking out branch '${branchName}' from ${repoUrl}"
+      checkout_named_branch(repoUrl, branchName)
+      return
+    }
+
+    def tagName = trim_prefix(normalizedRef, 'refs/tags/')
+    if (remote_ref_exists(repoUrl, 'tags', "refs/tags/${tagName}")) {
+      echo "Checking out tag '${tagName}' from ${repoUrl}"
+      checkout_named_tag(repoUrl, tagName)
+      return
+    }
+
+    def reason = looks_like_hex_ref(normalizedRef) ? 'hex-looking ref' : 'unresolved ref'
+    echo "Falling back to flexible checkout for ${reason} '${normalizedRef}' from ${repoUrl}"
+    checkout_flexible_ref(repoUrl, normalizedRef)
+  }
+}
+
+def checkout_github_pr_merge(String repoUrl, String prNumber, String targetBranch = null, List extraExtensions = []) {
+  def normalizedPr = prNumber?.trim()
+  if (!normalizedPr) {
+    error("Missing PR number for repository '${repoUrl}'")
+  }
+  def normalizedTargetBranch = targetBranch?.trim()
+  def mergeRef = "refs/pull/${normalizedPr}/merge"
+  def headRef = "refs/pull/${normalizedPr}/head"
+  def refspecs = [
+    "+${mergeRef}:refs/remotes/pr_origin/pull/${normalizedPr}/merge",
+    "+${headRef}:refs/remotes/pr_origin/pull/${normalizedPr}/head",
+  ]
+  if (normalizedTargetBranch) {
+    refspecs << "+refs/heads/${normalizedTargetBranch}:refs/remotes/origin/${normalizedTargetBranch}"
+  }
+
+  with_checkout_retry(repoUrl, "PR ${normalizedPr}") {
+    checkout scmGit(
+      branches: [[name: "refs/remotes/pr_origin/pull/${normalizedPr}/merge"]],
+      userRemoteConfigs: [[
+        url: repoUrl,
+        name: 'pr_origin',
+        refspec: refspecs.join(' '),
+      ]],
+      extensions: [
+        git_clone_extension(shallow: false, noTags: true, timeout: 30, honorRefspec: true),
+      ] + extraExtensions,
+    )
+  }
 }
 
 def path_basename(String path) {

--- a/hosts/hetzci/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/pipelines/ghaf-main.groovy
@@ -62,11 +62,9 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          checkout scmGit(
-            branches: [[name: 'main']],
-            userRemoteConfigs: [[url: REPO_URL]]
-          )
+          script {
+            utils.checkout_remote_ref(REPO_URL, 'main')
+          }
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -53,11 +53,9 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          checkout scmGit(
-            branches: [[name: params.GITREF]],
-            userRemoteConfigs: [[url: params.REPO_URL]]
-          )
+          script {
+            utils.checkout_remote_ref(params.REPO_URL, params.GITREF)
+          }
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
@@ -85,11 +85,9 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          checkout scmGit(
-            branches: [[name: 'main']],
-            userRemoteConfigs: [[url: REPO_URL]]
-          )
+          script {
+            utils.checkout_remote_ref(REPO_URL, 'main')
+          }
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -97,11 +97,9 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          checkout scmGit(
-            branches: [[name: 'main']],
-            userRemoteConfigs: [[url: REPO_URL]]
-          )
+          script {
+            utils.checkout_remote_ref(REPO_URL, 'main')
+          }
         }
       }
     }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
@@ -69,22 +69,12 @@ pipeline {
               error('Missing GITHUB_PR_NUMBER')
             }
           }
-          deleteDir()
-          checkout scmGit(
-            userRemoteConfigs: [[
-              url: REPO_URL,
-              name: 'pr_origin',
-              // Below, we set the git remote: 'pr_origin'.
-              // We use '/merge' in pr_origin to build the PR as if it was
-              // merged to the PR target branch. To build the PR head (without
-              // merge) you would replace '/merge' with '/head'.
-              refspec: "+refs/pull/${params.GITHUB_PR_NUMBER}/merge:refs/remotes/pr_origin/pull/${params.GITHUB_PR_NUMBER}/merge",
-            ]],
-            branches: [[name: "pr_origin/pull/${params.GITHUB_PR_NUMBER}/merge"]],
-          )
           script {
-            sh "git fetch pr_origin pull/${params.GITHUB_PR_NUMBER}/head:PR_head"
-            env.TARGET_COMMIT = sh(script: 'git rev-parse PR_head', returnStdout: true).trim()
+            utils.checkout_github_pr_merge(REPO_URL, params.GITHUB_PR_NUMBER)
+            env.TARGET_COMMIT = sh(
+              script: "git rev-parse refs/remotes/pr_origin/pull/${params.GITHUB_PR_NUMBER}/head",
+              returnStdout: true
+            ).trim()
             println "TARGET_COMMIT: ${env.TARGET_COMMIT}"
           }
         }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -78,40 +78,29 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          // https://www.jenkins.io/doc/pipeline/steps/params/scmgit/#scmgit
-          // https://github.com/KostyaSha/github-integration-plugin/blob/master/docs/Configuration.adoc
-          checkout scmGit(
-            userRemoteConfigs: [[
-              url: REPO_URL,
-              name: 'pr_origin',
-              // Below, we set two git remotes: 'pr_origin' and 'origin'
-              // We use '/merge' in pr_origin to build the PR as if it was
-              // merged to the PR target branch GITHUB_PR_TARGET_BRANCH.
-              // To build the PR head (without merge) you would replace
-              // '/merge' with '/head' in the pr_origin remote. We also
-              // need to set the 'origin' remote to be able to compare
-              // the PR changes against the correct target.
-              refspec: '+refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/pr_origin/pull/${GITHUB_PR_NUMBER}/merge +refs/heads/*:refs/remotes/origin/*',
-            ]],
-            branches: [[name: 'pr_origin/pull/${GITHUB_PR_NUMBER}/merge']],
-            extensions: [
-              // We use the 'changelogToBranch' extension to correctly
-              // show the PR changed commits in Jenkins changes.
-              // References:
-              // https://issues.jenkins.io/browse/JENKINS-26354
-              // https://javadoc.jenkins.io/plugin/git/hudson/plugins/git/extensions/impl/ChangelogToBranch.html
-              changelogToBranch (
-                options: [
-                  compareRemote: 'origin',
-                  compareTarget: "${GITHUB_PR_TARGET_BRANCH}"
-                ]
-              )
-            ],
-          )
           script {
-            sh 'git fetch pr_origin pull/${GITHUB_PR_NUMBER}/head:PR_head'
-            env.TARGET_COMMIT = sh(script: 'git rev-parse PR_head', returnStdout: true).trim()
+            utils.checkout_github_pr_merge(
+              REPO_URL,
+              env.GITHUB_PR_NUMBER,
+              env.GITHUB_PR_TARGET_BRANCH,
+              [
+                // We use the 'changelogToBranch' extension to correctly
+                // show the PR changed commits in Jenkins changes.
+                // References:
+                // https://issues.jenkins.io/browse/JENKINS-26354
+                // https://javadoc.jenkins.io/plugin/git/hudson/plugins/git/extensions/impl/ChangelogToBranch.html
+                changelogToBranch(
+                  options: [
+                    compareRemote: 'origin',
+                    compareTarget: "${GITHUB_PR_TARGET_BRANCH}"
+                  ]
+                )
+              ]
+            )
+            env.TARGET_COMMIT = sh(
+              script: 'git rev-parse refs/remotes/pr_origin/pull/${GITHUB_PR_NUMBER}/head',
+              returnStdout: true
+            ).trim()
             println "TARGET_COMMIT: ${env.TARGET_COMMIT}"
           }
         }

--- a/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
+++ b/hosts/hetzci/pipelines/ghaf-release-candidate.groovy
@@ -107,11 +107,9 @@ pipeline {
       agent { label 'built-in' }
       steps {
         dir(utils.controller_workdir()) {
-          deleteDir()
-          checkout scmGit(
-            branches: [[name: params.GITREF]],
-            userRemoteConfigs: [[url: REPO_URL]]
-          )
+          script {
+            utils.checkout_remote_ref(REPO_URL, params.GITREF)
+          }
         }
       }
     }


### PR DESCRIPTION
Improve checkout resilience in HetzCI Jenkins pipelines by switching them to shared checkout helpers with retries, workspace cleanup, and narrower fetch refspecs.

- Moved pipeline checkout logic into shared helpers in `hosts/hetzci/pipeline-library/vars/utils.groovy`
- Updated main, nightly, manual, release-candidate, and pre-merge pipelines to use the shared checkout paths
- Narrowed PR checkouts to fetch only the merge ref, head ref, and target branch
- Preserved support for manual branch/tag/commit refs, with fallback to the broader checkout path only when needed
- Rejected generic `refs/pull/*` inputs on pipelines that cannot safely pass those refs downstream
 

Tested in hetzci-vm:
- `ghaf-manual`, `GITREF=main`
  Observed `Preparing clean checkout of 'main'`, `Checking out branch 'main'`, a narrowed shallow fetch, then `Setup`
- `ghaf-manual`, `GITREF=refs/heads/main`
  Observed `Checking out branch ref 'refs/heads/main'`, then `Setup`
- `ghaf-manual`, `GITREF=refs/tags/ghaf-26.04.1`
  Observed `Checking out tag ref 'refs/tags/ghaf-26.04.1'`, then `Setup`
- `ghaf-manual`, `GITREF=872c1ebd66a3d830c77093608ed897fd3b971dbb`
  Observed fallback to the flexible checkout path for a hex-looking ref, then `Setup`
- `ghaf-manual`, `GITREF=refs/pull/826/head`
  Failed as intended on a non-pre-merge pipeline because GitHub synthetic PR refs are rejected there
- `ghaf-pre-merge-manual`, `GITHUB_PR_NUMBER=826`
  Observed `Preparing clean checkout of 'PR 826'` and `TARGET_COMMIT: 6e39a3b362035068f22c94c31c627377261eab15`, confirming the PR merge/head checkout path works

