### PR TITLE
Redeploy testagent prod in UAE

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -39,8 +39,8 @@ keys:
   - &uae-nethsm-gateway age1yqpkn74zacvyujqadz5cm90e6tz8ws2kphladkyvtfrv65x5autqe9404a
   - &uae-azureci-prod age13jsxg67hfnk7pqrf0tsnqrdxs8ktly4ke2vqwsx0c0lqytlwd98s58rkna
   - &uae-azureci-az86-1 age1rcwsekkzc2x35kv3qcg6dvgjsl28nxhes4e9g8l5gue54tx2qp7s53wclg
-  - &uae-testagent-prod age1sl8yrksst9aq2fhg8t8h7tysgzm6ks00n9hxsvj8x6frsnrskd4szerqez
-  - &uae-azureci-hetzarm-1 age1n8a2mc6y4446fxkzpulpmmdk5lmqeyhn3rqv8ynyl24nh5zpxd5qlm5v28
+  - &uae-testagent-prod age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
+  - &uae-azureci-hetzarm-1 age1khvgc59e6mty0408cs523jzwldgjl389dywfrfmas08kzfdyj40qcuh2vf
   - &uae-testagent2-prod age10x82kaw0zam7h4mfv88gx75gq7ex4gpfupslzgvh4cvp5sdc09vsmgwsdk
   - &uae-azureci-registry age14hx3z3hnzdcuertpyv7grznx3e0gvnzhadq3mpthl8q6t9nq83yquzveke
 
@@ -264,7 +264,6 @@ creation_rules:
       - *hetzci-dbg
       - *hetzci-prod
       - *hetzci-release
-      - *uae-lab-node1
       - *uae-nethsm-gateway
       - *uae-azureci-prod
       - *uae-testagent-prod

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -298,7 +298,7 @@
     system = "x86_64-linux";
     machine = {
       ip = "172.20.16.24";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHO30maPQbVUqURaur8ze2S0vrrUivj2QdItIHsK75RS";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF7/asZZRNxvkScL0AnAPG82YT2iJ1LcUOCd9dL77hpN";
     };
   };
 
@@ -307,7 +307,7 @@
     system = "aarch64-linux";
     machine = {
       ip = "91.98.90.243";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDP8yHa00zzjb+KSLB/pSZTKsAiU4vW1V75dqS1/6TqZ";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGipvpDvDhHwm55/qmxHrCfTfTGZfc912RSKwrBAg7+7";
     };
   };
 

--- a/hosts/uae/azureci/builders/hetzarm-1/secrets.yaml
+++ b/hosts/uae/azureci/builders/hetzarm-1/secrets.yaml
@@ -1,4 +1,4 @@
-ssh_host_ed25519_key: ENC[AES256_GCM,data:9OIGvwCJU6ZvkeMjBVrXMklVGLjmWg6HWaxxX2l7QB3aA5ionTR5eSctvcGopKg7PDOzUrYFA4BTC72fSWf6mOk0N4GR056nO7/JpFOAQkFfNIAJFD7z0o8jx5AYiDR3Fg7W5DMt10D7NKkJ0A81ysD2WowaCTaHrEkKaRAN73Gpzp3x/zdlR9onXY5dydU0rXIsFDWh2DjTML2OoElmD8jQXed3WcR+I7xHOZGi0ZUECa0NTi3nm20MNi87AQrogCWiCHv9kLu+gHYlBZaJV55QLEKUgT/Y7UsFFBoQZxjweLz8v8SeLO3f6NL6VXjvHLq/qJ9UoF5t5Tjb59+w/nIXdAvIDvJE3LXXOh4kTx5EAHyK6oCXN/JDIkqbK4MqnMsOrp2hQ8sb4ZWTCDjkgDKkK2DSpBiTXahChyTMJS1O1UAY+ZesTgRdm9qnPLa9XszxfluLwcvWJBMH8pg8fqENy3Ff382iaiIXL8oHuADPkdbmNi8dOH0C3UdLWw6xxPygUl9fFJVd4vk+KZpSa1qu1Zm8MCDpU17camfm7URN7o8=,iv:fDOny2h/wkFK08nfKI84EN/8r6hSg6iZGZwXafTvhBc=,tag:097cJsXMOkLmV+Pq5qiFSw==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:O0X8dvO2811i9jbvWzDk3QXE6wLZbOX6B4TjgJZYsgK8ekJWVhmYBPYMC38f5uX2kZwsInhmgaQUu82DK0qZVtVRVwPfKjRKOGw3X0zgNZHHuQASy/39v4XtyFLavfX9F3mCHQa4b+mlXGTYEK1m1ysZRhcU+raaiBhTWcNsQiv+XywyYlD406AyKhY0M7KFMJH9EqTPGP3pb2GdqCZQPXbjmUs2pc61VygxlL3HWpMXrIa1qJgy7VZ5NOPeLfzWgk9GBojqnlDWfSdUDKZ4TVmHkg78/lvCSM/POPvRs0CfAb+GlFlPJOSm37JzQvuj8W5B8o6pmfTMAdEalgPH654yR2qO3dt9PAwJZp3VhbBXwT5VSkdO5D+6u1lF/GVztQvpWzzSwKIx4sqy0LnaxlZkyKJSB2yxIP5tR9erOYV7rbg6GwihquQqKhgMefiKTPB54ni5CGxtlYKe4WfzsojsLOFBQQtmEUTedHEKn2AV1Vz6xO0hOl+SCDniX5ADrTvA1C3kv4stnGILgysQ97Iotfz4EZyhnfb8VXBpoLcJ60Q=,iv:hFPphkNMAEayOZc5BvDK+fKAkG3qJmkcBqzq+S68ldU=,tag:dAeOr5zH2YNfBw1zLdflOA==,type:str]
 loki_password: ENC[AES256_GCM,data:qWlqIpcXZFJEXY/FhXYxa4X4ew==,iv:F0fQ1Pu8jagagsyM3n8ncD3N1pVIBItOhCwxA4CjUg0=,tag:1m8WckdhkY2sIWUNPzRcYg==,type:str]
 sops:
     age:
