### PR TITLE
Add ghaf-fetch helper script

### DIFF
--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -32,6 +32,12 @@ REFERRER_MEDIA_TYPES = {
     "sbom_spdx": "application/spdx+json",
     "sbom_csv": "text/csv",
 }
+REFERRER_DESCRIPTIONS = {
+    "provenance": "SLSA Provenance",
+    "sbom_cyclonedx": "CycloneDX SBOM",
+    "sbom_spdx": "SPDX SBOM",
+    "sbom_csv": "CSV SBOM",
+}
 REPOSITORY_COMPONENT_PATTERN = re.compile(r"^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$")
 SOURCE_REF_ANNOTATION = "org.ghaf.source.ref"
 TARGET_ANNOTATION = "org.ghaf.target"
@@ -152,14 +158,13 @@ def publish_referrer(
 ) -> dict[str, str]:
     """Attach one referrer artifact."""
     media_type = REFERRER_MEDIA_TYPES[role]
-    path = target_dir / relpath
 
     files = [f"{relpath}:{media_type}"]
     if signature_relpath:
         files.append(f"{signature_relpath}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
 
     annotations = {
-        "org.opencontainers.image.description": path.name,
+        "org.opencontainers.image.description": REFERRER_DESCRIPTIONS[role],
     }
     output = run_oras(
         [
@@ -215,6 +220,7 @@ def publish_target_artifacts(
     image_signature = image["signature"]["path"]
     source = manifest.get("source", {})
     primary_annotations = {
+        "org.opencontainers.image.description": "Disk image",
         "org.opencontainers.image.title": target,
         "org.opencontainers.image.source": source.get("repository", ""),
         "org.opencontainers.image.revision": source.get("revision", ""),
@@ -341,7 +347,7 @@ def publish_test_results(args: argparse.Namespace) -> int:
             create_test_results_archive(results_dir, archive_path)
 
             annotations = {
-                "org.opencontainers.image.description": archive_path.name,
+                "org.opencontainers.image.description": "Test results",
             }
             output = run_oras(
                 [

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -51,6 +51,15 @@
         ];
         text = builtins.readFile ./run-cosign.sh;
       };
+      ghaf-fetch = pkgs.writeShellApplication {
+        name = "ghaf-fetch";
+        runtimeInputs = with pkgs; [
+          gum
+          jq
+          oras
+        ];
+        text = builtins.readFile ./ghaf-fetch.sh;
+      };
     in
     {
       packages = {
@@ -59,6 +68,7 @@
           archive-ghaf-release
           select-pkcs11-node
           run-cosign
+          ghaf-fetch
           ;
       };
     };

--- a/scripts/ghaf-fetch.sh
+++ b/scripts/ghaf-fetch.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+MYNAME="${0##*/}"
+
+usage() {
+  cat <<EOF
+Usage: $MYNAME [--all] OCI_REFERENCE
+
+Pull OCI_REFERENCE and referrers returned by 'oras discover' into the current
+directory after selecting the artifact and referrers interactively with gum.
+The selector shows org.opencontainers.image.description when available. With
+--all, pull OCI_REFERENCE and all referrers without requiring an interactive
+terminal.
+
+Example:
+
+  $MYNAME registry.vedenemo.dev/ghaf/job/target:tag
+  $MYNAME registry.vedenemo.dev/ghaf/job/target@sha256:...
+  $MYNAME --all registry.vedenemo.dev/ghaf/job/target:tag
+
+EOF
+}
+
+main() {
+  if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  pull_all=false
+  if [[ ${1:-} == "--all" ]]; then
+    pull_all=true
+    shift
+  fi
+
+  if [ "$#" -ne 1 ]; then
+    usage
+    exit 1
+  fi
+
+  if [ "$pull_all" = false ] && { ! [ -t 0 ] || ! [ -t 1 ]; }; then
+    printf "Error: interactive terminal required\n" >&2
+    exit 1
+  fi
+
+  reference="$1"
+  repository="$reference"
+
+  if [[ $repository == *@* ]]; then
+    repository="${repository%@*}"
+  elif [[ ${repository##*/} == *:* ]]; then
+    repository="${repository%:*}"
+  fi
+
+  printf "[+] Discovering referrers...\n"
+  discovery="$(
+    oras discover \
+      --distribution-spec v1.1-referrers-api \
+      --depth 1 \
+      --format json \
+      "$reference"
+  )"
+
+  printf "[+] Fetching artifact metadata...\n"
+  manifest="$(oras manifest fetch --format json "$reference")"
+  digest="$(oras resolve "$reference")"
+  config_digest="$(
+    printf "%s\n" "$manifest" |
+      jq -r '.content.config.digest // empty'
+  )"
+  artifact_name="${reference##*/}"
+  artifact_name="${artifact_name%@*}"
+  artifact_name="${artifact_name%%:*}"
+
+  artifact_label="$(
+    printf "%s\n" "$manifest" |
+      jq -r --arg fallback "$artifact_name" '
+        .content.annotations["org.opencontainers.image.description"]
+        // .content.layers[0].annotations["org.opencontainers.image.description"]
+        // .content.annotations["org.opencontainers.image.title"]
+        // .content.layers[0].annotations["org.opencontainers.image.title"]
+        // .content.artifactType
+        // $fallback
+        | gsub("[\t\r\n]+"; " ")
+      '
+  )"
+
+  choices="$(
+    printf "%s | %s\n" "$artifact_label" "$digest"
+    if [ -n "$config_digest" ]; then
+      printf "Manifest | %s\n" "$config_digest"
+    fi
+    printf "%s\n" "$discovery" |
+      jq -r '
+        .referrers[]?
+        | select(.digest)
+        | [
+            (
+              .annotations["org.opencontainers.image.description"]
+              // .annotations["org.opencontainers.image.title"]
+              // .artifactType
+              // "referrer"
+              | gsub("[\t\r\n]+"; " ")
+            ),
+            .digest
+          ]
+        | join(" | ")
+      '
+  )"
+
+  if [ "$pull_all" = true ]; then
+    selected="$choices"
+  else
+    selected="$(printf "%s\n" "$choices" | gum choose --no-limit --header "Select artifacts to pull")"
+  fi
+
+  if [ -z "$selected" ]; then
+    printf "[+] No artifacts selected\n"
+    return 0
+  fi
+
+  while IFS= read -r selected_artifact; do
+    selected_digest="${selected_artifact##* | }"
+    pull_reference="$repository@$selected_digest"
+
+    printf "[+] Pulling: %s\n" "$pull_reference"
+    if [ "$selected_digest" = "$config_digest" ]; then
+      oras blob fetch --output manifest.json "$pull_reference"
+    else
+      oras pull "$pull_reference"
+    fi
+  done <<<"$selected"
+}
+
+main "$@"


### PR DESCRIPTION
Add helper script which can be used to download a ghaf artifact from the oci registry. It will present the user with list of possible downloads using [gum](https://github.com/charmbracelet/gum) (image, provenance, sbom files) which can be selected and then downloaded. For non-interactive use there is `--all` which simply downloads all referrer artifacts.

<img width="1191" height="321" alt="image" src="https://github.com/user-attachments/assets/a3b28dfb-535e-4963-8cc5-ff5cbbc8892a" />

