### PR TITLE
nginx: drop deprecated DHE dhparams with cleanup transition

### DIFF
--- a/services/nginx/default.nix
+++ b/services/nginx/default.nix
@@ -17,14 +17,11 @@
 
     resolver.addresses =
       if config.networking.nameservers == [ ] then [ "1.1.1.1" ] else config.networking.nameservers;
-
-    sslDhparam = config.security.dhparams.params.nginx.path;
   };
 
-  security.dhparams = {
-    enable = true;
-    params.nginx = { };
-  };
+  # Keep the cleanup unit active for one rollout after removing the nginx
+  # dhparams consumer so stateful files under /var/lib/dhparams get removed.
+  security.dhparams.enable = true;
 
   security.acme = {
     acceptTerms = true;


### PR DESCRIPTION
Remove `services.nginx.sslDhparam =
config.security.dhparams.params.nginx.path` and the matching `security.dhparams.params.nginx` setup from the shared nginx module.

The nginx module already enables `recommendedTlsSettings`, so TLS continues to use modern key exchange groups without generating legacy finite-field DHE parameters.

Keep `security.dhparams.enable = true` for one transition rollout so the cleanup unit removes old stateful files from `/var/lib/dhparams`. This version must be deployed once on each host before removing the cleanup unit in a later change.