### PR TITLE
jenkins: add explicit hw test target support

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -40,6 +40,20 @@ def derive_target_name(String imgUrl, String ociTarget) {
 }
 
 @NonCPS
+def resolve_test_target(String explicitTestTarget = null, String buildTarget = null, String fallbackTarget = null) {
+  def explicit = explicitTestTarget?.trim()
+  if (explicit) {
+    return explicit
+  }
+  def build = buildTarget?.trim()
+  if (build) {
+    return build
+  }
+  def fallback = fallbackTarget?.trim()
+  return fallback ?: null
+}
+
+@NonCPS
 def derive_device_info(String target, boolean secureboot) {
   def devices = device_catalog()
   if (target.contains("lenovo-x1")) {
@@ -155,29 +169,39 @@ def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFla
 }
 
 def run_hw_test(
-  String shortname,
+  String buildShortname,
   String testset,
   String testagent_host,
   Map oci_result,
   boolean secureboot,
-  String ci_env) {
+  String ci_env,
+  String testTargetName = null) {
   // Keep the blocking downstream wait outside node('built-in') so ghaf-hw-test
   // can acquire a controller executor for its own initialization stages.
   def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
+  def normalizedTestTarget = testTargetName?.trim()
+  def desc = normalizedTestTarget ?
+    "Triggered by ${build_href}<br>(build: ${buildShortname}, test: ${normalizedTestTarget})" :
+    "Triggered by ${build_href}<br>(${buildShortname})"
   def test_params = [
     string(name: "TESTSET", value: testset),
-    string(name: "DESC", value: "Triggered by ${build_href}<br>(${shortname})"),
+    string(name: "DESC", value: desc),
     string(name: "TESTAGENT_HOST", value: testagent_host),
     booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: ci_env == "release"),
     booleanParam(name: "RELOAD_ONLY", value: false),
     booleanParam(name: "SECUREBOOT", value: secureboot),
   ]
   if (oci_result == null) {
-    error("Missing OCI publish result for ${shortname}; cannot trigger ghaf-hw-test")
+    error("Missing OCI publish result for ${buildShortname}; cannot trigger ghaf-hw-test")
   }
   test_params += [
     string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference),
   ]
+  if (normalizedTestTarget) {
+    test_params += [
+      string(name: "TEST_TARGET", value: normalizedTestTarget),
+    ]
+  }
   def job = build(job: "ghaf-hw-test", propagate: false, wait: true,
     parameters: test_params
   )

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -102,6 +102,11 @@ def derive_target_name(String imgUrl, String ociTarget) {
 }
 
 @NonCPS
+def resolve_test_target(String explicitTestTarget = null, String buildTarget = null, String fallbackTarget = null) {
+  hwTestUtils.resolve_test_target(explicitTestTarget, buildTarget, fallbackTarget)
+}
+
+@NonCPS
 def derive_device_info(String target, boolean secureboot) {
   hwTestUtils.derive_device_info(target, secureboot)
 }
