### PR TITLE
Add pipeline in UAE dev env for g4h

### DIFF
--- a/hosts/ghaf-auth/configuration.nix
+++ b/hosts/ghaf-auth/configuration.nix
@@ -148,18 +148,14 @@ in
           {
             id = "azureci-dev";
             name = "ci-dev.uaenorth.cloudapp.azure.com";
-            redirectURIs = [
-              "https://ci-dev.uaenorth.cloudapp.azure.com/oauth2/callback"
-            ];
+            redirectURIs = [ "https://ci-dev.uaenorth.cloudapp.azure.com/oauth2/callback" ];
             secretEnv = "UAE_CI_DEV_CLIENT_SECRET";
             inherit grantTypes;
           }
           {
             id = "uae-zot-registry";
             name = "registry.uaenorth.cloudapp.azure.com";
-            redirectURIs = [
-              "https://registry.uaenorth.cloudapp.azure.com/oauth2/callback"
-            ];
+            redirectURIs = [ "https://registry.uaenorth.cloudapp.azure.com/zot/auth/callback/oidc" ];
             secretEnv = "UAE_ZOT_CLIENT_SECRET";
             inherit grantTypes;
           }

--- a/hosts/hetzci/pipelines/g4h-manual.groovy
+++ b/hosts/hetzci/pipelines/g4h-manual.groovy
@@ -1,0 +1,82 @@
+#!/usr/bin/env groovy
+
+@Library('ghafInfra') _
+
+def DEFAULT_REPO_URL = 'https://github.com/tiiuae/ghaf/'
+def PIPELINE = [:]
+
+properties([
+  githubProjectProperty(displayName: ''),
+  parameters([
+    booleanParam(name: 'UEFISIGN', defaultValue: false, description: 'Enable secure boot signing (for supported targets)'),
+    booleanParam(name: 'SECUREBOOT', defaultValue: false, description: 'Run tests also on secureboot enabled hardware, if available'),
+    string(name: 'REPO_URL', defaultValue: DEFAULT_REPO_URL, description: 'Git repository URL'),
+    string(name: 'GITREF', defaultValue: 'main', description: 'Ghaf git reference (Commit/Branch/Tag)'),
+    string(name: 'TESTSET', defaultValue: null, description: 'By default tests are skipped. To run hw-tests, define the target testset here; e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.)'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
+    booleanParam(name: 'nvidia_jetson_orin_agx_debug', defaultValue: false, description: 'Build target packages.aarch64-linux.nvidia-jetson-orin-agx-debug'),
+ ])
+])
+pipeline {
+  agent none
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+  stages {
+    stage('Reload only') {
+      agent { label 'built-in' }
+      when { expression { params && params.RELOAD_ONLY } }
+      steps {
+        script {
+          currentBuild.result = 'ABORTED'
+          currentBuild.displayName = "Reloaded pipeline"
+          error('Reloading pipeline - aborting other stages')
+        }
+      }
+    }
+    stage('Checkout') {
+      agent { label 'built-in' }
+      steps {
+        dir(utils.controller_workdir()) {
+          script {
+            utils.checkout_remote_ref(params.REPO_URL, params.GITREF)
+          }
+        }
+      }
+    }
+    stage('Setup') {
+      agent { label 'built-in' }
+      steps {
+        dir(utils.controller_workdir()) {
+          script {
+            def TARGETS = []
+            if (params.nvidia_jetson_orin_agx_debug_from_x86_64) {
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64", uefisign: params.UEFISIGN, testset: params.TESTSET ])
+            }
+            if (params.nvidia_jetson_orin_agx_debug) {
+              TARGETS.push(
+                [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug", uefisign: params.UEFISIGN, testset: params.TESTSET ])
+            }
+
+            PIPELINE = utils.create_pipeline(TARGETS)
+          }
+        }
+      }
+    }
+    stage('Build') {
+      steps {
+        script {
+          parallel PIPELINE
+        }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        utils.clean_controller_workdir()
+      }
+    }
+  }
+}

--- a/hosts/nethsm-gateway/secrets.yaml
+++ b/hosts/nethsm-gateway/secrets.yaml
@@ -4,7 +4,7 @@ nebula-cert: ENC[AES256_GCM,data:TPgXHBZOhDr2exifO/n2kJPVHBuhoOz25li0WFAgJ84fo+x
 nebula-key: ENC[AES256_GCM,data:4msG0iMbwwdJqYu4j9x0cFcAzo8eE7LITk5c0gEX+YGGgri9MnH15UgqTD649Xr/qtwUrR1eayYryiYWVohcZ7POZQBLrP0R2fE6pBqVFOipHbNwH2y9Cj4y1BTmN52WBXpkS275SvUWu5/0M69ab4nfUGwVvKux5HLQNsWFKw==,iv:yRlZdcw7Y9hM6Ab75Hu9oTZ1nY1X50CYG/VasjUKA5E=,tag:z+1lnxvGzwXhn+fO7z0w4g==,type:str]
 nethsm-metrics-credentials: ENC[AES256_GCM,data:fklDL4wVCxtjuCnOwTu2xccvA84RzU9Kqc4jILvG3bEY7lcZIodFY3Wofbe0sYdwml05,iv:7Pij2E+W9WQ8Gn4u72I4R3zJaHWu6L4VXzfaNp5scOo=,tag:+Rz4vbA4Akd/eD1xPH+TRQ==,type:str]
 nethsm-operator-password: ENC[AES256_GCM,data:ph2Qa2ddi1cvkw==,iv:6WOLLo5JlnZrDp5UNvJu/woDr0hf7uCNNvvni0kjlas=,tag:0W7C7SuAUG9+7AMuDh6RuQ==,type:str]
-tls-pks-file: ENC[AES256_GCM,data:+Fm9WGkT5GwrBzlKMa8hUXdX8hBL6AL24iJmiVRPe9rV1s2A4sxSJ0VoO7Ur17P0aJsL+xOevMApGv11KxLLO4xKQiWk9UN76fPIG6QqfAGYkoWI94yZ0/0PIAJgbg7PkUtCvG6QiPOcWuhK7PEhMsGVHUbGh4TWA4p5wRjMXBntsOwIxGR2G6eU0POZAQNO1/RaHCuT6AL9uATlBjXWXF0w06qN/4DdxNUhUjrvjwI0HbWJ+qTHKk3pa05sz3UY43FglfoUaU5JMAE5sk4K9OEd6W2Xmb/xMwqihHDygLALUE4UDZJrUNLPjRfKIV15U2JMYvVOte70zgRkWaHDa7jBRa9UJr0EjJRQMWTzjs5BkAmTMdzG9XFb5+ydpYvqgO9MXdRYv+UaXfY7h8/3SrtuCedTCwt2bgTHtjQtqq2qE4LU3PdKREmPrvqO64+XhuKHB5r91vLHK8eQ9Oy0qF7ro0VtyHi6LgCFSZ2LW9fRHTjfkBcEYREoHOUhxDpP/hGD,iv:X8MffZ2+d9GTVgD7qfi8VHl4U+lYj+J44HLTAMEpFjI=,tag:4eKqyTunoGWCdTykNPbzfA==,type:str]
+tls-pks-file: ENC[AES256_GCM,data:CCdYbaRFxsFR2vJtJQctfk0aBnaXkeN1+B1DReE831aLx2MJAOc4M0fZaVjV525ErEo8lQ1siiFuPIdxUBatpfT9hHs4eenhV1F779KZpUIMhhJWGuZDPZGotTuUq8F2exH93GdAxJCZMPN7cWSPYR5Jgec+XO4NCxzshxm0fK8E/rdSQ4ICJ/8bwKhlAbu65m4x3JiuevM/tMoSOClXrad/kitzLBQAvFM8mSPmLFrOxBI9+zhz8Gn5WwphRBb2bEO4vLhkOOsqgNibIzDwDewuhrtf7yuLjbCxnJoDshZsgr228OFjMR14ERfoVj2pQ0LpByHynE61EMph5qqH4dUg34179GREKaqHzAIYwPjFgK9grMnImN5PGx+9hV04IMx92ZxMcxCF9nEttDez9lC3fX2bXiHcBXyVvuyWxNpP+/aJHu2/YjTa082gnOmRwtWiMCnTHm0PlSyBxr2QrqqxgZ9B4fTUWFhEVGTVc/x2EpPTfJsW/8Qb9jfw9HXAvvbFpuB8ajsU+orBM1eCxQk7h/Wla6VBLvDJgf/pFD6fe1FjEfSMfgRLiUyur0c4Dv6l37QaILFyy22NRMmrMML/0Oi0Yg9Z5BVDr8ZEv8A=,iv:U7YAB77KDo2tZn5ZI4GisaxkLMJJjcLMgZVTleYoL3s=,tag:1Htc8NmuJy0klYTN9UHQmw==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:x9Pn1Kha0+en583H,iv:Fdm+FRmaY4B5/KOeQW9HLCX2Q/HreLb6pnCHOvJTUss=,tag:tu7zDZskwAhx9zvxuI7A1g==,type:str]
 sops:
     age:
@@ -53,7 +53,7 @@ sops:
             ZFhnMklpL3daRnlrT3Vqazc2ajExMmcKzAElb7laJHAZ4+O0vKA5a6DdMsRHmoGU
             LmKOwtxfYoa6jMKVARuyhxa27d2eXc1u8n6e3H8KIj6byapg34gfQQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-24T12:06:23Z"
-    mac: ENC[AES256_GCM,data:baLfBcjnrdPTg3/kgQESMPMUJ2gg0WzQ54qODE/OuT2OSPULtH2H/D7fU8i3QEo8kZhZAxAn5gHTgBKkef9D7wrc5N35iE6TWzRIOIXYA4MjRzvup8bJ749/dN9tp8msQX4JAWOicQ8AvPVZdDki/i0ZhEdwxdsdWLIn9dcryZU=,iv:cumrcI8zhFiKIQnf+1bzisUKlCG6gWVv+BW+NKHIGhI=,tag:GmnAheO4T5wkecb2LfWsiQ==,type:str]
+    lastmodified: "2026-06-03T07:14:22Z"
+    mac: ENC[AES256_GCM,data:NCKf65KSl93iz9P1Byb00m+HVRKgPM7IesTmEkc9w2+UtQCGIIPz8m1Ql54mIxtFyf1TlkB9FcSsm61EMxS3oqqy//sQq6Z54ENMNnq47YCGpTLlEzeZLxldCrMSXH+4NC88ZowXWuTyzIrFCbVyWCYezhPBT+V0YqsVFdJKG7c=,iv:9kKo2sPJRf5qDNdl3S6M/r0yGBj2ad7arXcTE9gcRg0=,tag:nv0mihZeP1mJstxHL3mQ2g==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/hosts/uae/azureci/dev/configuration.nix
+++ b/hosts/uae/azureci/dev/configuration.nix
@@ -34,8 +34,8 @@
       pipelines = [
         "ghaf-hw-test-manual"
         "ghaf-hw-test"
-        "ghaf-main"
         "ghaf-manual"
+        "g4h-manual"
       ];
       withCachix = false;
       withRegistryPublish = true;

--- a/hosts/uae/azureci/dev/secrets.yaml
+++ b/hosts/uae/azureci/dev/secrets.yaml
@@ -6,7 +6,7 @@ oauth2_proxy_client_secret: ENC[AES256_GCM,data:NPF+sJxlg2jNbDEaxmoOGcaG3KB1R8i2
 oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:XNEkj/2tNGBqtCjNhWPhV+8ZWEZKW6Cmywjz63ciWnbKXradnK6GZrdEzVY=,iv:do9oL6TAa/2IUJGEFhZ41XDv02NopcG5nEi+ibSRHPg=,tag:PMfH1vx13jwnNRqsvNvKIA==,type:str]
 jenkins_github_webhook_secret: ENC[AES256_GCM,data:+aXUBIaW5aRR4UlGHwUe5WERHsOAks2dA7uUJUFbYpo=,iv:QJLSyorNqRx2yc1316RhfYQ1Mt/I3YnZFweFRFhQN5g=,tag:l/ZGQPoQ0OD24f618LRPjQ==,type:str]
 jenkins_github_commit_status_token: ENC[AES256_GCM,data:Q83eQGGwZBpHuCrfn2eiiStR5iJJcZpvpbqrSGIq1ziRsNm6kZAWhg==,iv:ZHQrGsZf1S5poVx50COQSrhYtPgl7y/BOB7I8rid0Kg=,tag:VY+VNnhKK+tDY1FcBDJS0Q==,type:str]
-tls-pks-file: ENC[AES256_GCM,data:GzX6JyYzF4xD2QRDc4AkwA6Jj2An+7lbxFJQZx6r/bPyGuh94XVByFwHx5Bb/OMnBLOvffrXrZ+or0oadtcVHyv8M137jX/6m2qFYtu+,iv:VjZ2qehcwC+Go3/cRcLl+09vN0nsy2FFv5nNoISB2LI=,tag:JCszPSH1TQ/8AnptB1ZNAw==,type:str]
+tls-pks-file: ENC[AES256_GCM,data:CxUBJiRWplospo9knFE5WA/Q34mfEZuEULIbjE3hMx37Wa96JWeoKhGKzytISTziqfQWLLnz83AYmy6aTu9EwCJx1qd7q2FB5QKtDk0=,iv:q/jWBfUfg+khFCFEVoeF54if4/YNGjdcXM/lFRZRvO4=,tag:Er7g90IHbewE1IX2Xel4ZQ==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:/bC23+GvXMVpvTIv,iv:NI3suo2yDIfkIgCwJ6fIGkHOJERdZerIjnv+fgK13GY=,tag:9OeXnrvnVrKc8WTZYXqeWQ==,type:str]
 loki_password: ENC[AES256_GCM,data:YFMRbolajBffj+r0xU/2hAiP2A==,iv:2hLCKZ8lQ3DgkN3NOGHpGoyx6wEWryqSI7Wy2YSBTvs=,tag:JXh/374+GEmeFqeNR/2eYQ==,type:str]
 oci_registry_password: ENC[AES256_GCM,data:vS8lSMKDUK0C3rRc4Y4T,iv:Xh0ShzCNmPzVPW8234U9rm4dNOt/hw0fKyysAfVmg30=,tag:Cg27qmGVdpDzb1G8k0Lcog==,type:str]
@@ -48,7 +48,7 @@ sops:
             ekNCZCtIV2pTRW9jOG45QkgxMUZPSXcKhL91Nhub6CBMfhVawT53y6oCx8DgbvcY
             gM39JeQaikfUsnKD+J0XM6rFyenBqqpnaE2xz0kBO1w2ploxFtvVxw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-22T14:26:28Z"
-    mac: ENC[AES256_GCM,data:peIqBHlK34GyS0fW7vSuygM8ioXgMvWw0jAOd/y/fg9mJ/jOGPuXbPVqbg2uJVl5BhW0f3DAE2Vif9K/jWAI9Ly+vAMTBtIyDsEOGIwr7ofrcFVvya12/StYbO5X2abRMJxd8hx4pnGLhcRTd+J7eLYWFU3xtiUAwAH/MgsHdC8=,iv:NYVrnqwMXW1EUbUDdUKcrUPKmRShVcMZSRdsyV/QZx0=,tag:KYVJ8SDvkjJKAbAjoQpOYw==,type:str]
+    lastmodified: "2026-06-03T07:14:51Z"
+    mac: ENC[AES256_GCM,data:gCxo7obMMPBoJGMbYGu1oisXi9m9CVwJoqlSOaGpC64Zm4sdImh2ctFjLJiEBXGXMIPNy4yk87JacFx8crBeF/s/E7U7dJLcb1/Fy1E6rgY4XqQQgbtxwwVTAbl/x+QAiAyV+roWsFV2TxiPoFyFRQKtufps48a7zeOXDWm1Dbg=,iv:gSigzcYNXL1EOL5umRza1tXZJ64Y9c3gAzHUZEhEhFY=,tag:DTIBMQzTcrUZAaMf9ixD+A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1

--- a/hosts/uae/nethsm-gateway/secrets.yaml
+++ b/hosts/uae/nethsm-gateway/secrets.yaml
@@ -4,7 +4,7 @@ nebula-key: ENC[AES256_GCM,data:vFPLOqGKpI1QQ5IoFHT2Bpzt/3eE4mWATSPubVqT/xTHUo0M
 loki_password: ENC[AES256_GCM,data:FmMlFkHxC6eV8Bq5OaPrXKt/cw==,iv:5q1Iu9HNpkM66od49F/ziYEv4gPd+tKFCz2/UZd2xWA=,tag:tyrDSuXf2cR/q9fs0O15fw==,type:str]
 nethsm-metrics-credentials: ENC[AES256_GCM,data:edKuAskQp6qd+QyUZLYJly1Qh3lLV+mwybKJc1P7Zv9BHb8j1NSOvyLGo5/GkCLAQic9,iv:lJKM8U7hSSrgM8yq6GbaeeI3N+LtVmGa+I9cWmSvQF8=,tag:cPUn06CYOeOAjqZyrgyXoA==,type:str]
 nethsm-operator-password: ENC[AES256_GCM,data:OBd08zuNzVqDug==,iv:hzmBScNrMhXqQvoAEZpyPwurRxeoGwRcKYYeEVXn6LM=,tag:f2+qSGpBkGxJrwpv8TMJkA==,type:str]
-tls-pks-file: ENC[AES256_GCM,data:9jC0okDjcRqnNKJeomvuOBnZ8kt/AbjfgYMs7Pfuwkgj6qAPHa59/qgIYjgSUokyZQYI1yC3MBWlB769Px6kkzt1v6mxMip2OrbmbMa17OPuF8Cj8vvrjrSWDo/6ciKfgsOWdL+3a32to3zhgKArilS9tBwYseDuYTLlThcTKJdEfD5NuwWhG3Kfe8xPuazBgl2NGttpW/rITonm83y1qDWnPAnZyazfCFZhukSMXEscu7nD/P/wGewEAfni+HTIUd3BXups1MML+98Sj0OKi19EfZ0mmF0wo+K8pTQj4Sqc5Uf0lEyqVx3WdaKuzdcTJjmEEdTuNDb6Ivq/ddBN3WOSSfgCTrai3qNjWQ+aptqCldC6qOC3inQCtmlHziWxpfrmCvHSIsLfsjRUDfLguK5/6f7TiPk=,iv:U3SsDR+qp8WYUgZjH41I787uD1Aom7cKlLZPt4O3HkU=,tag:e0FKQmYgB8VFXLcRzxbkkA==,type:str]
+tls-pks-file: ENC[AES256_GCM,data:1uJkn7pTdR2hwqHixlMPRC3nJpB4tGoK0fcF/9vDzB9//Nrmjx9qL/c0WLTuSTmdn8zwtHZOPmXDnI8siZMUpY2r2f1jm/YROjL4aYUCm5RWvzgLn0eKcgUL7miu89Os6/TTVx4QdeCXZRzFa8gRWGsTgDjS8g5sCvKOrvEfRPc2j2VBGy6rWYzXjcI6QsT/U00v4wefVmMNQ2eekxEzlxKTAzHZfGNNTZfGN00PEYcZmoQ9k7awBVPatSad8OK90PWgqZ27yAIJ6SE3PgELLxuqAz6TsV2T/6MM76Kqmn217XD9wSoDr82TYwd12t5+OGW1hQ0z1jEpFqKzkng0lYbGlE1kTzhWgTWEO9hk3o7ZbonWfvo9+ASShA0KrnJIebpKvRb2LfmGYl3uZzUUPM6LmDBSsMZakyrUmh43nSAD/FSRrKhZO+S1Kx7IyNF69SqvdQ7XECTZtLu0IOnJy2JnlCBcUEjD+Z84gJ5eGB2+4zW8dZ+67FLP4khALLFqw1vAbfglEtRTN2nVJqDxVonVbt9m/dZu2riDGTwqnVfLo28a0OUgm4fyFW1F7goXB5OtgwlOJqDvW9kRK/NECfkPyYfyT+Tjc/8WCafSoQQ=,iv:MK0f0aJpuueL8paide3PAzjTd5pkSfnkUsd9CDWTRiA=,tag:j77rqENAcaTf3jgeuBfd+Q==,type:str]
 yubihsm-pin: ENC[AES256_GCM,data:luPCyvijzOnyijOM,iv:lZI5w1gFgvMKcup88Lt2wJ5sN1Q9TNtMjQkvi679tS0=,tag:RIb5cg1wjrwoW9F5m01sdQ==,type:str]
 sops:
     age:
@@ -53,7 +53,7 @@ sops:
             MnRxeTNuSjVoNzZ3TTJMV25PVVFFOGcKixtTzebv8V0aQtcQAWDyyOtYUe28poII
             oMR3rCLlZpRWDlNxB4HqMhQ5xRJM0Imy5rCr8d+Dm+PiA4jj4w+LxA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-11T05:59:08Z"
-    mac: ENC[AES256_GCM,data:cprEaZu1V+o+Pg7+cpBL0Nxjwb4JeW1ecwVUPcV0zn6Zbzxtd55L0264jYDd27QrRJsWqbEJKOCwEcCxnrnNgxc8TRDPxJi6Y4xp4I1UWBg4bFhiwd03dlXY/dua1iYTuxALy/ybgx4jaBnoxBtNO6PWsl5yW+GJ8G8RZfCaa8Q=,iv:m7HwWuroEsS+7nIExANExEt8VZzounWWLojkH/02AEY=,tag:vtyJ93XC4SDmAJlYp2A5zg==,type:str]
+    lastmodified: "2026-06-03T07:21:36Z"
+    mac: ENC[AES256_GCM,data:32t5Lt8EN43MjyIc4speNS2qkAefCPv/g5ICQEIVjNu87g+ZftLG745Rql/jNIfoUU5aT1aqdZbjTimk60dS2BGMt5dfcwDWTNm+uqS9F+cpFW+AjNqM3CF68yeFY+FHGwSXbjQIWSQnUIEQC/qF8Hbh9lMt/SDXcl1+t/Qowzk=,iv:zCj4EgbNnDtbV7WtchBoIHXBD2kwmO+j/cOpksD1rMs=,tag:yv6gI6Xv8QVRCW1XR3mG0Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
Add a manual pipline with agx target only. Import only on UAE dev environment. The pipline will trigger ghaf-hw-test against dev testagent once configured.

Also includes fix for uae registry auth callback url.
Generate tls psk on both nethsm gateways to allow signing from CI dev.