@@ -38,7 +38,7 @@ sops:
             anBtZDcxRTlpTnNuNnU2U2RoekJudmcK00TzQufGtdecijz8x//HWrteoYrgRNIC
             UjNJUnQjjxNqDnfuOinFNRbCzex/yAW++qIYoRd36o2dvjtVGz360w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-16T02:56:46Z"
-    mac: ENC[AES256_GCM,data:ucT9DjpHmYHbHEJWjG1zVICtNV6+peb++njnFHbg0yjd+bBmf7RqZGMUeEL1wOIeJKYgtlw5uWwfmbViZs8JQxx95KA1qMW7lNNxZnlqLpAfdQCD5zSKP9ndMt1qnNJrUCJxPXUykXvS5q2yFMCNO91PJaC7OWyJrN4Dbep5eRU=,iv:eS7yvW/07WepCjjrpM9GYZlSC2TIkhOyIN7qBJ4udkY=,tag:BPUekdj7newVjc1QcGV2aA==,type:str]
+    lastmodified: "2026-05-21T16:36:38Z"
+    mac: ENC[AES256_GCM,data:8xX86pKOTax/gxTD0p37DuQ1MFP59WYJK93YrbI5/LDt7VdqAtOUcJgkLG6z9ekp1Xqv5qlsruaahd4lr8YjYYdWoGcg3aq1TUVoVZN+xxO6aA/5XXg5s7g9VEfKna6oWaR6IgImoWdnnWtAYplsA19zPjhFnWVppvnW7H+usXI=,iv:MRAkIOqGWvW7ks2jhWsdNieJwhW2DEJth3P+18YumbA=,tag:A72VFAgfjGbd4a8G29VUwg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/hosts/uae/azureci/prod/configuration.nix
+++ b/hosts/uae/azureci/prod/configuration.nix
@@ -30,7 +30,7 @@
   hetzci = {
     jenkins = {
       envType = "prod";
-      pluginsFile = ../plugins.json;
+      pluginsFile = ../../../hetzci/plugins.json;
       url = "https://ci-prod.uaenorth.cloudapp.azure.com";
       pipelines = [
         "ghaf-hw-test-manual"

--- a/hosts/uae/azureci/registry/configuration.nix
+++ b/hosts/uae/azureci/registry/configuration.nix
@@ -17,17 +17,18 @@ let
 
   zotConfig = {
     storage = {
+      # Use local filesystem storage until aws s3 me-central-1 outage is resolved
       rootDirectory = zotDataDir;
 
       # Use AWS s3 storage as backend
-      storageDriver = {
-        name = "s3";
-        bucket = "ghaf-infra-artifacts";
-        region = "me-central-1";
-        forcepathstyle = true;
-        secure = true;
-        chunksize = toString (32 * 1024 * 1024);
-      };
+      #storageDriver = {
+      #  name = "s3";
+      #  bucket = "ghaf-infra-artifacts";
+      #  region = "me-central-1";
+      #  forcepathstyle = true;
+      #  secure = true;
+      #  chunksize = toString (32 * 1024 * 1024);
+      #};
 
       dedupe = false;
       gc = true;

--- a/hosts/uae/testagent/credentials.yaml
+++ b/hosts/uae/testagent/credentials.yaml
@@ -9,50 +9,50 @@ pi-login: ENC[AES256_GCM,data:H69GRA==,iv:c7SBQR3RWY4d7XScmgO/bKQbTB7COLOyrmuO4P
 pi-pass: ENC[AES256_GCM,data:pIUeLqZl8H+vVVk0kw==,iv:sKSBmiVssQe+kgr3L89JgQrofZkGfdcYi02fnFxbOrE=,tag:gDEiXxFKn2FhO7y7X9LpaQ==,type:str]
 sops:
     age:
-        - recipient: age1sl8yrksst9aq2fhg8t8h7tysgzm6ks00n9hxsvj8x6frsnrskd4szerqez
+        - recipient: age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1WjF5Lzk2dTErR1hTZ0tH
-            UzRidjFRM2dlMGZpVEdHL2Y2NDhqeTY1aXpvCjVSK2kxaE5NR3R1REU3UXJWdm9B
-            MFIyWkFLdGg0UUwzblVjMG5DUnpNQlUKLS0tIDRmM1pKOStJQ2ZUNlArMnRkZitL
-            VitCekNPZkxaVDNkSWlIcGRveVVtT28KkE1+FdYnGeYJkPWSvb6G0i6LX543Gxgl
-            9L/RJfQgJDnLLQ52lPuPSGZ2j/2lBBLWRi/fvic2B6dDKp8fxudTvg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMNDNMQlZMbmxhNkJFcnF4
+            a0t0T2JxZlU1RENjQTNzMHJYK0NUZmp4d0RVCkQ4cmdUU3pkZWdxQ1d2UUdVK3B4
+            ZUpHMTljSStnejZNcnkrV1BoQXJMSG8KLS0tIHRkeldGaUFHNnIrNnBrMHNmamlx
+            N0k4WGlETjRDdm9RTTNaR0V1cVBtbmMKpKr95za66vy3PqU355MBg9OE2mO5jBE4
+            v0bKBxSvD/r2noWXHNAC1c7azOAq46m7bDLyQ+2GxexteILSLuKdXA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age10x82kaw0zam7h4mfv88gx75gq7ex4gpfupslzgvh4cvp5sdc09vsmgwsdk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHaEtsQkgrRVhqMktDdDVr
-            QjdxY21GTkE4Y21YTFBpU1NzTTNkVUhrVVhnClhCdWRINEhkMTZGeUZ4WHFUUmZq
-            elNaNTE0bEpqVW94dXBuYkxsQlBVbzAKLS0tIDhtWjhjR0IzY3lmUFFIbWcwNU5T
-            VGhTVnFpUlBvMU5mNmJ3S0lBcGp5L1EKto9vxAks3bWn0NCIQtFwybztz3/IGG0O
-            4T7fcByjf7LewlwYf3rWLeU2Ky9be/ryQMUrfAlRhrfg1z1SSrhxSQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQMDlIbmM2dTMzZG9jeEVM
+            R0FiV00vazBzUlZydWVmKzF0Rlo2QWdIVFFjCm9UTHVFK243eEszaTZ5UEFycGE4
+            c3grUEFnL0ptMEI3Q3BVUGp0ZnkzYjgKLS0tIFBkczhHc0V3V2R2OG0wd3M1ZVNO
+            M0JZZjZ6YW85ZEpuaHI3QXJOTUp2dW8KyQGz9OzgK3BUljcaJFx/I56kYzcL9Jj+
+            acOMaQT73RzXQfcp6pho7sKqOykfeqv9cKDQDb0/9DNTZmuzVbE5bQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOZUF2R2Y4d2VYU1pCZUpG
-            T21oUkpkYXRlTUpwZnN5V1R4TFUyakJ1akZ3Cm10OW8zSWZuUU9aeTk3aEpucmNw
-            dHdQdERMTFo2T1JjLzNTdXJlSHEvb2sKLS0tIEl0MkhHdlBnOGY2bHZPcm9ZeGJ4
-            RUlTSmUwTW56V3EzRUZhRXkzWWFsOTAKEnDUBYD84MLR8MYhhdm7C2OJN2j9Jskt
-            KEIBAcJ1yy3Q/AVZ+pgnxjC2QEG8Y9KKQm/LQBTvyE5FLDH7hJGg5Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMS1FlQ2V6ZmlHVkFsNmY1
+            SjlyaSt6VFpYeE5rYUVodmtvZ3I5ZXRERmxjCjMxK05OQXBNSHRkazVid0cvK2Q2
+            R05kVVNWa210UGh0VGV1VVZkS0laTjAKLS0tIEw5VTRXRTBVR3hWMUgzazBHSzVI
+            dzhHYVZKbjZoNmU1MmZQbktuVE41bm8KAVThysrDkdBj1K0/XSRVz94AaPja/hoJ
+            KWMidXdnE7Vwv0zYugFVO0fzz8YbCsl9axfqwvVbgyrvzCK5QSxhOA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBROWRrZVE3MGpUbzR2bHNT
-            QXdYUUJlNzliMmtCUDR3VE1qMFJhZDA3bFNBClYyRXRleUw4MTFFd05uWHRkWG9a
-            T3pWK3gwZC9OWi9FOXQzTVpyUkJmUWcKLS0tIEVTc0RNcEdXbjViNEtpNHZWNnNB
-            UDVpM1cxWi9kenR4eVUrZFVFUTRUMEkKK2AthO5wdOhauTIOWZsba0AhrVuvEsPZ
-            mykGyDw1yKZtODaIfsfKeluwqZQOOZdWKVYqcmP44Wq8v5KbpUZ7Aw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2alpyVEp5N3NHdmZKUHBr
+            Ykg3SHZFcUdQcW1GUC9tUjBvd2pWOVFQbFc4CnRMSkZBWmdDWnllazltMUF6cm1j
+            VGlXbUxabW9PellicFhYTURGMVVhQzgKLS0tIGZCbHZMd2hSNGNFMmhLK2NVM1hX
+            WmZmRFBQbTFLU1oxc1l5NGNVa1c4azAKvq//cCi83VDjVR0A5jiZBlYIFMPiM97a
+            gpNtujU9YjrzaX9veO9oAQ1obeTjMi+THF9HJLNJdDwoXazluJD3qQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVaXRyWFRxT255a0hET1lF
-            U0NBaXJXY2hUSkNMb3VvQTAwM1lGc2Jkc3lFClI0cnRiWXlIZ010UW5jM1JkWU11
-            ODJiWmJsZ1BDSlFvU0tpaExGQ3VhRFkKLS0tIHhtb01paVBYSFBwZThoZVlxS1ZS
-            SEI4aUpDUXBkNzAxMDR3WU5FMGhCRDgKLE31bubiktOy726kTrLbldZqRKK6mD0t
-            f+Zt25uQLcgAVcRo4SXQcV815KBtsxCzWle+j1AxTKIID7HA1y/GWw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSb3ZNemx3QTNmb3dUTi9p
+            U1JFdEFPZjBORGl6QVNycXFZS0duRThpV1Z3CjROVjlUZXRoY1lNem1Zb0pWWnBk
+            YXRhMkxhbUp1VW5lMmZGY0JoVWx2NlUKLS0tIGVscXA3blVtNklqSmtCM2tlRnNs
+            ZDVPTjFzOGFGaUU0eHVsZHZmU0N4VWsKgP/ayANnfHfsOvS0tj8E/2pzP2+7jRJi
+            KHFxh8fUtwN5sjSkFtm3mcZEP1R/p/fhJeyKow+sWH7zP9DtVpQPEw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-02-02T08:31:33Z"
     mac: ENC[AES256_GCM,data:5HDxGzT4bxNmbnEaoQLwDUmJ5J0JNItN15WZJ7fo5HtKp5dGa0qVQae5/mLGVGYcZIkbT9toF2uaQGoIsCE3o1O8HAbx1PJReS3BN1EYnd5LNthRR5Zm4HoeODLvj9KI2eJCOGgU0iwLVEXttF7op8AJS5FKr1u6FWadNSDl71k=,iv:5FmQUb1oFsqR4DaDMRutrMF3gxd4b6w42ShXIfsBONU=,tag:q7d1i9I8Jvs0Ra9UC5kosA==,type:str]

--- a/hosts/uae/testagent/prod/disk-config.nix
+++ b/hosts/uae/testagent/prod/disk-config.nix
@@ -1,35 +1,31 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  disko.devices = {
-    disk = {
-      vda = {
-        device = "/dev/nvme0n1";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
-            boot = {
-              type = "EF02";
-              size = "1M";
-            };
-            ESP = {
-              type = "EF00";
-              size = "512M";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot";
-              };
-            };
-            root = {
-              size = "100%";
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                mountpoint = "/";
-              };
-            };
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/nvme-Samsung_SSD_970_EVO_Plus_2TB_S4J4NX0R830938M";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "1024M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
           };
         };
       };

--- a/hosts/uae/testagent/prod/secrets.yaml
+++ b/hosts/uae/testagent/prod/secrets.yaml
@@ -1,44 +1,44 @@
-ssh_host_ed25519_key: ENC[AES256_GCM,data:QVBWy96lz3SqfNikV2XZgZFP2gttTpp0fqx7HumR25zqCM4WNYFOq3e/97QFtE0QGHUnsLjqPECQ9RYLNr4jGbSsB+RyfZAcYz6lMSMnuOPdKsb8yIEOpN9VWb5yE8uwltbgVT/lfv69QCr2DNE3w90izbL/xoNKNO47EEFBrYFPoru5aqW7y6/rb6/kARTVTUxBCvBeA5xpYkhobSk486sinqvAM6X934o/VAeNj/5kn7nv1Qhu8ND4XltbUXMI6ZwZRpf30t3QvJ9XIGueN3ICtOPpCFWTvnVifPxpS2kbXq9kVJpeO75enohVrBGfQ55/DT2kR77L/gv3w7WYD3s4mYaJVx519tCaP69fyGgX58Xb0eGV3Qg0hJM8kJnjGkKqzHtGV7TZz/1R1pE3N2KnXWz3WBAx2RXl2sSe8B3PKLKe7HcVJsx/1mbilNTe2PQtFLrv7mekcnwBpIyz6t/Xr+Qosw1Ib6mp11++lHM6oNYY/2rBEt2f0nefzSH5ixaBc/5383jRYYh1YTJ7qMgrhUoh8qZZnic2/kDJyn+oi/k=,iv:rF+HAQpQttM9ekXvcGuXDgjVmfvtS83E7s9aPzjKAlY=,tag:ZScymbGeXtQl1ioBRclazA==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:Vew0A30fONaXnTRr4cPrMZPUhpNiUcVRETrhXv31bL3BLa5gE4YoAFVKtCULajj0aia8GzopQRMAtIA4dtBRSDk73s39FdUwbSZA4ukTHdU2Im3Df5VE0EePkXEECdFAZTMvot1QSoXLZjnK365xtXwwSZOyS3/5FBlhHGU91CVVGYQ/b0VwfhHoyEIDLAMfSEFZfgoRPwDI0PxeJCjtqCZ+DYREClesV4JF4PqNpMjBuXfX6hztHS9ol3zkrXVN+G+sf7P68ehgZOJXmnyvv+oWLGwU5wBeW0yA7NQbY9LBw1ij8GGM2kDdQNMTOLi6dpOYhxDq3TOsG0032OFJR5a6racmwNZQ3xVOZ+XIJutZ55hyKVJTRG1s7qOBO8d//tn2SHYSDJwuYKraRu0ugVKOX7nNpCp5K6ZrGV9E7j5J6AwmlrkIXYrPuF+w/Re/NAmgpiCxIf57zEJzRhfbLVLoxZcthrDWE3zhBxrQlDnMt5TkukHp7GwVmKAP1qY7Nl8wps1yefwDYVhdvGoPSeznGvZDScp/hnGeRpeJCexNHy0=,iv:6+MaRBhqkHc3Ju+LpL/lXPe7vTrj3SVuXavAeC/bjLg=,tag:tVL6FO2smcXC3hqruVCwYA==,type:str]
 metrics_password: ENC[AES256_GCM,data:HGgLF/FpZv7CLR5vsFEcEu4BEQ==,iv:ab6sv1CkbirsaMfCeFC8yxgATAd+71ccrLkiXwNyc4o=,tag:SAvycKxGUDpgUhGVO5tIrQ==,type:str]
 sops:
     age:
-        - recipient: age1sl8yrksst9aq2fhg8t8h7tysgzm6ks00n9hxsvj8x6frsnrskd4szerqez
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvL082Q2pDL1lJOTVZaThx
-            TE0yd282Ky9kT0N4YVhmanV6bWN0bCtyeEZvCkE5VkVURWsvQ1VFRGtST2RyNVJ4
-            R3d0K01pMXBITXdRTDZTVXR2cEtoRmMKLS0tIDdEOG9LTzZyT2FzYVprWWduZ1pm
-            K3dtaWd6WExrSExnYXF0SHNjYUFaWTgKiUrVid7hWSi4EiuTq5JfRI1JpXPSUNGv
-            weQMmPqXHE1T1urssySprturbUxtZCD/i63yces0S6yvbpozdCSB1A==
-            -----END AGE ENCRYPTED FILE-----
         - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsRFBYb1RmMFZpdDQzVVFw
-            QWJhTnd2dU5vN0RDT2ozekpQQ1RxZ2NMSGtBCjRadjBYTnRFME1LNWpSUzFtVVlG
-            V3kyVUxjc29mTldrK1Z0c3hhY2tuUkUKLS0tIG5mek5rL1h4ZzY2dFUrcnY3VlpK
-            dUtIR2hENjR2b3RlN3FGL1kzVFNRdFkKAlC5bWzc5iI8ZPK25nxBomIIBbukACWS
-            o9Whl+JhoSaiCzWCc4h/n7E+CupTgx1/ClC15HAr4VtrafC9wwGPdw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2UTV0VFMwWVhxYnhSRyt1
+            QkNiR3ViUkFYanFrRFNnSXZHZ2ttUkxlQnhVCmpPR0FBQ2dmbHBnZG1aSEMwckhv
+            cDg1eUJ5MWVSeFgydXE2NHJTenpCR2cKLS0tICswL0FiZEQzY3JQOTEydldjcFJl
+            NzlqbENkV1NFRFcwRmg3NkxNNVU4SWsK9LeO0xnZ2gJzb/UpEE/ieEAEdtvqnGaY
+            zw9+l2r+G1Zws4Zh1O9vj5g2bcas8Eu7JCJ8Gg7ayEC7nmZ3XJ1U6A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPMjhIZUo4SmZMMCtvZU85
-            by9MYm8wSFI5SGVrTzNEN0lkOXlDZ3pVajAwClo2SitVTDY1SXBkc3FGL0w1M0wz
-            SjF4Vm90Y3ZkUFFLaXNqemZQalFDSUUKLS0tIGJFbVUvaTZRQW5sU0JCancwcWVT
-            YTdDbkFHS3dabFMwQXFoTVZPQWtwUncK2KMjtGqOSLRs4yoj4r7BZs4Zvcqu3ezF
-            vrzbQ0xi/tHBAIJqMLYMxerKZ/p0u4bK82+LjwWVRwv52o/FX1dHRw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZ2xnY3BKUXEwb21ISHJu
+            cHNFYkkxKzVGLzJyTmZ6MWRETStjUWhrYkI0Cm41cUc3NURnU3VLZHdwRmVzWGJF
+            Zi9IakZqRkN4RXVLWWx4c1JtRkk4SkEKLS0tIHhSRjdtNkFCMlBIQ1FSYW12bWM0
+            ekRKbnZvYWluWnZ3eWlkRi9tUUNLblUKYP+PjR+tkvocDu9iaNsHMUtFX0GLODOE
+            U2QHTQgAKDf3dPYm+VMIUY7mVMwjPhRFHuVJ6Q8VwkfAqhakJLGooQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuWlQrWEtvdjFFeUtiSGsx
-            dG5jdFVlTU9NMTVaVHdOVnNpbzhlajBMZGt3CjhUVWJraG5xcTBBWENLYlVNSTVH
-            VHNubEZKMnhyN1M5cXlUTG9DejhqMG8KLS0tIHlWQ0dvWHFxalNZcS9vOGY1SkpY
-            T0EyQ01sTDNXNmVlanNUczE4YUYwS2MKXuwder8F+ozBmB1DZasrYls3m35tF3EY
-            HByjy1SkR2BZ3Z9lWBaCVswIoTtzzLIm48syrtHuTOVwrmSy0ZhpvA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2RDA2a3JvY0J0ZHN0QUpO
+            Nm9mRUh1bEtheUpwZnpTTkJaeEpVSURreHhJCld0SmRFZ044cnFGRUJXOHYvZzJn
+            OGRzVzREQVI0RkhVQ3lkSlNUMzdZYUEKLS0tIFl6ZlcvS2hNbGY4bXlsS2NxY2NG
+            QmVwanRRMUQ3OXJCalNjclBxQ0NVaWsKuT1yNcgsujzXZNAoFGZH/2J/AfhGuAjB
+            5WL6vqwX8MLX/7J8ekcfp/xEkaAmdLa/vBbdbibJylFhgS59ZyHyiw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-24T04:31:34Z"
-    mac: ENC[AES256_GCM,data:KyzxQYmahlBaRRdkhR9xp9oN2EbIdRITGn0OpKqe1eCO5Kbzu/+0OgG9CcKkGtOMuWp2lmkP8sbjCdIxFP3PPiwoBSSi5M2PNceMvzU2XZU1v2Xq2DD5Yfi6bInm6Xvo04YwdFNGlqovCR3fJjNpnQyV7l7eVNQcn0uSweiZ7r4=,iv:m3DjzUE9oPy+2qxjRW7zdtcS8ErNDnZchVQL+uvEPWQ=,tag:v5ENrsLJhBLpsKWQ8vHDQA==,type:str]
+        - recipient: age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPa29kMVJhb0FIeXRGcU9Z
+            eUIyUlBBa3hCZkI3N1lkN2tjeXh3UXQzQ1dNClIvMFV4YzZpVTNORC94YW4ySXVS
+            WEpxZVhLOWY4ODk5cmVqV1lBaXA4dWMKLS0tIFBKSUVjOGN3VldpTUt2V0lGQ1lN
+            QTNIVUlVYmx3UTZLMnRwekR2V2ltNDQKLkFLfySMHQO2qeD7MqAzK/aFgI8LxeMV
+            XXVw1hPXHk7TlctRUOyxlbEwSlpAb+gCxphQfFVNilQXF3G0yZrKFQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-21T14:33:28Z"
+    mac: ENC[AES256_GCM,data:2lLy34Bf35/IyNFGegbi2busuLQi1E457UUIyy0x6BViXUK2C6WvSHrmqRqmr7dnV0Xv6Q1Jk/HYN7S/6eSxNNi37B6fE3rCCW2EYiH1iQdN/lwQfAeQXkBLCOrDTHQa85FQfqWTai6tVA6Ei0ngZ0lq3stuC2M7RVv4PkW0eFg=,iv:h0++1UOO3MpXk80ZTtdactVl28RO6orXKi4vgnI5mts=,tag:jQL74JILucGl60cPypxMbA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/hosts/uae/testagent/prod2/configuration.nix
+++ b/hosts/uae/testagent/prod2/configuration.nix
@@ -70,8 +70,8 @@
         relay_serial_port = "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_B0013I2U-if00-port0";
         OrinAGX1 = {
           inherit location;
-          device_id = "00-b8-c3-23-16";
-          netvm_hostname = "ghaf-3099796246";
+          device_id = "00-b2-e1-cb-48";
+          netvm_hostname = "ghaf-3001142088";
           serial_port = "/dev/ttyAGX1";
           relay_number = 2;
           device_ip_address = "172.20.16.55";


### PR DESCRIPTION
Testagent prod machine had to be redployed in uae lab due to faulty usb port.
Cleaned up sops as nebula tunnel was removed from node1 in lab but was still allowed to decrypt ca. 
Hetzarm was redeployed so ssh keys updated.
Jenkins plugin is now reused from hetzci.
Netvm hostname and device-id has been updated on agx32 target.
Reconfigure registry to use filesystem for storage as S3 in uae me-central-1 is unreliable after the recent incident.