### PR TITLE
Update registry access control to allow authenticated pushes

### DIFF
--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -77,6 +77,8 @@ let
       auth = {
         htpasswd.path = config.sops.secrets.zot-htpasswd.path;
 
+        apikey = true;
+
         openid.providers.oidc = {
           name = "Vedenemo Auth";
           issuer = "https://auth.vedenemo.dev";
@@ -110,7 +112,12 @@ let
             anonymousPolicy = [ "read" ];
           };
           "**" = {
-            defaultPolicy = [ "read" ];
+            defaultPolicy = [
+              "read"
+              "create"
+              "update"
+              "delete"
+            ];
             anonymousPolicy = [ "read" ];
           };
         };

--- a/hosts/uae/azureci/registry/configuration.nix
+++ b/hosts/uae/azureci/registry/configuration.nix
@@ -79,6 +79,8 @@ let
       auth = {
         htpasswd.path = config.sops.secrets.zot-htpasswd.path;
 
+        apikey = true;
+
         openid.providers.oidc = {
           name = "Vedenemo Auth";
           issuer = "https://auth.vedenemo.dev";
@@ -111,7 +113,12 @@ let
             anonymousPolicy = [ "read" ];
           };
           "**" = {
-            defaultPolicy = [ "read" ];
+            defaultPolicy = [
+              "read"
+              "create"
+              "update"
+              "delete"
+            ];
             anonymousPolicy = [ "read" ];
           };
         };


### PR DESCRIPTION
Allow authenticated developers to create a zot api key and push artifacts to the registry into arbitrary repositories, but not under `ghaf/`; that remains jenkins-only.