### PR TITLE
Disable HTTP/2 on ghaf-registry

### DIFF
--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -170,6 +170,7 @@ in
     enableACME = true;
     forceSSL = true;
     default = true;
+    http2 = false;
 
     locations."/" = {
       proxyPass = "http://127.0.0.1:${toString zotPort}";
@@ -193,9 +194,6 @@ in
       '';
     };
   };
-
-  environment.systemPackages = [
-  ];
 
   users.groups.zot = { };
   users.users.zot = {


### PR DESCRIPTION
Disables HTTP/2 for the registry endpoint.

CI pulls from the zot registry occasionally fail during large OCI blob downloads with HTTP/2 stream reset errors, for example:
```
copy failed: stream error: stream ID ... INTERNAL_ERROR
```
At the same time, zot logs show the response stream being cancelled by the peer while writing blob data. This points to an HTTP/2 stream/proxy interaction between ORAS, nginx, and zot rather than a registry storage problem.

Using HTTP/1.1 for the nginx registry proxy makes OCI blob transfers more predictable and hopefully avoids these intermittent stream cancellation failures.