### PR TITLE
Jenkins: support build-to-many hardware tests

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -170,23 +170,25 @@ def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFla
 
 def run_hw_test(
   String buildShortname,
+  String testTargetName,
+  String testIdentity,
   String testset,
   String testagent_host,
   Map oci_result,
   boolean secureboot,
-  String ci_env,
-  String testTargetName = null) {
+  String ci_env) {
   // Keep the blocking downstream wait outside node('built-in') so ghaf-hw-test
   // can acquire a controller executor for its own initialization stages.
   def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
   def normalizedTestTarget = testTargetName?.trim()
-  def desc = normalizedTestTarget ?
-    "Triggered by ${build_href}<br>(build: ${buildShortname}, test: ${normalizedTestTarget})" :
+  def normalizedTestIdentity = testIdentity?.trim()
+  def desc = normalizedTestIdentity ?
+    "Triggered by ${build_href}<br>(build: ${buildShortname}, test: ${normalizedTestIdentity})" :
     "Triggered by ${build_href}<br>(${buildShortname})"
   def test_params = [
     string(name: "TESTSET", value: testset),
     string(name: "DESC", value: desc),
-    string(name: "TESTAGENT_HOST", value: testagent_host),
+    string(name: "TESTAGENT_HOST", value: testagent_host ?: ''),
     booleanParam(name: "USE_FLAKE_PINNED_CI_TEST", value: ci_env == "release"),
     booleanParam(name: "RELOAD_ONLY", value: false),
     booleanParam(name: "SECUREBOOT", value: secureboot),
@@ -206,28 +208,27 @@ def run_hw_test(
     parameters: test_params
   )
   return [
-    absoluteUrl: job.absoluteUrl,
+    url: job.absoluteUrl,
     number: job.number,
     result: job.result,
   ]
 }
 
 def collect_hw_test_result(
-  String shortname,
-  String testset,
-  String output,
+  String testIdentity,
+  String testPathKey,
   boolean secureboot,
+  String output,
   Map job) {
-  def logPrefix = secureboot ? "ghaf-hw-test log SB '${shortname}:" : "ghaf-hw-test log '${shortname}:"
+  def logPrefix = secureboot ? "ghaf-hw-test log SB '${testIdentity}:" : "ghaf-hw-test log '${testIdentity}:"
   println(logPrefix)
   sh "cat /var/lib/jenkins/jobs/ghaf-hw-test/builds/${job.number}/log | sed 's/^/    /'"
   if (job.result != "SUCCESS") {
-    unstable("FAILED: ${shortname} ${testset}")
+    unstable("FAILED: ${testIdentity}")
     currentBuild.result = "FAILURE"
-    def buildDescriptionName = secureboot ? "${shortname} (SB)" : shortname
-    utils.append_to_build_description("<a href=\"${job.absoluteUrl}\">⛔ ${buildDescriptionName}</a>")
+    utils.append_to_build_description("<a href=\"${job.url}\">⛔ ${testIdentity}</a>")
   }
-  def artifactsTarget = secureboot ? "${output}/test-results/secureboot" : "${output}/test-results"
+  def artifactsTarget = "${output}/test-results/${testPathKey}"
   copyArtifacts(
     projectName: "ghaf-hw-test",
     selector: specific("${job.number}"),

--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -179,12 +179,13 @@ def run_hw_test(
   String ci_env) {
   // Keep the blocking downstream wait outside node('built-in') so ghaf-hw-test
   // can acquire a controller executor for its own initialization stages.
-  def build_href = "<a href=\"${env.BUILD_URL}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
+  def build_href = "<a href=\"${utils.html_escape(env.BUILD_URL)}\">" +
+    "${utils.html_escape("${env.JOB_NAME}#${env.BUILD_ID}")}</a>"
   def normalizedTestTarget = testTargetName?.trim()
   def normalizedTestIdentity = testIdentity?.trim()
   def desc = normalizedTestIdentity ?
-    "Triggered by ${build_href}<br>(build: ${buildShortname}, test: ${normalizedTestIdentity})" :
-    "Triggered by ${build_href}<br>(${buildShortname})"
+    "Triggered by ${build_href}<br>(${utils.html_escape(normalizedTestIdentity)})" :
+    "Triggered by ${build_href}<br>(${utils.html_escape(buildShortname)})"
   def test_params = [
     string(name: "TESTSET", value: testset),
     string(name: "DESC", value: desc),
@@ -226,7 +227,9 @@ def collect_hw_test_result(
   if (job.result != "SUCCESS") {
     unstable("FAILED: ${testIdentity}")
     currentBuild.result = "FAILURE"
-    utils.append_to_build_description("<a href=\"${job.url}\">⛔ ${testIdentity}</a>")
+    utils.append_to_build_description(
+      "<a href=\"${utils.html_escape(job.url)}\">⛔ ${utils.html_escape(testIdentity)}</a>"
+    )
   }
   def artifactsTarget = "${output}/test-results/${testPathKey}"
   copyArtifacts(

--- a/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
@@ -76,9 +76,41 @@ def test_identity(Map testConfig, boolean secureboot = false) {
   validate_test_identity_component('testset', testset)
   validate_test_identity_component('testagent host', effectiveHost)
 
-  def mode = secureboot ? 'secureboot' : 'normal'
-  def hostComponent = effectiveHost == null ? 'host-any' : "host-${effectiveHost}"
-  return "${testTarget}@${testset}@${hostComponent}@${mode}".toString()
+  def targetComponent = testTarget.replaceFirst(/^packages\./, '')
+  def mode = secureboot ? 'secureboot' : 'no-secureboot'
+  def hostComponent = effectiveHost == null ? 'any' : effectiveHost
+  return "${targetComponent}@${testset}@${hostComponent}@${mode}".toString()
+}
+
+def test_result_entry(Map testRun, Map result = [:]) {
+  if (testRun == null) {
+    fail("Missing test run")
+  }
+
+  def entry = [
+    id: testRun.id,
+    target: testRun.target,
+    testset: testRun.testset,
+    testagent_host_override: testRun.get('testagent_host_override', null),
+    effective_testagent_host: testRun.get('effective_testagent_host', null),
+    secureboot: testRun.get('secureboot', false),
+    artifacts: testRun.get('artifacts', null) ?: "test-results/${testRun.test_path_key}",
+  ]
+
+  def status = result.containsKey('status') ? result.status : testRun.get('initial_status', null)
+  def reason = result.containsKey('reason') ? result.reason : testRun.get('initial_reason', null)
+
+  if (status != null) {
+    entry.status = status
+  }
+  if (reason != null) {
+    entry.reason = reason
+  }
+  if (result.get('job', null) instanceof Map) {
+    entry.job = shallow_copy_map(result.job)
+  }
+
+  return entry
 }
 
 def normalize_tests(Map buildConfig, String defaultTestagentHost = null) {
@@ -199,6 +231,59 @@ def normalize_tests(Map buildConfig, String defaultTestagentHost = null) {
   return normalizedTests
 }
 
+def expand_test_runs(Map buildConfig) {
+  if (buildConfig == null) {
+    fail("Missing build config")
+  }
+
+  def buildTarget = buildConfig.target
+  if (!(buildTarget instanceof String) || buildTarget.isEmpty()) {
+    fail("Missing target name")
+  }
+
+  def normalizedTests = buildConfig.get('tests', [])
+  if (!(normalizedTests instanceof List)) {
+    fail("Invalid tests for '${buildTarget}': expected a list")
+  }
+
+  def ciEnv = normalize_optional_string(buildConfig.get('ci_env', null))
+  def securebootExecutionAllowed = buildConfig.get('secureboot_execution_allowed', false)
+  def runs = []
+
+  normalizedTests.each { normalizedTest ->
+    def normalRun = shallow_copy_map(normalizedTest)
+    normalRun.id = normalizedTest.id
+    normalRun.test_path_key = normalizedTest.test_path_key
+    normalRun.secureboot = false
+    normalRun.stage_name = "Test ${normalRun.test_path_key}"
+    normalRun.artifacts = "test-results/${normalRun.test_path_key}"
+    if (ciEnv == 'vm') {
+      normalRun.initial_status = 'SKIPPED'
+      normalRun.initial_reason = 'ci_env_vm'
+    }
+    runs << normalRun
+
+    if (normalizedTest.secureboot_requested) {
+      def securebootRun = shallow_copy_map(normalizedTest)
+      securebootRun.id = normalizedTest.secureboot_id
+      securebootRun.test_path_key = normalizedTest.secureboot_test_path_key
+      securebootRun.secureboot = true
+      securebootRun.stage_name = "Test SB ${securebootRun.test_path_key}"
+      securebootRun.artifacts = "test-results/${securebootRun.test_path_key}"
+      if (ciEnv == 'vm') {
+        securebootRun.initial_status = 'SKIPPED'
+        securebootRun.initial_reason = 'ci_env_vm'
+      } else if (!securebootExecutionAllowed) {
+        securebootRun.initial_status = 'SKIPPED'
+        securebootRun.initial_reason = 'secureboot_not_available'
+      }
+      runs << securebootRun
+    }
+  }
+
+  return runs
+}
+
 def normalize_build_config(
   Map targetConfig,
   boolean signingPossible,
@@ -220,7 +305,9 @@ def normalize_build_config(
   def normalized = shallow_copy_map(targetConfig)
   normalized.target = targetName
   normalized.shortname = short_target_name(targetName)
+  normalized.ci_env = ciEnv
   normalized.no_image = normalized.get('no_image', false)
+  normalized.signing_possible = signingPossible
   normalized.uefi_sign_requested = normalized.get('uefisign', false) || normalized.get('uefisigniso', false)
   normalized.testset = normalized.get('testset', null)
   normalized.has_testset = normalized.testset != null && !normalized.testset.isEmpty()
@@ -229,8 +316,10 @@ def normalize_build_config(
   normalized.build_otapin_requested = normalized.get('build_otapin', false)
   normalized.sbom_requested = normalized.get('sbom', false)
   normalized.can_uefi_sign = !normalized.no_image && signingPossible && normalized.uefi_sign_requested
+  normalized.secureboot_execution_allowed = normalized.can_uefi_sign && ciEnv == "prod"
   normalized.tests = normalize_tests(normalized, defaultTestagentHost)
+  normalized.test_runs = expand_test_runs(normalized)
   normalized.run_secboot_test =
-    normalized.test_secboot_requested && normalized.can_uefi_sign && ciEnv == "prod"
+    normalized.test_secboot_requested && normalized.secureboot_execution_allowed
   return normalized
 }

--- a/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
@@ -27,6 +27,41 @@ def safe_stage_key(String value) {
   return value.replace('@', '__').replaceAll(/[^A-Za-z0-9_.-]/, '-')
 }
 
+def html_escape(String value) {
+  if (value == null) {
+    return null
+  }
+  return value
+    .replace('&', '&amp;')
+    .replace('<', '&lt;')
+    .replace('>', '&gt;')
+    .replace('"', '&quot;')
+    .replace("'", '&#39;')
+}
+
+def display_testset(String value) {
+  def normalized = normalize_optional_string(value)
+  if (normalized == null) {
+    return null
+  }
+  normalized = normalized.replaceAll(/^_+|_+$/, '').replace('_', ' ')
+  return normalized ?: value
+}
+
+def test_stage_name(Map testRun) {
+  if (testRun == null) {
+    fail("Missing test run")
+  }
+  def shortname = normalize_optional_string(testRun.get('shortname', null))
+  if (shortname == null) {
+    shortname = short_target_name(testRun.target)
+  }
+  def testset = display_testset(testRun.testset)
+  def host = normalize_optional_string(testRun.get('effective_testagent_host', null)) ?: 'any'
+  def mode = testRun.get('secureboot', false) ? 'secureboot' : 'no-secureboot'
+  return "Test ${shortname} / ${testset} / ${host} / ${mode}".toString()
+}
+
 def normalize_optional_string(value) {
   if (!(value instanceof String)) {
     return null
@@ -255,7 +290,7 @@ def expand_test_runs(Map buildConfig) {
     normalRun.id = normalizedTest.id
     normalRun.test_path_key = normalizedTest.test_path_key
     normalRun.secureboot = false
-    normalRun.stage_name = "Test ${normalRun.test_path_key}"
+    normalRun.stage_name = test_stage_name(normalRun)
     normalRun.artifacts = "test-results/${normalRun.test_path_key}"
     if (ciEnv == 'vm') {
       normalRun.initial_status = 'SKIPPED'
@@ -268,7 +303,7 @@ def expand_test_runs(Map buildConfig) {
       securebootRun.id = normalizedTest.secureboot_id
       securebootRun.test_path_key = normalizedTest.secureboot_test_path_key
       securebootRun.secureboot = true
-      securebootRun.stage_name = "Test SB ${securebootRun.test_path_key}"
+      securebootRun.stage_name = test_stage_name(securebootRun)
       securebootRun.artifacts = "test-results/${securebootRun.test_path_key}"
       if (ciEnv == 'vm') {
         securebootRun.initial_status = 'SKIPPED'
@@ -279,6 +314,18 @@ def expand_test_runs(Map buildConfig) {
       }
       runs << securebootRun
     }
+  }
+
+  def seenStageNames = [:]
+  runs.each { run ->
+    if (seenStageNames.containsKey(run.stage_name)) {
+      def previous = seenStageNames[run.stage_name]
+      fail(
+        "Duplicate test stage name '${run.stage_name}' for build '${buildTarget}': " +
+          "'${previous.id}' and '${run.id}'"
+      )
+    }
+    seenStageNames[run.stage_name] = run
   }
 
   return runs

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -65,6 +65,10 @@ def path_basename(String path) {
   return idx >= 0 ? path.substring(idx + 1) : path
 }
 
+def html_escape(String value) {
+  pipeline_model_call { pipelineModel.html_escape(value) }
+}
+
 def image_role(String path) {
   def basename = path_basename(path)
   if (basename == null) {
@@ -604,65 +608,71 @@ def create_pipeline(
       if (!normalized_test_runs.isEmpty()) {
         try {
           def test_branches = [:]
+          def hw_test_stage_name = "HW test ${build_shortname}"
+          def all_tests_skipped = normalized_test_runs.every { testRun ->
+            testRun.initial_status == 'SKIPPED'
+          }
           normalized_test_runs.each { testRun ->
             def localTestRun = testRun
             def stageName = localTestRun.stage_name
             test_branches[stageName] = {
-              stage(stageName) {
-                if (localTestRun.initial_status == 'SKIPPED') {
-                  persist_test_result(localTestRun)
-                  Utils.markStageSkippedForConditional(stageName)
-                  println(
-                    "Skipping hardware test ${localTestRun.id}: ${localTestRun.initial_reason}"
+              if (localTestRun.initial_status == 'SKIPPED') {
+                persist_test_result(localTestRun)
+                println(
+                  "Skipping hardware test ${localTestRun.id}: ${localTestRun.initial_reason}"
+                )
+              } else {
+                def job = null
+                try {
+                  job = run_hw_test(
+                    build_shortname,
+                    localTestRun.target,
+                    localTestRun.id,
+                    localTestRun.testset,
+                    localTestRun.effective_testagent_host,
+                    oci_result,
+                    localTestRun.secureboot,
+                    ci_env
                   )
-                } else {
-                  def job = null
-                  try {
-                    job = run_hw_test(
-                      build_shortname,
-                      localTestRun.target,
+                  persist_test_result(localTestRun, [job: job])
+                  with_controller_workspace(ghaf_checkout) {
+                    collect_hw_test_result(
                       localTestRun.id,
-                      localTestRun.testset,
-                      localTestRun.effective_testagent_host,
-                      oci_result,
+                      localTestRun.test_path_key,
                       localTestRun.secureboot,
-                      ci_env
+                      output,
+                      job
                     )
-                    persist_test_result(localTestRun, [job: job])
-                    with_controller_workspace(ghaf_checkout) {
-                      collect_hw_test_result(
-                        localTestRun.id,
-                        localTestRun.test_path_key,
-                        localTestRun.secureboot,
-                        output,
-                        job
-                      )
-                    }
-                    persist_test_result(localTestRun, [
-                      status: job.result ?: 'UNKNOWN',
-                      job: job,
-                    ])
-                  } catch (Exception e) {
-                    def result = [
-                      status: 'ERROR',
-                      reason: e.message,
-                    ]
-                    if (job != null) {
-                      result.job = job
-                    }
-                    persist_test_result(localTestRun, result)
-                    append_to_build_description("⛔ ${localTestRun.id}")
-                    throw e
                   }
+                  persist_test_result(localTestRun, [
+                    status: job.result ?: 'UNKNOWN',
+                    job: job,
+                  ])
+                } catch (Exception e) {
+                  def result = [
+                    status: 'ERROR',
+                    reason: e.message,
+                  ]
+                  if (job != null) {
+                    result.job = job
+                  }
+                  persist_test_result(localTestRun, result)
+                  append_to_build_description("⛔ ${html_escape(localTestRun.id)}")
+                  throw e
                 }
               }
             }
           }
 
-          if (parallel_tests) {
-            parallel test_branches
-          } else {
-            test_branches.each { key, value -> value() }
+          stage(hw_test_stage_name) {
+            if (parallel_tests) {
+              parallel test_branches
+            } else {
+              test_branches.each { key, value -> value() }
+            }
+            if (all_tests_skipped) {
+              Utils.markStageSkippedForConditional(hw_test_stage_name)
+            }
           }
         } finally {
           stage("Publish test results ${build_shortname}") {

--- a/hosts/hetzci/pipeline-library/vars/utils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/utils.groovy
@@ -198,6 +198,10 @@ def normalize_build_config(
   }
 }
 
+def test_result_entry(Map testRun, Map result = [:]) {
+  pipeline_model_call { pipelineModel.test_result_entry(testRun, result) }
+}
+
 def controller_workdir() {
   def rawTag = env.BUILD_TAG ?: "${env.JOB_NAME}-${env.BUILD_NUMBER}"
   def tag = safe_path_component(rawTag)
@@ -231,33 +235,45 @@ def with_controller_workspace(String workspace, Closure body) {
 
 def run_hw_test(
   String buildShortname,
+  String testTargetName,
+  String testIdentity,
   String testset,
   String testagent_host,
   Map oci_result,
   boolean secureboot,
-  String ci_env,
-  String testTargetName = null) {
+  String ci_env) {
   hwTestUtils.run_hw_test(
     buildShortname,
+    testTargetName,
+    testIdentity,
     testset,
     testagent_host,
     oci_result,
     secureboot,
-    ci_env,
-    testTargetName
+    ci_env
   )
 }
 
 def collect_hw_test_result(
-  String shortname,
-  String testset,
-  String output,
+  String testIdentity,
+  String testPathKey,
   boolean secureboot,
+  String output,
   Map job) {
-  hwTestUtils.collect_hw_test_result(shortname, testset, output, secureboot, job)
+  hwTestUtils.collect_hw_test_result(
+    testIdentity,
+    testPathKey,
+    secureboot,
+    output,
+    job
+  )
 }
 
-def create_pipeline(List<Map> targets, String testagent_host = null, String target_flake_ref = null) {
+def create_pipeline(
+  List<Map> targets,
+  String testagent_host = null,
+  String target_flake_ref = null,
+  Map options = [:]) {
   def pipeline = [:]
   def stamp = run_cmd('date +"%Y%m%d_%H%M%S%3N"')
   def target_commit = run_cmd('git rev-parse HEAD')
@@ -274,8 +290,8 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
   def immutable_tag = "${ci_env}-${stamp}-${target_commit}"
   def signing_possible = ci_env != 'vm'
   def ghaf_checkout = pwd()
+  def parallel_tests = options.get('parallel_tests', true)
 
-  // Evaluate
   stage("Eval") {
     lock('evaluator') {
       sh 'bash -o pipefail -c "nix flake show --all-systems | ansi2txt"'
@@ -286,20 +302,15 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
       raw_target_config,
       signing_possible,
       ci_env,
-      testagent_host,
-      false
+      testagent_host
     )
-    def target_name = target_config.target
-    def shortname = target_config.shortname
-    def output = "${artifacts_local_dir}/${target_name}"
-    def local_target_ref = "${ghaf_checkout}#${target_name}"
+    def build_target_name = target_config.target
+    def build_shortname = target_config.shortname
+    def normalized_test_runs = target_config.test_runs
+    def output = "${artifacts_local_dir}/${build_target_name}"
+    def local_target_ref = "${ghaf_checkout}#${build_target_name}"
     def no_image = target_config.no_image
     def uefi_sign_requested = target_config.uefi_sign_requested
-    def can_uefi_sign = target_config.can_uefi_sign
-    def testset = target_config.testset
-    def has_testset = target_config.has_testset
-    def test_secboot_requested = target_config.test_secboot_requested
-    def run_secboot_test = target_config.run_secboot_test
     def provenance_requested = target_config.provenance_requested
     def build_otapin_requested = target_config.build_otapin_requested
     def sbom_requested = target_config.sbom_requested
@@ -317,7 +328,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
         revision: target_commit,
         flake_ref: target_flake_ref,
       ],
-      target: target_name,
+      target: build_target_name,
       build: [
         ts_begin: null,
         ts_finished: null,
@@ -358,6 +369,32 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
       ],
     ]
     def oci_result = null
+    def result_file_for = { Map testRun ->
+      "${output}/test-results/${testRun.test_path_key}/result.json"
+    }
+    def write_manifest = { List testEntries = null ->
+      if (testEntries == null) {
+        manifest.remove('tests')
+      } else {
+        manifest.tests = testEntries
+      }
+      writeFile(
+        file: "${output}/manifest.json",
+        text: JsonOutput.prettyPrint(JsonOutput.toJson(manifest))
+      )
+    }
+    def persist_test_result = { Map testRun, Map result = [:] ->
+      def entry = test_result_entry(testRun, result)
+      with_controller_workspace(ghaf_checkout) {
+        sh "mkdir -v -p '${output}/test-results/${testRun.test_path_key}'"
+        writeFile(
+          file: result_file_for(testRun),
+          text: JsonOutput.prettyPrint(JsonOutput.toJson(entry))
+        )
+      }
+      return entry
+    }
+
     if (no_image) {
       manifest.uefi.reason = "no_image"
     } else if (!signing_possible) {
@@ -366,25 +403,23 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
       manifest.uefi.reason = "not_requested"
     }
 
-    pipeline["${target_name}"] = {
+    pipeline["${build_target_name}"] = {
       with_controller_workspace(ghaf_checkout) {
-        // Build
-        stage("Build ${shortname}") {
+        stage("Build ${build_shortname}") {
           sh "mkdir -v -p ${output}"
 
           manifest.build.ts_begin = run_cmd('date +%s')
           lock(label: 'nix-build', quantity: 1) {
-            sh "nix build --fallback -v .#${target_name} --out-link ${output}/unsigned-output"
+            sh "nix build --fallback -v .#${build_target_name} --out-link ${output}/unsigned-output"
           }
           manifest.build.ts_finished = run_cmd('date +%s')
         }
-        // Provenance
         if (provenance_requested) {
-          stage("Provenance ${shortname}") {
+          stage("Provenance ${build_shortname}") {
             def ext_params = """
               {
                 "target": {
-                  "name": "${target_name}",
+                  "name": "${build_target_name}",
                   "repository": "${target_repo}",
                   "ref": "${target_commit}"
                 },
@@ -423,10 +458,9 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             }
           }
         }
-        // Build OTA pin
         if (build_otapin_requested) {
-          stage("OTA Build ${shortname}") {
-            def ota_target = target_name.tokenize('.').last()
+          stage("OTA Build ${build_shortname}") {
+            def ota_target = build_target_name.tokenize('.').last()
             sh """
               mkdir -v -p ${ota_target}; cd ${ota_target}
               nixos-rebuild build --fallback --flake .#${ota_target}
@@ -436,9 +470,8 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             """
           }
         }
-        // Run sbomnix
         if (sbom_requested) {
-          stage("SBOM ${shortname}") {
+          stage("SBOM ${build_shortname}") {
             def outdir = "${output}/attestations"
             sh """
               mkdir -v -p ${outdir}
@@ -452,10 +485,8 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             manifest.attestations.sbom_spdx.path = "attestations/sbom.spdx.json"
           }
         }
-        // Signing stages
-        // Skip signing stages only in vm, where the signing proxy is not configured.
         if (signing_possible && provenance_requested) {
-          stage("Sign (SLSA) provenance ${shortname}") {
+          stage("Sign (SLSA) provenance ${build_shortname}") {
             lock('signing') {
               withRedundancyRouter("GhafInfraSignProv") { ctx ->
                 sh """
@@ -472,7 +503,7 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           }
         }
         if (!no_image) {
-          stage("Find image ${shortname}") {
+          stage("Find image ${build_shortname}") {
             def img_path = run_cmd("find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit")
             if (!img_path) {
               error("No image found!")
@@ -482,12 +513,12 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           }
           if (signing_possible) {
             if (uefi_sign_requested) {
-              stage("Sign (UEFI) ${shortname}") {
-                def tmpdir = build_tmpdir("uefisign-${shortname}")
+              stage("Sign (UEFI) ${build_shortname}") {
+                def tmpdir = build_tmpdir("uefisign-${build_shortname}")
                 def img_name = path_basename(manifest.image.path)
 
                 def signer = "uefisign"
-                if (target_name.contains("nvidia-jetson-orin")) {
+                if (build_target_name.contains("nvidia-jetson-orin")) {
                   signer = "uefisign-simple"
                 }
 
@@ -511,19 +542,17 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
                   }
 
                   sh "mv '${tmpdir}/signed_${img_name}' '${output}/${img_name}'"
-                  // replace original image with uefisigned one
                   manifest.image.path = img_name
-                  manifest.uefi.signed = true;
+                  manifest.uefi.signed = true
                   manifest.uefi.reason = null
                 } finally {
                   sh "rm -rf '${tmpdir}'"
                 }
               }
             }
-            stage("Sign (SLSA) image ${shortname}") {
+            stage("Sign (SLSA) image ${build_shortname}") {
               lock('signing') {
                 def img_name = path_basename(manifest.image.path)
-                // sign the current main image be it unsigned or uefisigned
                 manifest.image.signature.path = "${img_name}.sig"
                 withRedundancyRouter("GhafInfraSignECP256") { ctx ->
                   sh """
@@ -539,29 +568,24 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
             }
           }
         }
-        // Link artifacts
-        stage("Link artifacts ${shortname}") {
+        stage("Link artifacts ${build_shortname}") {
           if (manifest.image.path && !manifest.uefi.signed) {
             def img_name = path_basename(manifest.image.path)
-            // make symlink from output root to original image if not using uefisigned
             sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
             manifest.image.path = img_name
           }
 
-          writeFile(
-            file: "${output}/manifest.json",
-            text: JsonOutput.prettyPrint(JsonOutput.toJson(manifest))
-          )
+          write_manifest()
 
           if (!currentBuild.description || !currentBuild.description.contains(artifacts_href)) {
             append_to_build_description(artifacts_href)
           }
         }
         if (!no_image) {
-          stage("Publish OCI ${shortname}") {
+          stage("Publish OCI ${build_shortname}") {
             withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
               def job_name = env.JOB_BASE_NAME.replaceFirst('^ghaf-', '')
-              def oci_target_name = target_name.replaceFirst('^packages\\.', '')
+              def oci_target_name = build_target_name.replaceFirst('^packages\\.', '')
               def oci_repository = "ghaf/${job_name}/${oci_target_name}"
               def oci_result_json = "${output}/oci-result.json"
               sh """
@@ -576,54 +600,105 @@ def create_pipeline(List<Map> targets, String testagent_host = null, String targ
           }
         }
       }
-      // Test
-      if (has_testset) {
-        def testStageName = "Test ${shortname}"
-        stage(testStageName) {
-          if (ci_env == "vm") {
-            Utils.markStageSkippedForConditional(testStageName)
-            println("Skipping hardware tests for ${shortname}: CI_ENV is vm")
-          } else {
-            def job = run_hw_test(shortname, testset, testagent_host, oci_result, false, ci_env)
-            with_controller_workspace(ghaf_checkout) {
-              collect_hw_test_result(shortname, testset, output, false, job)
-            }
-          }
-        }
-        // Run an additional secure boot test only when the target requests it and
-        // secure-boot-capable hardware is available in prod. X1 update tests
-        // still need secure boot disabled, even for signed images, so the
-        // regular test run cannot be replaced with a secure boot-only run.
-        if (test_secboot_requested) {
-          def testSecbootStageName = "Test SB ${shortname}"
-          println(
-            "Secure boot test decision ${shortname}: " +
-              "requested=${test_secboot_requested}, " +
-              "can_uefi_sign=${can_uefi_sign}, " +
-              "ci_env=${ci_env}, " +
-              "run=${run_secboot_test}"
-          )
-          if (run_secboot_test) {
-            stage(testSecbootStageName) {
-              def job = run_hw_test(shortname, testset, testagent_host, oci_result, true, ci_env)
-              with_controller_workspace(ghaf_checkout) {
-                collect_hw_test_result(shortname, testset, output, true, job)
+
+      if (!normalized_test_runs.isEmpty()) {
+        try {
+          def test_branches = [:]
+          normalized_test_runs.each { testRun ->
+            def localTestRun = testRun
+            def stageName = localTestRun.stage_name
+            test_branches[stageName] = {
+              stage(stageName) {
+                if (localTestRun.initial_status == 'SKIPPED') {
+                  persist_test_result(localTestRun)
+                  Utils.markStageSkippedForConditional(stageName)
+                  println(
+                    "Skipping hardware test ${localTestRun.id}: ${localTestRun.initial_reason}"
+                  )
+                } else {
+                  def job = null
+                  try {
+                    job = run_hw_test(
+                      build_shortname,
+                      localTestRun.target,
+                      localTestRun.id,
+                      localTestRun.testset,
+                      localTestRun.effective_testagent_host,
+                      oci_result,
+                      localTestRun.secureboot,
+                      ci_env
+                    )
+                    persist_test_result(localTestRun, [job: job])
+                    with_controller_workspace(ghaf_checkout) {
+                      collect_hw_test_result(
+                        localTestRun.id,
+                        localTestRun.test_path_key,
+                        localTestRun.secureboot,
+                        output,
+                        job
+                      )
+                    }
+                    persist_test_result(localTestRun, [
+                      status: job.result ?: 'UNKNOWN',
+                      job: job,
+                    ])
+                  } catch (Exception e) {
+                    def result = [
+                      status: 'ERROR',
+                      reason: e.message,
+                    ]
+                    if (job != null) {
+                      result.job = job
+                    }
+                    persist_test_result(localTestRun, result)
+                    append_to_build_description("⛔ ${localTestRun.id}")
+                    throw e
+                  }
+                }
               }
             }
+          }
+
+          if (parallel_tests) {
+            parallel test_branches
           } else {
-            stage(testSecbootStageName) {
-              Utils.markStageSkippedForConditional(testSecbootStageName)
+            test_branches.each { key, value -> value() }
+          }
+        } finally {
+          stage("Publish test results ${build_shortname}") {
+            with_controller_workspace(ghaf_checkout) {
+              def finalTestEntries = normalized_test_runs.collect { testRun ->
+                def resultFile = result_file_for(testRun)
+                if (sh(script: "test -f '${resultFile}'", returnStatus: true) == 0) {
+                  return readJSON(file: resultFile, returnPojo: true)
+                }
+                if (testRun.initial_status != null) {
+                  return test_result_entry(testRun)
+                }
+                return test_result_entry(testRun, [
+                  status: 'UNKNOWN',
+                  reason: 'missing_result',
+                ])
+              }
+              write_manifest(finalTestEntries)
+              writeFile(
+                file: "${output}/test-results.json",
+                text: JsonOutput.prettyPrint(JsonOutput.toJson([
+                  target: build_target_name,
+                  tests: finalTestEntries,
+                ]))
+              )
             }
           }
         }
         if (ci_env != "vm") {
-          stage("Publish OCI test results ${shortname}") {
+          stage("Publish OCI test results ${build_shortname}") {
             with_controller_workspace(ghaf_checkout) {
               if (sh(
                 script: "test -d '${output}/test-results'",
                 returnStatus: true
               ) != 0) {
-                error("Missing test results for ${shortname}: ${output}/test-results")
+                error("Missing test results for ${build_shortname}: ${output}/test-results")
               }
               withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
                 sh """

--- a/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
@@ -97,9 +97,13 @@ pipeline {
         dir(utils.controller_workdir()) {
           script {
             if (params.SET_TESTAGENT_HOST && params.TESTAGENT_HOST) {
-              PIPELINE = utils.create_pipeline(TARGETS, params.TESTAGENT_HOST)
+              PIPELINE = utils.create_pipeline(TARGETS, params.TESTAGENT_HOST, null, [
+                parallel_tests: false,
+              ])
             } else {
-              PIPELINE = utils.create_pipeline(TARGETS, env.CI_ENV)
+              PIPELINE = utils.create_pipeline(TARGETS, env.CI_ENV, null, [
+                parallel_tests: false,
+              ])
             }
           }
         }

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -230,6 +230,9 @@ prepare_artifacts() {
     if [[ -d "$dir/test-results" ]]; then
       ln -s "$dir/test-results" "$TMPDIR/$target_name/test-results"
     fi
+    if [[ -f "$dir/test-results.json" ]]; then
+      ln -s "$dir/test-results.json" "$TMPDIR/$target_name/test-results.json"
+    fi
 
     # Create a release tarball
     tarball=${target_name#"packages."} # strip possible 'packages.' prefix

--- a/tests/jenkins/PipelineModelTest.groovy
+++ b/tests/jenkins/PipelineModelTest.groovy
@@ -20,19 +20,20 @@ assert pipelineModel.short_target_name('packages.x86_64-linux.lenovo-x1-carbon-g
 assert pipelineModel.short_target_name('plain-target') == 'plain-target'
 assert pipelineModel.safe_path_component('ghaf/main 1@prod') == 'ghaf-main-1-prod'
 assert pipelineModel.safe_stage_key(
-  'packages.x86_64-linux.lenovo@_relayboot bat_@host-prod@normal'
-) == 'packages.x86_64-linux.lenovo___relayboot-bat___host-prod__normal'
+  'x86_64-linux.lenovo@_relayboot bat_@prod@no-secureboot'
+) == 'x86_64-linux.lenovo___relayboot-bat___prod__no-secureboot'
 
 def sampleTestTarget = 'packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'
+def sampleTestIdentityTarget = 'x86_64-linux.lenovo-x1-carbon-gen11-debug'
 assert pipelineModel.test_identity([
   target: sampleTestTarget,
   testset: '_relayboot_bat_',
   effective_testagent_host: 'prod',
-]) == "${sampleTestTarget}@_relayboot_bat_@host-prod@normal"
+]) == "${sampleTestIdentityTarget}@_relayboot_bat_@prod@no-secureboot"
 assert pipelineModel.test_identity([
   target: sampleTestTarget,
   testset: '_relayboot_bat_',
-], true) == "${sampleTestTarget}@_relayboot_bat_@host-any@secureboot"
+], true) == "${sampleTestIdentityTarget}@_relayboot_bat_@any@secureboot"
 
 def normalizedLegacyBuild = pipelineModel.normalize_build_config([
   target: sampleTestTarget,
@@ -61,9 +62,9 @@ assert normalizedLegacyBuild.tests[0].testagent_host_override == null
 assert normalizedLegacyBuild.tests[0].effective_testagent_host == 'prod'
 assert normalizedLegacyBuild.tests[0].secureboot_requested == true
 assert normalizedLegacyBuild.tests[0].id ==
-  "${sampleTestTarget}@_relayboot_bat_@host-prod@normal"
+  "${sampleTestIdentityTarget}@_relayboot_bat_@prod@no-secureboot"
 assert normalizedLegacyBuild.tests[0].secureboot_id ==
-  "${sampleTestTarget}@_relayboot_bat_@host-prod@secureboot"
+  "${sampleTestIdentityTarget}@_relayboot_bat_@prod@secureboot"
 
 def normalizedDocBuild = pipelineModel.normalize_build_config([
   target: 'packages.x86_64-linux.doc',
@@ -111,11 +112,11 @@ assert normalizedExplicitTests.size() == 2
 assert normalizedExplicitTests[0].effective_testagent_host == 'prod'
 assert normalizedExplicitTests[0].secureboot_requested == true
 assert normalizedExplicitTests[0].test_path_key ==
-  'packages.x86_64-linux.lenovo-x1-carbon-gen11-debug___relayboot_bat___host-prod__normal'
+  'x86_64-linux.lenovo-x1-carbon-gen11-debug___relayboot_bat___prod__no-secureboot'
 assert normalizedExplicitTests[1].testagent_host_override == 'release'
 assert normalizedExplicitTests[1].effective_testagent_host == 'release'
 assert normalizedExplicitTests[1].id ==
-  'packages.x86_64-linux.system76-darp11-b-debug@_relayboot_bat_@host-release@normal'
+  'x86_64-linux.system76-darp11-b-debug@_relayboot_bat_@release@no-secureboot'
 
 def normalizedBuildWithExplicitTests = pipelineModel.normalize_build_config([
   target: 'packages.x86_64-linux.intel-laptop-debug',
@@ -136,6 +137,33 @@ def normalizedBuildWithExplicitTests = pipelineModel.normalize_build_config([
 assert normalizedBuildWithExplicitTests.tests.size() == 2
 assert normalizedBuildWithExplicitTests.has_testset == false
 assert normalizedBuildWithExplicitTests.tests[1].effective_testagent_host == 'release'
+assert normalizedBuildWithExplicitTests.test_runs.size() == 3
+assert normalizedBuildWithExplicitTests.test_runs[1].initial_status == 'SKIPPED'
+assert normalizedBuildWithExplicitTests.test_runs[1].initial_reason == 'secureboot_not_available'
+
+def skippedTestEntry = pipelineModel.test_result_entry(normalizedBuildWithExplicitTests.test_runs[1])
+assert skippedTestEntry.status == 'SKIPPED'
+assert skippedTestEntry.reason == 'secureboot_not_available'
+assert skippedTestEntry.artifacts ==
+  'test-results/x86_64-linux.lenovo-x1-carbon-gen11-debug___relayboot_bat___prod__secureboot'
+
+def finishedTestEntry = pipelineModel.test_result_entry(
+  normalizedBuildWithExplicitTests.test_runs[0],
+  [
+    status: 'SUCCESS',
+    job: [
+      url: 'https://ci.example.invalid/job/ghaf-hw-test/42/',
+      number: 42,
+      result: 'SUCCESS',
+    ],
+  ]
+)
+assert finishedTestEntry.status == 'SUCCESS'
+assert finishedTestEntry.job == [
+  url: 'https://ci.example.invalid/job/ghaf-hw-test/42/',
+  number: 42,
+  result: 'SUCCESS',
+]
 
 expectFailure('Missing target name') {
   pipelineModel.normalize_build_config([:], true, 'prod', 'prod')

--- a/tests/jenkins/PipelineModelTest.groovy
+++ b/tests/jenkins/PipelineModelTest.groovy
@@ -22,6 +22,10 @@ assert pipelineModel.safe_path_component('ghaf/main 1@prod') == 'ghaf-main-1-pro
 assert pipelineModel.safe_stage_key(
   'x86_64-linux.lenovo@_relayboot bat_@prod@no-secureboot'
 ) == 'x86_64-linux.lenovo___relayboot-bat___prod__no-secureboot'
+assert pipelineModel.html_escape(null) == null
+assert pipelineModel.html_escape('<script data-x="a&b">\'</script>') ==
+  '&lt;script data-x=&quot;a&amp;b&quot;&gt;&#39;&lt;/script&gt;'
+assert pipelineModel.display_testset('_relayboot_bat_') == 'relayboot bat'
 
 def sampleTestTarget = 'packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'
 def sampleTestIdentityTarget = 'x86_64-linux.lenovo-x1-carbon-gen11-debug'
@@ -65,6 +69,10 @@ assert normalizedLegacyBuild.tests[0].id ==
   "${sampleTestIdentityTarget}@_relayboot_bat_@prod@no-secureboot"
 assert normalizedLegacyBuild.tests[0].secureboot_id ==
   "${sampleTestIdentityTarget}@_relayboot_bat_@prod@secureboot"
+assert normalizedLegacyBuild.test_runs*.stage_name == [
+  'Test lenovo-x1-carbon-gen11-debug / relayboot bat / prod / no-secureboot',
+  'Test lenovo-x1-carbon-gen11-debug / relayboot bat / prod / secureboot',
+]
 
 def normalizedDocBuild = pipelineModel.normalize_build_config([
   target: 'packages.x86_64-linux.doc',
@@ -138,6 +146,11 @@ assert normalizedBuildWithExplicitTests.tests.size() == 2
 assert normalizedBuildWithExplicitTests.has_testset == false
 assert normalizedBuildWithExplicitTests.tests[1].effective_testagent_host == 'release'
 assert normalizedBuildWithExplicitTests.test_runs.size() == 3
+assert normalizedBuildWithExplicitTests.test_runs*.stage_name == [
+  'Test lenovo-x1-carbon-gen11-debug / relayboot bat / prod / no-secureboot',
+  'Test lenovo-x1-carbon-gen11-debug / relayboot bat / prod / secureboot',
+  'Test system76-darp11-b-debug / relayboot bat / release / no-secureboot',
+]
 assert normalizedBuildWithExplicitTests.test_runs[1].initial_status == 'SKIPPED'
 assert normalizedBuildWithExplicitTests.test_runs[1].initial_reason == 'secureboot_not_available'
 
@@ -241,6 +254,22 @@ expectFailure('Duplicate test path key') {
       ],
     ],
   ], 'prod')
+}
+
+expectFailure('Duplicate test stage name') {
+  pipelineModel.normalize_build_config([
+    target: 'packages.x86_64-linux.intel-laptop-debug',
+    tests: [
+      [
+        target: 'packages.x86_64-linux.same-shortname',
+        testset: '_relayboot_',
+      ],
+      [
+        target: 'packages.aarch64-linux.same-shortname',
+        testset: '_relayboot_',
+      ],
+    ],
+  ], true, 'prod', null)
 }
 
 expectFailure("reserved in canonical test identities") {


### PR DESCRIPTION
Refactor the Jenkins shared pipeline model to support one build triggering zero, one, or many hardware tests, while keeping legacy `target + testset` entries working.

This adds explicit per-test normalization, result metadata, and OCI test-result publishing, and cleans up hardware test stage/build descriptions.

#### Changes

- add explicit `tests` support in the shared pipeline model
- keep legacy single-test entries compatible
- fan out downstream `ghaf-hw-test` runs per normalized test run
- persist per-test `result.json`, aggregate `test-results.json`, and write test data into `manifest.json`
- publish OCI test-results for built artifacts
- keep `ghaf-nightly-perftest` sequential
- shorten hardware test stage/build descriptions
- validate duplicate test identities, artifact keys, and displayed stage names
- escape dynamic test identity text in Jenkins HTML descriptions 

 Tested in ci-vm and in [ci-dbg](https://ci-dbg.vedenemo.dev/job/ghaf-manual/45/).