### PR TITLE
sops: update ghaf-log and hetzarm-1 recipients

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -140,6 +140,7 @@ creation_rules:
       - *ghaf-log
       - *jrautiola
       - *hrosten
+      - *cazfi
   - path_regex: hosts/ghaf-monitoring/secrets.yaml$
     key_groups:
     - age:

--- a/hosts/ghaf-log/secrets.yaml
+++ b/hosts/ghaf-log/secrets.yaml
@@ -4,40 +4,44 @@ github_client_id: ENC[AES256_GCM,data:KhQtPeuMATu122vSb9kUrtICcWI=,iv:+8X1B31h8t
 github_client_secret: ENC[AES256_GCM,data:AY/1NgKgNOw8SrZb+T1C1vZCK9CV/lMEykY6lTPeycXW4vp4d0putQ==,iv:AqofLZQ1AG/FCHIo3jRDp3Xih1Envq6yugDDHlqD9/o=,tag:PPPdyQZZ1eRDFlXwVJcoYQ==,type:str]
 vedenemo_loki_password: ENC[AES256_GCM,data:8OFLIBdNo2IaB4UiC6N2OljR8g==,iv:ZmKwPGozJOzh3T5gxFUTmis0zsZrXVpcr6D2ZR1hPoU=,tag:ujuncHYbCMq0OYapV1NWhQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age15kk5q4u68pfsy5auzah6klsdk6p50jnkr986u7vpzfrnj30pz4ssq7wnud
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWWGUwZVA4WS9DZUZDTnY3
-            UXZ3dEtMMXpjczBxSDdKcFVuRWdmTzhWaGlBCkw0b1ZQTU8wYXprWEFZbWRtTUZ3
-            OTBCbHBhRklwdENNbjY2ZHNjTXFYcDAKLS0tIEVWeC9xdEFEMmhLTlJaME5FaGV3
-            Sm9UU3Z3MlFGeWJ1L0ZjWDREM3Z6RFEKRh+Q3+p33PyIHU1ZgUKSwUSKkUkxm/Yq
-            OdBQsXwaeO/SsskplilUjC1lP/HO1EFejZEFoSTd9NfyMApdcq5ovw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6dkhxS2ZqV01PSjdTMDRJ
+            NC9jVVg1eEczdzBjb2VUcGtINGpwcW9QVVgwCjZRU2ErNEZ6b1lEU1RRQ2tXS0tk
+            bTdkeHoraThFM3pnenNVRkhEdHBwV1EKLS0tIEs2a09EcXlkQlhnVC8vWXdEWE4w
+            a29HaXJvVFgrWEhuWTJVWVFqdkxkVk0KLcB8zPrvYNSchWHmW352l0MFew+RFsiw
+            l9PXsucA3oPXmqwHNuaN1LtNUHM4v5yc29mNq4jIEt/zUW8/D/sY/w==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZVnNBcklUOStjQ01CZ2tT
-            T2s2OXd2bFhyc0p3TC84cEVCYXR5MzQ1dnd3CmE2QTY1MG4wVzJTOEpNOUd0U0tz
-            dElSUFVUbnZFZmxIOWpaa0twaEpJaUkKLS0tIHEvb1ZVSkZFdWJ2bXZLakJDRGl4
-            SCtST3dFaVRmNTErVUREZC9FUWFoeDQKavWmaKXr8rXejQNZxMc8LF9uky/J+JAY
-            Ckbp3Q0nYnFMrUSmtK4Y+U7BbiOcM2iNuJ7t8CVBux4vUvt3HqHKqw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaMVVHcTI1aVBucnBEdTFz
+            R0h3b3UrckRFWmhrSXE1ditaTzZQSnMrMlU4CkpkSXArc2xaLzluT1M4RzB0ekV0
+            T2VQbW44MHRFN2tlSlVrSFp0dDBjakEKLS0tIDJEekFDTFFrMy8yNVpVdjQ2MVJx
+            WHc0M0lsZ3VCYWZoSjdxT1JkOW5lSncKc+FVn0xB8urPT+yJhXOimI3LZX/NNo+b
+            hyM/WfTyfw5/pjnyEsTx4lH7AxAicAHfeX9GcOhdu3gjKe9pHxVbIA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhWklzcnNFa1JOY1pPYUJK
-            ZVBtY09ZT2JMeklHTWY4eGYxbTQ1N3ZDNEFVClYyYkJ3NmFxQnhqbnBUQVNRckRn
-            cGR6RHhFZWZCWWRvMDczdXJrQkZFRWcKLS0tIGtYNlRRTkJYMHdGcUdZUEgwL1lx
-            M1Vuc01iVnlUWHJvaEFla2Q1dmlrQ00KWKbCP67sAZH4xwRgLKYMLq1h31zNOYOV
-            fMifRt7YfDOWqm3tdWCLuppRy7qkUQqPhNOhZBRlNmVno6cnpyCgwQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1dE5Tcmx6blRRU1RYd1ZP
+            dmxISmtrbzNJNVRNYS9odXI4L3Zxdmt3NVhVCldWcWp2VnZjN0hBOG9ubXMycXNQ
+            QTNybzJxSXV2bXYzdUVDZ0VnWTU5V2cKLS0tIEp2SnM3VFFoM2xpbUF0UmFQUWg3
+            cUY1ZlFXczRFclloZWNzVSthWmNmYXMKS4nlRH8hJ9rpHQK5Y7lwfxKOa+cFrtYU
+            2M24MWuZwiMnipAHTfiKwFxE9ftWHUuxtcj9eifcVa5gSvWPAwzQfA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4YlcxTFluRzBpTFFVR2lQ
+            OCtnN0RFb3crNjc2b1ByQlIrQ1BmYnBLT2tVCmN2bU50czZnN2d6SVFsb0s0MDZB
+            MHBoV0dOdGNuM29vcTZBU2Z4ZVc5TU0KLS0tIHJOTGRQMDVOVFV2aDdxeVUrVm44
+            VFBIR0tud0RydkN4OG9pYmh2cHVOMzQKHznlaI5hDhkpQppxyuR0cTpK4bpJkvyY
+            +NUwLo2SjjW8jkkyZM0MxY8w5wH3J71QEPvRNrSf2tws6LEXTZOxlA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-11-11T09:29:49Z"
     mac: ENC[AES256_GCM,data:4ZL4ZHcKU9jV187WKSB6cusvnSilWs2pjxXDUZA8hFx/moAMfJhw7lqfnqvE5pIX5B0nnraKbzPM5Bl2YVZj7GOzQgihH7e/xqFgugSsa4XHKyYvxWjgJFibp7u/sfJTRMhRbegoOg1Pwogk/TyK18T6O6tNVVQDxMkNUU0uUnc=,iv:3hCHPtT+QUh7QCkILed2plrTzYAPtYD2dFks/KQAL9w=,tag:dPKuoSy2YZP8VvuH+saDhA==,type:str]
-    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/hosts/uae/azureci/builders/hetzarm-1/secrets.yaml
+++ b/hosts/uae/azureci/builders/hetzarm-1/secrets.yaml
@@ -2,41 +2,41 @@ ssh_host_ed25519_key: ENC[AES256_GCM,data:O0X8dvO2811i9jbvWzDk3QXE6wLZbOX6B4TjgJ
 loki_password: ENC[AES256_GCM,data:qWlqIpcXZFJEXY/FhXYxa4X4ew==,iv:F0fQ1Pu8jagagsyM3n8ncD3N1pVIBItOhCwxA4CjUg0=,tag:1m8WckdhkY2sIWUNPzRcYg==,type:str]
 sops:
     age:
-        - recipient: age1n8a2mc6y4446fxkzpulpmmdk5lmqeyhn3rqv8ynyl24nh5zpxd5qlm5v28
+        - recipient: age1khvgc59e6mty0408cs523jzwldgjl389dywfrfmas08kzfdyj40qcuh2vf
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTE5GTGxaK25FYmNWRzJK
-            NUlBL0ROckM3Z0I0Ulc3ZDFzMVhmeXkzdm1vClFmdHlUVkZOM2RHdWpkUExvdTZQ
-            ZTBUQ2MvLzFKZGk5YkFqdGRYeU5oOVkKLS0tIHVFUy9haElWaThPUjdTRUpYU2xZ
-            elByUlo0Z2VaT2swSjdkOVI0VGs4OEkKmVqZm9/toutBnUaU3QuuPzwVwdBc2quB
-            kfKt/riYxaVLs2moreh32mhfd8kauyCdtUyq7KkbX30C92YqN6iwHw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmUEFiWThSN2hPN0dEWGV2
+            NDlHY3RjL3NMN0ozMDgrY25GUEZpTHlNS3pVCkphOHRWVXdhemJIVVM1N1RNb1dJ
+            cWwrQkV3ZXBhZ2NyUmUvQWtXa3RvMDAKLS0tIHZQZitRMmFtRkFaMjZpdys1N1BB
+            STFOa3lHWG9RMUhuQkliSWVVVEd3aVEKvOYjPIFQ4l9d2/F5gDZFTizXz1NrxBEx
+            gnFaZEkijjwCnKPiz/Drg2Z1brsFM1HIdODVmPKUuYAhC5gytCc+WQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwK0JjUjJJdHBESnQ4blQz
-            L3JHYmU3cGh6WUh4ZWIxQXUxbThTOVlNekFvCjFwM2NUMTZzK2hLUmdRU0M0Z09H
-            UHlyZU5aalJqZ3lGTTRsenpNeW9sbDQKLS0tIFNxNjVlNmUrNkdvQW5qWHpMUEgy
-            dFhEZDJSdGJNN3RyZDM5ZEthdC9rQUkKeXYAmvXqeXRFWvjA+RsGUGvPhoygFfaE
-            GhhkNBYNO8W3UnZXD5beHp3XtqIsX5pNIAwNg6QxWXt7T6OjwU+LIQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArUE9JZHlCeG14a1ZDVjJl
+            Z1d6bHcyOUJsUnAvSHlDdzBJbzNVSThSQ3lRCkdtVVlJejNmVzRreWFQWms3Vnds
+            MTMxZjFlOUZwREVTL1RLZkozZGpRcGcKLS0tIFBicCtvUDZOWnFjUjJaOHB5UFMz
+            aExib2lNbVFLTmdHeWZoODdKaG9lelkKWTvnHIWzPTmww8IjGXnMfXJKybF6lPxX
+            UlBjjv1tSQi7l0F8jvt7qpb//xetlFXGtqKJT6DPA89Qf3ObmRM1Ew==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxVHRlK1BUaCtsV2VLQWpj
-            M3dGUFNZRkJMMnhJRjJGZlBoT25VYlBPU2hFCnlpMTlqczB1UVE3SHdTWDF2ZDV4
-            dWJ1LzM1QzRpcXRUdHloY3pSeGJySEUKLS0tIGlEdlFtNVFyZmZuN0sveGFUcklK
-            ZWs0dFNJLzhWMEFpMFA0VTJtVDdtTW8Ku23m9DQ/zNouuDFP0NLH2AUI33REBUAO
-            CpoYooqk/YVdUuagwZsdZ15xyFTXV/h4oaUksFo3Klg5/fun2OjggQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwbUtTT1RzZDJQTDJ0STBs
+            Z29PZDZKYldtemE3cDJHQXZucFJRT3FMVmkwClU1WDVqeUU1anVyRmgvMFVpMGVU
+            bE42ei9tclNTWUtyT1NjNVNHOGdOMm8KLS0tIHNxSThXV0h4QU1uZjlmdFU4aExW
+            YnpDQTNUWjBZdWZxY25iMDF4MWU3VUkK/Zm8xeN21z8eG3pv53JbiiwUp2oM+Qkj
+            rwBUWpFxJvOhON0zqdg1xk7N8oLkKyTYavLz3otqPu/r6w0A1k+MQQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvWCtta1o0K3lrbExpS1RS
-            eTNqaURPRUdwYnhPRGRrUXNtN0pSVkFYd0ZjCjVBY0RrTlMwYkx3NUNQS1dEQlhr
-            RFpoWUVFYTdOUXNlV1EzdlFqdzhQMEEKLS0tIDZIclFvNDlQazB1bGlHN3QzanFD
-            anBtZDcxRTlpTnNuNnU2U2RoekJudmcK00TzQufGtdecijz8x//HWrteoYrgRNIC
-            UjNJUnQjjxNqDnfuOinFNRbCzex/yAW++qIYoRd36o2dvjtVGz360w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkSjI5ZTJ1V1ZSKy84Mmo0
+            NS9pUzcrdkluVUZ2YkM5Wnkyc2p4Rmp0d0NRClhiQnJ5Sm9JNkVIbzN0QnRVS3g4
+            MmdWcEVTcGd2U0YxZWs5QU1NQjRJcncKLS0tIEl1SjJPR0c1UXI5M2Rkekt6V3Iz
+            WXdNQTA1bWduVEM3ZExWNDlWOWwwQVEKsHcrrLRjhbz9m65ma8XqhXirDu0NlLf9
+            ORIfNJaGmAclg7lxsojtjmeSPyunGl10zTT68ffUBHECQqtrh9GmXA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-05-21T16:36:38Z"
     mac: ENC[AES256_GCM,data:8xX86pKOTax/gxTD0p37DuQ1MFP59WYJK93YrbI5/LDt7VdqAtOUcJgkLG6z9ekp1Xqv5qlsruaahd4lr8YjYYdWoGcg3aq1TUVoVZN+xxO6aA/5XXg5s7g9VEfKna6oWaR6IgImoWdnnWtAYplsA19zPjhFnWVppvnW7H+usXI=,iv:MRAkIOqGWvW7ks2jhWsdNieJwhW2DEJth3P+18YumbA=,tag:A72VFAgfjGbd4a8G29VUwg==,type:str]


### PR DESCRIPTION
Add cazfi to the ghaf-log SOPS recipient group and rekey the host secret file so the new recipient can decrypt the existing secrets.

Running inv update-sops-files also updated the UAE Azure CI hetzarm-1 builder secret file, which was not up to date with its current builder age key.