@@ -225,13 +230,22 @@ def with_controller_workspace(String workspace, Closure body) {
 }
 
 def run_hw_test(
-  String shortname,
+  String buildShortname,
   String testset,
   String testagent_host,
   Map oci_result,
   boolean secureboot,
-  String ci_env) {
-  hwTestUtils.run_hw_test(shortname, testset, testagent_host, oci_result, secureboot, ci_env)
+  String ci_env,
+  String testTargetName = null) {
+  hwTestUtils.run_hw_test(
+    buildShortname,
+    testset,
+    testagent_host,
+    oci_result,
+    secureboot,
+    ci_env,
+    testTargetName
+  )
 }
 
 def collect_hw_test_result(

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -42,6 +42,11 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
         Target image url. If specified, the target device is flashed with the given image before running the tests.
         Can be left empty, in which case DEVICE_TAG must be specified. With installer image this is mandatory to give!'''.stripIndent()),
     string(
+      name: 'TEST_TARGET',
+      defaultValue: '',
+      description: '''
+        Concrete target identity to test. When set, this controls device selection and job identity even if OCI_IMAGE_REF or IMG_URL points to a generic build artifact.'''.stripIndent()),
+    string(
       name: 'GHAF_FLAKE_REF',
       defaultValue: '',
       description: '''
@@ -72,10 +77,9 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       name: 'JOB_SELECTOR',
       defaultValue: '',
       description: '''
-        Select the job. If device is flashed, the job is derived from OCI_IMAGE_REF or IMG_URL when available.
-        Otherwise this selection is used.
-        For example system76-darp11-b-storeDisk-debug-installer or system76-darp11-b-storeDisk-debug.
-        DEVICE_TAG is used as the job by default when not flashing.'''.stripIndent()),
+        Legacy fallback for explicit test identity. Used only when TEST_TARGET is empty.
+        If neither TEST_TARGET, JOB_SELECTOR, nor a build target derived from OCI_IMAGE_REF or IMG_URL is available, DEVICE_TAG is used as the job.
+        For example system76-darp11-b-storeDisk-debug-installer or system76-darp11-b-storeDisk-debug.'''.stripIndent()),
     [
       $class: 'ChoiceParameter',
       name: 'TESTAGENT_HOST',
@@ -118,12 +122,19 @@ def init() {
     env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
     env.OCI_SOURCE_REF = annotations[SOURCE_REF_ANNOTATION] ?: ''
   }
-  def flashTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
+  env.BUILD_TARGET = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET) ?: ''
+  env.TEST_TARGET = utils.resolve_test_target(
+    params.TEST_TARGET,
+    env.BUILD_TARGET,
+    params.JOB_SELECTOR?.trim() ?: params.DEVICE_TAG
+  ) ?: ''
+  def installerTarget = env.BUILD_TARGET ?: env.TEST_TARGET
+  env.INSTALLER_FLOW = installerTarget.contains("installer") ? 'true' : 'false'
   def deviceInfo = null
-  if (flashTarget && !params.DEVICE_TAG) {
-    deviceInfo = utils.derive_device_info(flashTarget, params.SECUREBOOT)
+  if (env.TEST_TARGET && !params.DEVICE_TAG) {
+    deviceInfo = utils.derive_device_info(env.TEST_TARGET, params.SECUREBOOT)
     if (!deviceInfo) {
-      error("Could not derive DEVICE_TAG from target '${flashTarget}' and DEVICE_TAG is not defined")
+      error("Could not derive DEVICE_TAG from test target '${env.TEST_TARGET}' and DEVICE_TAG is not defined")
     }
   }
   if (params.DEVICE_TAG) {
@@ -134,7 +145,10 @@ def init() {
     deviceInfo = [name: deviceName, tag: params.DEVICE_TAG]
   }
   if (!deviceInfo) {
-    error("DEVICE_TAG is not defined and could not be derived from IMG_URL '${params.IMG_URL}', OCI_IMAGE_REF '${params.OCI_IMAGE_REF}', or explicit DEVICE_TAG")
+    error(
+      "DEVICE_TAG is not defined and could not be derived from TEST_TARGET '${params.TEST_TARGET}', " +
+        "JOB_SELECTOR '${params.JOB_SELECTOR}', IMG_URL '${params.IMG_URL}', OCI_IMAGE_REF '${params.OCI_IMAGE_REF}', or explicit DEVICE_TAG"
+    )
   }
   env.DEVICE_NAME = deviceInfo.name
   env.DEVICE_TAG = deviceInfo.tag
@@ -225,18 +239,11 @@ pipeline {
         stage('Resolve target') {
           steps {
             script {
-              def explicitTarget = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
-              def jobSelector = params.JOB_SELECTOR?.trim()
-              if (explicitTarget) {
-                env.TARGET = explicitTarget
-              } else if (jobSelector) {
-                env.TARGET = jobSelector
-              } else {
-                env.TARGET = env.DEVICE_TAG
-              }
+              env.TARGET = env.TEST_TARGET
               env.DEVICE_BOOT_TAG = utils.boot_tag_for(env.DEVICE_TAG)
-              currentBuild.description = "${env.TEST_AGENT_LABEL}"
-              println("Using TARGET: ${env.TARGET}")
+              currentBuild.description = "${env.TEST_AGENT_LABEL}<br>${env.TEST_TARGET}"
+              println("Using TEST_TARGET: ${env.TEST_TARGET}")
+              println("Using TARGET alias: ${env.TARGET}")
               println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
               println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
             }
@@ -264,10 +271,10 @@ pipeline {
                 mkdir -p ${TEST_CONFIG_DIR}
                 rm -f ${TEST_CONFIG_DIR}/*.json
                 ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
-                echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+                echo { \\\"Job\\\": \\\"${env.TEST_TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}
               """
-              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TARGET, env.DEVICE_NAME)
+              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
               env.MOUNT_CMD = mountCommands.mount_cmd
               env.UNMOUNT_CMD = mountCommands.unmount_cmd
             }
@@ -300,9 +307,11 @@ pipeline {
                   env.IMG_PATH = img_path
                 }
                 println "Uncompressed image at: ${env.IMG_PATH}"
+                env.INSTALLER_FLOW = env.IMG_PATH.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
               } else {
                 // flash-script handles .zst natively; pass the original download path.
                 env.FLASH_INPUT_PATH = img_path
+                env.INSTALLER_FLOW = img_path.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
                 println "Flash input: ${env.FLASH_INPUT_PATH}"
               }
             }
@@ -316,7 +325,7 @@ pipeline {
               if (params.USE_LEGACY_DD_FLASH) {
                 // Wipe possible ZFS leftovers, more details here:
                 // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
-                if(env.TARGET.contains("lenovo-x1")) {
+                if(env.TEST_TARGET.contains("lenovo-x1")) {
                   echo "Wiping filesystem..."
                   def SECTOR = 512
                   def MIB_TO_SECTORS = 20480
@@ -359,7 +368,7 @@ pipeline {
           }
         }
         stage('Run Ghaf-installer') {
-          when { expression { env.TARGET.contains("installer") && !params.WIPE_ONLY } }
+          when { expression { env.INSTALLER_FLOW == 'true' && !params.WIPE_ONLY } }
           steps {
             script {
               sh "${env.UNMOUNT_CMD}"
@@ -387,10 +396,10 @@ pipeline {
           }
         }
         stage('Wipe system') {
-          when { expression { env.TARGET.contains("installer")} }
+          when { expression { env.INSTALLER_FLOW == 'true'} }
           steps {
             script {
-              if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
+              if (env.INSTALLER_FLOW == 'true' && env.DEVICE_TAG == "darter-pro") {
                 ghaf_robot_test('break')
               }
               ghaf_robot_test('relay-turnoff')

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -32,6 +32,10 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
     string(name: 'CI_TEST_REPO_BRANCH', defaultValue: 'main', description: 'Select ci-test-automation branch to checkout.'),
     string(name: 'OCI_IMAGE_REF', defaultValue: '', description: 'Published OCI image reference.'),
     string(name: 'IMG_URL', defaultValue: '', description: 'Target image url.'),
+    string(
+      name: 'TEST_TARGET',
+      defaultValue: '',
+      description: 'Concrete target identity to test. If empty, derive it from OCI_IMAGE_REF or IMG_URL.'),
     string(name: 'GHAF_FLAKE_REF', defaultValue: '', description: 'Pinned Ghaf flake reference for flash-script. If empty, derive it from OCI metadata or IMG_URL commit.'),
     string(name: 'TESTSET', defaultValue: '_relayboot_', description: 'Target testset, e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.'),
     string(name: 'TESTAGENT_HOST', defaultValue: null, description: 'Target testagent host, e.g.: dev, prod, release'),
@@ -65,19 +69,25 @@ def init() {
   if (!ociImageRef && !imgUrl) {
     error("Missing OCI_IMAGE_REF or IMG_URL parameter")
   }
+  env.BUILD_TARGET = utils.derive_target_name(imgUrl, env.OCI_TARGET) ?: ''
+  env.TEST_TARGET = utils.resolve_test_target(params.TEST_TARGET, env.BUILD_TARGET) ?: ''
+  env.TESTSET = params.TESTSET ?: ''
+  env.INSTALLER_FLOW = env.BUILD_TARGET.contains("installer") ? 'true' : 'false'
   // Resolve the target here as well for controller-side fail-fast validation and
   // device/agent selection. The agent-side Resolve target stage repeats this so
   // it can initialize runtime state after node allocation.
-  def target = utils.derive_target_name(imgUrl, env.OCI_TARGET)
-  if (!target) {
-    if (ociImageRef) {
-      error("Unable to derive target name from OCI image '${ociImageRef}'")
-    }
-    error("Unexpected IMG_URL: ${params.IMG_URL}")
+  if (imgUrl && !env.BUILD_TARGET) {
+    error("Unsupported IMG_URL layout '${params.IMG_URL}': expected a path containing commit_<sha>/<target>/...")
   }
-  def deviceInfo = utils.derive_device_info(target, params.SECUREBOOT)
+  if (!env.TEST_TARGET) {
+    if (ociImageRef) {
+      error("Unable to derive test target from OCI image '${ociImageRef}'. Set TEST_TARGET explicitly.")
+    }
+    error("Unable to derive test target from IMG_URL '${params.IMG_URL}'")
+  }
+  def deviceInfo = utils.derive_device_info(env.TEST_TARGET, params.SECUREBOOT)
   if (!deviceInfo) {
-    error("Unable to parse device config for target '${target}'")
+    error("Unable to parse device config for test target '${env.TEST_TARGET}'")
   }
   env.DEVICE_NAME = deviceInfo.name
   env.DEVICE_TAG = deviceInfo.tag
@@ -240,16 +250,12 @@ pipeline {
         stage('Resolve target') {
           steps {
             script {
-              env.TARGET = utils.derive_target_name(params.IMG_URL, env.OCI_TARGET)
-              if (!env.TARGET) {
-                if (params.OCI_IMAGE_REF) {
-                  error("Unable to derive target name from OCI image '${params.OCI_IMAGE_REF}'")
-                }
-                error("Unexpected IMG_URL: ${params.IMG_URL}")
-              }
-              env.EXTRATAG = utils.extra_tag_suffix(env.TARGET, env.DEVICE_TAG)
-              currentBuild.description = params.containsKey('DESC') ? "${params.DESC}" : "${env.TARGET}"
-              println("Using TARGET: ${env.TARGET}")
+              env.TARGET = env.TEST_TARGET
+              env.TESTSET = params.TESTSET ?: ''
+              env.EXTRATAG = utils.extra_tag_suffix(env.TEST_TARGET, env.DEVICE_TAG)
+              currentBuild.description = params.containsKey('DESC') ? "${params.DESC}" : "${env.TEST_TARGET}"
+              println("Using TEST_TARGET: ${env.TEST_TARGET}")
+              println("Using TARGET alias: ${env.TARGET}")
               println("Using DEVICE_NAME: ${env.DEVICE_NAME}")
               println("Using DEVICE_TAG: ${env.DEVICE_TAG}")
               if (env.EXTRATAG) {
@@ -282,7 +288,7 @@ pipeline {
                 mkdir -p ${TEST_CONFIG_DIR}
                 rm -f ${TEST_CONFIG_DIR}/*.json
                 ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
-                echo { \\\"Job\\\": \\\"${env.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+                echo { \\\"Job\\\": \\\"${env.TEST_TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}
               """
             }
@@ -351,6 +357,7 @@ pipeline {
               sh "verify-signature image ${img_path} ${sig_path}"
               // flash-script handles .zst natively; pass the original download path.
               env.FLASH_INPUT_PATH = img_path
+              env.INSTALLER_FLOW = img_path.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
               println "Flash input: ${env.FLASH_INPUT_PATH}"
             }
           }
@@ -358,7 +365,7 @@ pipeline {
         stage('Flash') {
           steps {
             script {
-              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TARGET, env.DEVICE_NAME)
+              def mountCommands = utils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
               env.MOUNT_CMD = mountCommands.mount_cmd
               env.UNMOUNT_CMD = mountCommands.unmount_cmd
               def dev = utils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
@@ -385,7 +392,7 @@ pipeline {
           }
         }
         stage('Run Ghaf-installer') {
-          when { expression { env.TARGET.contains("installer") } }
+          when { expression { env.INSTALLER_FLOW == 'true' } }
           steps {
             script {
               println "Run ghaf-installer"
@@ -438,10 +445,10 @@ pipeline {
           }
         }
         stage('Wipe system') {
-          when { expression { env.TARGET.contains("installer")} }
+          when { expression { env.INSTALLER_FLOW == 'true'} }
           steps {
             script {
-              if (env.TARGET.contains("installer") && env.DEVICE_TAG == "darter-pro") {
+              if (env.INSTALLER_FLOW == 'true' && env.DEVICE_TAG == "darter-pro") {
                 ghaf_robot_test('break')
               }
               ghaf_robot_test('relay-turnoff')


### PR DESCRIPTION
Add explicit TEST_TARGET support to ghaf-hw-test and ghaf-hw-test-manual. This allows flashing a generic build artifact while device selection, Robot job identity, and installer or wipe behavior use a separate concrete test target.

Keep the legacy fallback behavior by deriving the test target from OCI_IMAGE_REF or IMG_URL when TEST_TARGET is empty. Thread the explicit target through utils.run_hw_test() and keep OCI image handling bound to the build artifact.