### PR TITLE
Remove hetzarm-rel-1 kexec pinning

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -78,10 +78,6 @@ KEXEC_IMAGES = {
         f"{NIXOS_IMAGES_URL}/nixos-24.05/"
         "nixos-kexec-installer-noninteractive-x86_64-linux.tar.gz"
     ),
-    "hetzarm-rel-1": (
-        f"{NIXOS_IMAGES_URL}/nixos-25.11/"
-        "nixos-kexec-installer-noninteractive-aarch64-linux.tar.gz"
-    ),
 }
 
 RELEASE_BUILDER_USERS = (


### PR DESCRIPTION
It's no longer needed with current kernel (7.0.9), and would break with upcoming kernel (7.0.10) from #1091