### PR TITLE
jenkins: remove dell-7230 target from pipelines

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/pipelines/ghaf-main.groovy
@@ -21,9 +21,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null,
-  ],
   [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
     tests: [[
       test_target: "dell-latitude-7330-debug",

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -43,9 +43,6 @@ def TARGETS = [
   [ target: "packages.x86_64-linux.intel-laptop-release-installer",
     testset: null, sbom: true,
   ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null, sbom: true,
-  ],
   [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
     sbom: true,
     tests: [[

--- a/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
@@ -21,9 +21,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null,
-  ],
   [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
     tests: [[
       test_target: "dell-latitude-7330-debug",

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -21,9 +21,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.dell-latitude-7230-debug",
-    testset: null,
-  ],
   [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
     tests: [[
       test_target: "dell-latitude-7330-debug",


### PR DESCRIPTION
I tested today that Dell-7230 works with the `intel-laptop-low-mem-debug` image, so there is no need to keep a separate target for it.