### PR TITLE
jenkins: add temporary Orin flash-image support

### DIFF
--- a/docs/ghaf-pr-1872-ci-plan.md
+++ b/docs/ghaf-pr-1872-ci-plan.md
@@ -1,0 +1,222 @@
+<!--
+SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Plan: ghaf-infra changes for Ghaf PR #1872
+
+This document is a handoff-oriented plan for adapting `ghaf-infra` to
+[`tiiuae/ghaf#1872`](https://github.com/tiiuae/ghaf/pull/1872).
+
+## Summary
+
+PR `#1872` changes Jetson Orin from:
+
+- one flashable image artifact
+- one generic `flash-script`
+- optional Jenkins-side UEFI signing of that image
+
+to:
+
+- one per-target flash-images directory:
+  `flash-manifest.json`, `esp.img.zst`, `root.img.zst`
+- one matching target-specific flasher:
+  `packages.x86_64-linux.<target>-flash-script` or `-flash-qspi`
+- one flasher invocation that accepts `--flash-images=DIR`
+- one drive-selection flag:
+  `--target=emmc|nvme|usb`
+
+Expected `ghaf-infra` behavior for Orin:
+
+- Jenkins-side UEFI signing still remains for Orin.
+- That UEFI signing applies only to ESP-side payloads, not `root.img.zst`.
+- The ESP-side payload set is expected to include bootloader, kernel, and
+  `initrd`.
+- Detached artifact signatures should cover both flashed artifacts:
+  the signed ESP artifact and the root artifact.
+- Provenance remains one target-level attestation per build target, not one
+  provenance file per flash artifact.
+- The upstream manifest now covers artifact discovery, flasher binding,
+  target-drive choices, and coarse signing posture.
+- The upstream manifest still does not expose the exact Jenkins-side ESP
+  signing scope, so `ghaf-infra` would still have to hardcode that part today.
+
+Without the Orin-specific changes in this plan, the current Jenkins flow can
+collapse the flash set to `esp.img.zst`, publish only that file, and hand
+downstream hardware testing an incomplete flash artifact.
+
+The main remaining blocker is automation compatibility: the current upstream
+`--target=usb` flow still expects direct USB/recovery access to the target.
+The existing automated lab model writes only the removable USB SSD from the
+test agent. Stage 1 is not complete until that gap is closed or the automation
+model is explicitly changed.
+
+This plan uses two stages:
+
+- Stage 1: minimum-change support in `ghaf-infra`, using controller artifacts
+  as the Orin transport, keeping non-Orin flows unchanged, and skipping the
+  misleading single-image OCI path for Orin.
+- Stage 2: a follow-up cleanup and OCI model change, where Orin publishes and
+  consumes full flash sets through OCI and the Stage 1 controller-artifact path
+  can be reduced or removed.
+
+## Main files
+
+- `hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy`
+- `hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy`
+- `hosts/hetzci/pipeline-library/vars/artifactSupport.groovy`
+- `hosts/hetzci/pipelines/ghaf-hw-test.groovy`
+- `hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy`
+- `scripts/archive-ghaf-release.sh`
+- `tests/jenkins/HwTestUtilsTest.groovy`
+
+## Current branch
+
+| Work item | Status | Temporary? | Notes |
+| --- | --- | --- | --- |
+| Controller-side Orin flash-set detection and preservation of upstream `flash-manifest.json` | Done | No | Jenkins preserves the upstream manifest and records minimal pointers into the artifact tree. |
+| Orin hw-test transport via Jenkins artifact-root `IMG_URL` plus `--flash-images=DIR` | Done | Yes | This is the Stage 1 controller-artifact transport and can later be replaced or reduced once OCI carries full flash sets. |
+| Target-specific Orin flasher selection for native and cross targets | Done | No | The branch derives the matching x86 flasher attr instead of using the generic `flash-script`. |
+| Target-level provenance signing and automated verification for Orin Stage 1 transport | Done | Yes | Jenkins still generates one provenance statement per build target from `unsigned-output`, signs it, and `ghaf-hw-test` verifies it from the artifact root before flashing. |
+| Jenkins-side Orin UEFI signing retargeted to `signed-output/` | Partial | Yes | The layout exists, but final `initrd` signer support and manifest-driven scope are still missing. |
+| Detached artifact signatures for Orin `esp` and `root` | Done | No | Jenkins signs both flashed artifacts after UEFI-signing the ESP artifact. Orin-aware consumers must verify both signatures, not just the top-level image signature. |
+| Skip the broken single-image OCI publish path for Orin | Done | Yes | This prevents publishing a misleading `esp.img.zst`-only OCI artifact until a real multi-artifact OCI model exists. |
+| Release packaging for Orin flash sets | Done | No | Release archival preserves `signed-output/` and verifies provenance plus the detached signatures for both Orin flash artifacts. |
+| Debug CI plumbing for validating the new Orin flow | Done | Yes | `ci-dbg` temporarily reuses the `ghaf-dev` cache and enables `ghaf-pre-merge-manual`. |
+| `ci-yubi` support for signing Orin `initrd` inside the ESP payload set | Not done in this branch | No | This still needs the upstream signer change and a pin update in `ghaf-infra`. |
+| Manifest-driven Jenkins-side ESP signing scope | Not done in this branch | No | The upstream manifest has coarse signing posture flags, but not the explicit `bootloader + kernel + initrd` scope needed by `ghaf-infra`. |
+| Current lab-compatible USB-media-only automation with no direct target USB/recovery dependency | Blocked outside this branch | No | Current AGX testing shows the upstream flasher still probes the target board and requires recovery-mode USB connection. |
+| Full OCI flash-set publish/pull/test-results model | Not done | Yes | This is the longer-term Stage 2 follow-up. |
+
+## Key implementation details
+
+For Orin, Jenkins `manifest.json` should stay minimal and point at the
+preserved upstream artifact tree:
+
+```json
+{
+  "flash_images": {
+    "manifest_path": "unsigned-output/flash-manifest.json",
+    "unsigned_artifacts_dir": "unsigned-output",
+    "signed_artifacts_dir": "signed-output"
+  }
+}
+```
+
+Stage 1 transport and flashing details:
+
+- For Orin, `IMG_URL` means the target artifact root, not a direct image URL.
+- `ghaf-hw-test` should derive these from the artifact root:
+  - `${IMG_URL}/signed-output/flash-manifest.json`
+  - `${IMG_URL}/signed-output/`
+  - `${IMG_URL}/attestations/provenance.json`
+  - `${IMG_URL}/attestations/provenance.json.sig`
+  - `${IMG_URL}/esp.img.zst.sig`
+  - `${IMG_URL}/root.img.zst.sig`
+- `signed-output/` is the directory that gets flashed.
+- Detached artifact signatures stay at the target artifact root.
+- `ghaf-hw-test` should build the matching
+  `packages.x86_64-linux.<target>-flash-script` from the same Ghaf flake ref
+  and run:
+
+```bash
+result/bin/initrd-flash-<target> \
+  --target=usb \
+  --flash-images=/path/to/flash-images
+```
+
+Implemented Stage 1 signing and provenance model:
+
+- Provenance signing:
+  - Jenkins generates one provenance statement per build target from
+    `unsigned-output`.
+  - Jenkins signs `attestations/provenance.json` separately from any image
+    signing.
+  - The automated `ghaf-hw-test` path downloads and verifies that provenance
+    before flashing.
+  - The manual `ghaf-hw-test-manual` path still does not add an equivalent
+    provenance-verification stage here.
+  - Stage 1 provenance still attests the build output tree in
+    `unsigned-output`, not the final Jenkins-produced `signed-output` flash
+    set.
+- UEFI signing:
+  - Jenkins-side UEFI signing for Orin is still part of the `ghaf-infra`
+    flow.
+  - `firmware_pkc_signed` in the upstream manifest is upstream firmware state.
+    It does not replace Jenkins-side ESP payload signing.
+  - UEFI signing applies only to the ESP-side artifact. `root.img.zst` is not
+    a UEFI-signing target by itself.
+  - The current Stage 1 layout is:
+    - preserve upstream output in `unsigned-output/`
+    - create the flasher input in `signed-output/`
+    - keep detached artifact signatures at the target artifact root
+- Detached artifact signatures (`Sign (SLSA) image`):
+  - After UEFI signing the ESP artifact, Jenkins produces detached signatures
+    for both `signed-output/<esp>` and `signed-output/<root>`.
+  - Those `.sig` files live at the target artifact root and are part of the
+    Stage 1 consumer contract.
+  - The top-level `manifest.image` and `manifest.image.signature` fields stay
+    centered on the ESP artifact for compatibility. Orin-aware consumers must
+    read `flash_images` and verify both artifact signatures.
+
+## Remaining To Finish Stage 1
+
+Stage 1 is the minimum-change `ghaf-infra` adaptation for PR `#1872`. It is
+finished once the remaining items below are addressed and the relevant
+validation passes.
+
+Remaining items:
+
+- Extend `uefisign-simple` in `ci-yubi` so the Orin ESP signing path also signs
+  `initrd`.
+- After that change lands, update the pinned `ci-yubi` input in `ghaf-infra`.
+- Extend the upstream manifest so it exposes the explicit Jenkins-side ESP
+  signing scope instead of only coarse signing posture.
+- Preserve the current USB-media-only CI semantics for `--target=usb`, or
+  provide an explicit second mode with a clear selection rule.
+- If both direct-device and USB-media-only flows remain supported, make the
+  automation select the intended mode explicitly.
+
+### Validation
+
+This validation section is for finishing the remaining Stage 1 work in this
+document. Stage 2 will need its own validation plan once the OCI follow-up
+work starts.
+
+Controller-side:
+
+- Verify that Orin targets no longer publish or consume only `esp.img.zst`.
+- Verify that `ghaf-hw-test` bypasses the legacy single-image `IMG_URL` logic
+  for Orin.
+- Verify that the target-specific flasher is used for Orin, not the generic
+  `packages.x86_64-linux.flash-script`.
+- Verify that hw-tests consume `signed-output/`, not the original unsigned
+  directory.
+
+Hardware:
+
+- Orin AGX automated USB-media-only flash to USB target drive with no direct
+  USB/recovery-mode connection to the target.
+- Orin NX automated USB-media-only flash to USB target drive with no direct
+  USB/recovery-mode connection to the target, if NX is expected to use the same
+  automation model.
+- Separate direct-device validation for recovery-mode / QSPI / eMMC / NVMe
+  flows if those remain supported as a distinct mode.
+- Existing x86 targets still use the unchanged single-image path.
+
+Release:
+
+- Verify that release packaging preserves the full Orin flash set.
+- Verify detached Orin artifact signatures and provenance signatures during
+  release packaging.
+
+## Stage 2 follow-up
+
+- Publish the full Orin flash set through OCI.
+- Pull the full Orin flash set from OCI on the test side.
+- Attach provenance and test-results to the flash-set OCI artifact instead of a
+  fake single-image subject.
+- If stronger provenance-to-artifact binding is needed, verify downloaded flash
+  artifact digests against provenance `subject` entries.
+- Re-evaluate whether the Stage 1 controller-artifact transport can then be
+  reduced to a compatibility path or removed.

--- a/hosts/hetzci/dbg/configuration.nix
+++ b/hosts/hetzci/dbg/configuration.nix
@@ -31,6 +31,8 @@ in
   networking.hostName = "hetzci-dbg";
   ghaf.nix-cache.caches = [
     "nixos-org"
+    # Temporary: allow ci-dbg to reuse artifacts from the dev cache.
+    "ghaf-dev"
     "ghaf-dbg"
   ];
 
@@ -48,6 +50,7 @@ in
         "ghaf-hw-test-manual"
         "ghaf-hw-test"
         "ghaf-manual"
+        "ghaf-pre-merge-manual"
         "ghaf-release-candidate"
       ];
       withRegistryPublish = true;

--- a/hosts/hetzci/pipeline-library/vars/artifactSupport.groovy
+++ b/hosts/hetzci/pipeline-library/vars/artifactSupport.groovy
@@ -105,6 +105,70 @@ def path_basename(String path) {
   return idx >= 0 ? path.substring(idx + 1) : path
 }
 
+def orin_artifact_root_urls(String artifactsUrl) {
+  def base = artifactsUrl?.trim()?.replaceAll('/+$', '')
+  if (!base) {
+    error("Missing Orin artifacts URL")
+  }
+  return [
+    root_url: base,
+    signed_artifacts_url: "${base}/signed-output",
+    manifest_url: "${base}/signed-output/flash-manifest.json",
+    provenance_url: "${base}/attestations/provenance.json",
+    provenance_signature_url: "${base}/attestations/provenance.json.sig",
+  ]
+}
+
+@NonCPS
+def flash_manifest_artifact(Map flashManifest, String role) {
+  return flashManifest?.artifacts?.find { it.role == role }
+}
+
+def download_orin_artifact_root_flash_set(String artifactsUrl, String outputDir) {
+  def urls = orin_artifact_root_urls(artifactsUrl)
+  def manifestPath = run_wget(urls.manifest_url, outputDir)
+  def flashManifest = readJSON file: manifestPath, returnPojo: true
+  def transport = flashManifest?.transport ?: ''
+  if (transport != 'initrd-mass-storage') {
+    error("Unsupported Orin flash transport '${transport}' for Orin artifact-root flashing")
+  }
+  def flasher = flashManifest?.flasher ?: [:]
+  def flasherEntrypoint = flasher.entrypoint?.trim()
+  if (!flasherEntrypoint) {
+    error("Missing flasher entrypoint in Orin flash manifest '${manifestPath}'")
+  }
+  if (!(flasherEntrypoint ==~ /bin\/initrd-flash-[A-Za-z0-9._-]+/)) {
+    error("Unsupported flasher entrypoint '${flasherEntrypoint}' in Orin flash manifest '${manifestPath}'")
+  }
+  def espArtifact = flash_manifest_artifact(flashManifest, 'esp')
+  def rootArtifact = flash_manifest_artifact(flashManifest, 'root')
+  if (!espArtifact?.name || !rootArtifact?.name) {
+    error("Expected Orin flash manifest '${manifestPath}' to define both esp and root artifacts")
+  }
+
+  def manifestDirIdx = manifestPath.lastIndexOf('/')
+  def flashImagesDir = manifestDirIdx > 0 ? manifestPath.substring(0, manifestDirIdx) : '.'
+  def espPath = run_wget("${urls.signed_artifacts_url}/${espArtifact.name}", outputDir)
+  def rootPath = run_wget("${urls.signed_artifacts_url}/${rootArtifact.name}", outputDir)
+  def espSigPath = run_wget("${urls.root_url}/${espArtifact.name}.sig", outputDir)
+  def rootSigPath = run_wget("${urls.root_url}/${rootArtifact.name}.sig", outputDir)
+
+  return [
+    manifest: flashManifest,
+    manifest_path: manifestPath,
+    flash_images_dir: flashImagesDir,
+    transport: transport,
+    flasher_entrypoint: flasherEntrypoint,
+    flash_target_drives: flasher.target_drives ?: [],
+    esp_path: espPath,
+    root_path: rootPath,
+    esp_signature_path: espSigPath,
+    root_signature_path: rootSigPath,
+    provenance_url: urls.provenance_url,
+    provenance_signature_url: urls.provenance_signature_url,
+  ]
+}
+
 def image_role(String path) {
   def basename = path_basename(path)
   if (basename == null) {

--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -26,6 +26,26 @@ def derive_target_name(String imgUrl, String ociTarget) {
   return null
 }
 
+def is_orin_artifact_root_mode(String testTarget, String buildTarget, String imgUrl, String ociImageRef) {
+  if (ociImageRef?.trim() || !imgUrl?.trim()) {
+    return false
+  }
+  if (imgUrl.trim() ==~ /.*\.(img|raw|zst|iso)$/) {
+    return false
+  }
+  return buildTarget?.trim()?.contains('nvidia-jetson-orin') || testTarget?.trim()?.contains('nvidia-jetson-orin')
+}
+
+@NonCPS
+def orin_flash_script_attr(String buildTarget) {
+  def normalizedTarget = buildTarget?.trim()
+  if (!normalizedTarget?.contains('nvidia-jetson-orin')) {
+    throw new IllegalArgumentException("Cannot derive Orin flash-script attribute from target '${buildTarget}'")
+  }
+  def rewrittenTarget = normalizedTarget.replaceFirst(/^packages\.[^.]+\./, '')
+  return "packages.x86_64-linux.${rewrittenTarget}-flash-script"
+}
+
 def extra_tag_suffix(String target, String deviceTag) {
   def filters = []
   if (target.contains("lenovo-x1") || target.contains("darp11-b")) {
@@ -137,6 +157,72 @@ def resolve_ghaf_flake_ref(String explicitFlakeRef, String imgUrl, String ociFla
   return null
 }
 
+def prepare_orin_artifact_root_flash(
+  String imgUrl,
+  String outputDir,
+  String buildTarget,
+  String testTarget,
+  String requestedDrive = null
+) {
+  def flashSet = artifactSupport.download_orin_artifact_root_flash_set(imgUrl, outputDir)
+  def orinTarget = buildTarget?.trim() ?: testTarget?.trim()
+  def targetDrive = requestedDrive?.trim() ?: 'usb'
+  def supportedDrives = flashSet.flash_target_drives ?: []
+  if (supportedDrives && !supportedDrives.contains(targetDrive)) {
+    error(
+      "Unsupported Orin flash target drive '${targetDrive}' for '${orinTarget}'; " +
+        "supported values: ${supportedDrives.join(', ')}"
+    )
+  }
+  println "Downloaded Orin flash set to workspace: ${flashSet.flash_images_dir}"
+  println "Downloaded ESP signature to workspace: ${flashSet.esp_signature_path}"
+  println "Downloaded root signature to workspace: ${flashSet.root_signature_path}"
+  sh "verify-signature image '${flashSet.esp_path}' '${flashSet.esp_signature_path}'"
+  sh "verify-signature image '${flashSet.root_path}' '${flashSet.root_signature_path}'"
+
+  def flasherPackageAttr = orin_flash_script_attr(orinTarget)
+  println "Orin flash input: ${flashSet.flash_images_dir}"
+  println "Orin flasher entrypoint: ${flashSet.flasher_entrypoint}"
+  println "Orin flasher package attr: ${flasherPackageAttr}"
+
+  return [
+    flash_target_drive: targetDrive,
+    flash_input_path: flashSet.flash_images_dir,
+    flasher_entrypoint: flashSet.flasher_entrypoint,
+    flasher_package_attr: flasherPackageAttr,
+  ]
+}
+
+def run_orin_artifact_root_flash(
+  String explicitFlakeRef,
+  String imgUrl,
+  String ociFlakeRef,
+  String ociImageRef,
+  String flasherPackageAttr,
+  String flasherEntrypoint,
+  String flashTargetDrive,
+  String flashInputPath
+) {
+  def ghafFlakeRef = resolve_ghaf_flake_ref(explicitFlakeRef, imgUrl, ociFlakeRef)
+  if (!ghafFlakeRef) {
+    if (ociImageRef?.trim()) {
+      error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${ociImageRef}'")
+    }
+    error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${imgUrl}'.")
+  }
+
+  println "Building Orin flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
+  def flashScriptPath = artifactSupport.run_cmd(
+    "nix build --no-link --print-out-paths '${ghafFlakeRef}#${flasherPackageAttr}'"
+  )
+  sh """
+    /run/wrappers/bin/sudo '${flashScriptPath}/${flasherEntrypoint}' \
+      --target='${flashTargetDrive}' \
+      --flash-images='${flashInputPath}'
+  """
+  return ghafFlakeRef
+}
+
 def run_hw_test(
   String buildShortname,
   String testTargetName,
@@ -146,7 +232,10 @@ def run_hw_test(
   Map oci_result,
   boolean secureboot,
   String ci_env,
-  String deviceTag = null) {
+  String deviceTag = null,
+  String imgUrl = null,
+  String ghafFlakeRef = null,
+  String flashTargetDrive = null) {
   // Keep the blocking downstream wait outside node('built-in') so ghaf-hw-test
   // can acquire a controller executor for its own initialization stages.
   def build_href = "<a href=\"${pipelineModel.html_escape(env.BUILD_URL)}\">" +
@@ -165,10 +254,19 @@ def run_hw_test(
     booleanParam(name: "RELOAD_ONLY", value: false),
     booleanParam(name: "SECUREBOOT", value: secureboot),
   ]
-  if (oci_result == null) {
-    error("Missing OCI publish result for ${buildShortname}; cannot trigger ghaf-hw-test")
+  if (oci_result != null) {
+    test_params << string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference)
+  } else if (imgUrl?.trim()) {
+    test_params << string(name: "IMG_URL", value: imgUrl.trim())
+    if (ghafFlakeRef?.trim()) {
+      test_params << string(name: "GHAF_FLAKE_REF", value: ghafFlakeRef.trim())
+    }
+    if (flashTargetDrive?.trim()) {
+      test_params << string(name: "FLASH_TARGET_DRIVE", value: flashTargetDrive.trim())
+    }
+  } else {
+    error("Missing OCI publish result or IMG_URL for ${buildShortname}; cannot trigger ghaf-hw-test")
   }
-  test_params << string(name: "OCI_IMAGE_REF", value: oci_result.primary.reference)
   if (normalizedTestTarget) {
     test_params << string(name: "TEST_TARGET", value: normalizedTestTarget)
   }

--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -43,6 +43,9 @@ def orin_flash_script_attr(String buildTarget) {
     throw new IllegalArgumentException("Cannot derive Orin flash-script attribute from target '${buildTarget}'")
   }
   def rewrittenTarget = normalizedTarget.replaceFirst(/^packages\.[^.]+\./, '')
+  if (normalizedTarget.startsWith('packages.aarch64-linux.')) {
+    return "packages.x86_64-linux.${rewrittenTarget}-from-x86_64-flash-script"
+  }
   return "packages.x86_64-linux.${rewrittenTarget}-flash-script"
 }
 

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -136,6 +136,7 @@ def create_pipeline(
       ],
     ]
     def oci_result = null
+    def isStage1Orin = false
     def result_file_for = { Map testRun ->
       "${output}/test-results/${testRun.test_path_key}/result.json"
     }
@@ -266,16 +267,45 @@ def create_pipeline(
         }
         run_optional_stage(
           !target_config.no_image,
-          "Find image ${build_shortname}"
+          "Resolve artifacts ${build_shortname}"
         ) {
-          def img_path = artifactSupport.run_cmd(
-            "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit"
-          )
-          if (!img_path) {
-            error("No image found!")
+          def flashManifestPath = "${output}/unsigned-output/flash-manifest.json"
+          isStage1Orin = build_target_name.contains("nvidia-jetson-orin") &&
+            sh(script: "test -f '${flashManifestPath}'", returnStatus: true) == 0
+
+          if (isStage1Orin) {
+            def flashManifest = readJSON(file: flashManifestPath, returnPojo: true)
+            def espArtifact = artifactSupport.flash_manifest_artifact(flashManifest, 'esp')
+            def rootArtifact = artifactSupport.flash_manifest_artifact(flashManifest, 'root')
+            if (!espArtifact?.name || !rootArtifact?.name) {
+              error("Expected Orin flash manifest '${flashManifestPath}' to define both esp and root artifacts")
+            }
+
+            sh """
+              rm -rf '${output}/signed-output'
+              mkdir -p '${output}/signed-output'
+              for entry in "${output}"/unsigned-output/*; do
+                name=\$(basename "\$entry")
+                ln -s "../unsigned-output/\$name" '${output}/signed-output/'"\$name"
+              done
+            """
+
+            manifest.image.path = "signed-output/${espArtifact.name}"
+            manifest.image.role = 'disk'
+            manifest.flash_images = [
+              manifest_path: 'signed-output/flash-manifest.json',
+              signed_artifacts_dir: 'signed-output',
+            ]
+          } else {
+            def img_path = artifactSupport.run_cmd(
+              "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit"
+            )
+            if (!img_path) {
+              error("No image found!")
+            }
+            manifest.image.path = img_path - "${output}/"
+            manifest.image.role = artifactSupport.image_role(manifest.image.path)
           }
-          manifest.image.path = img_path - "${output}/"
-          manifest.image.role = artifactSupport.image_role(manifest.image.path)
         }
         run_optional_stage(
           !target_config.no_image && signing_possible && target_config.uefi_sign_requested,
@@ -284,6 +314,12 @@ def create_pipeline(
           def tmpdir = artifactSupport.build_tmpdir("uefisign-${build_shortname}")
           def img_name = artifactSupport.path_basename(manifest.image.path)
           def signer = build_target_name.contains("nvidia-jetson-orin") ? "uefisign-simple" : "uefisign"
+          def input_path = isStage1Orin ?
+            "${output}/unsigned-output/${img_name}" :
+            "${output}/${manifest.image.path}"
+          def signed_output_dir = isStage1Orin ?
+            "${output}/${manifest.flash_images.signed_artifacts_dir}" :
+            output
 
           try {
             sh """
@@ -295,14 +331,22 @@ def create_pipeline(
               sh """
                 ${signer} /etc/jenkins/keys/secboot/DB.pem \
                   "${ctx.uri}" \
-                  ${output}/${manifest.image.path} \
+                  '${input_path}' \
                   '${tmpdir}'
               """
               record_signature(manifest.uefi, ctx)
             }
 
-            sh "mv '${tmpdir}/signed_${img_name}' '${output}/${img_name}'"
-            manifest.image.path = img_name
+            if (isStage1Orin) {
+              sh """
+                rm -f '${signed_output_dir}/${img_name}'
+                mv '${tmpdir}/signed_${img_name}' '${signed_output_dir}/${img_name}'
+              """
+              manifest.image.path = "${manifest.flash_images.signed_artifacts_dir}/${img_name}"
+            } else {
+              sh "mv '${tmpdir}/signed_${img_name}' '${output}/${img_name}'"
+              manifest.image.path = img_name
+            }
             manifest.uefi.signed = true
             manifest.uefi.reason = null
           } finally {
@@ -314,18 +358,43 @@ def create_pipeline(
           "Sign (SLSA) image ${build_shortname}"
         ) {
           withRedundancyRouter("GhafInfraSignECP256") { ctx ->
-            def img_name = artifactSupport.path_basename(manifest.image.path)
-            record_signature(manifest.image.signature, ctx, "${img_name}.sig")
-            sh """
-              openssl dgst -sha256 -sign \
-                "${ctx.uri}" \
-                -out ${output}/${manifest.image.signature.path} \
-                ${output}/${manifest.image.path}
-            """
+            if (isStage1Orin) {
+              def flashManifest = readJSON(
+                file: "${output}/${manifest.flash_images.manifest_path}",
+                returnPojo: true
+              )
+              ['esp', 'root'].each { role ->
+                def artifact = artifactSupport.flash_manifest_artifact(flashManifest, role)
+                if (!artifact?.name) {
+                  error("Missing '${role}' artifact in Orin flash manifest '${manifest.flash_images.manifest_path}'")
+                }
+                def artifactPath = "${output}/${manifest.flash_images.signed_artifacts_dir}/${artifact.name}"
+                def signaturePath = "${artifact.name}.sig"
+                sh """
+                  openssl dgst -sha256 -sign \
+                    "${ctx.uri}" \
+                    -out ${output}/${signaturePath} \
+                    '${artifactPath}'
+                """
+                if (role == 'esp') {
+                  record_signature(manifest.image.signature, ctx, signaturePath)
+                  manifest.image.path = "${manifest.flash_images.signed_artifacts_dir}/${artifact.name}"
+                }
+              }
+            } else {
+              def img_name = artifactSupport.path_basename(manifest.image.path)
+              record_signature(manifest.image.signature, ctx, "${img_name}.sig")
+              sh """
+                openssl dgst -sha256 -sign \
+                  "${ctx.uri}" \
+                  -out ${output}/${manifest.image.signature.path} \
+                  ${output}/${manifest.image.path}
+              """
+            }
           }
         }
         stage("Link artifacts ${build_shortname}") {
-          if (manifest.image.path && !manifest.uefi.signed) {
+          if (manifest.image.path && !manifest.uefi.signed && !isStage1Orin) {
             def img_name = artifactSupport.path_basename(manifest.image.path)
             sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
             manifest.image.path = img_name
@@ -334,10 +403,12 @@ def create_pipeline(
           write_manifest()
 
           artifactSupport.append_to_build_description(artifacts_href, true)
-          artifactSupport.append_to_build_description("OCI Tag: ${pipelineModel.html_escape(immutable_tag)}", true)
+          if (!isStage1Orin) {
+            artifactSupport.append_to_build_description("OCI Tag: ${pipelineModel.html_escape(immutable_tag)}", true)
+          }
         }
         run_optional_stage(
-          !target_config.no_image,
+          !target_config.no_image && !isStage1Orin,
           "Publish OCI ${build_shortname}"
         ) {
           withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
@@ -379,6 +450,15 @@ def create_pipeline(
 
                 def job = null
                 try {
+                  def hwImgUrl = null
+                  def hwFlakeRef = null
+                  def hwFlashTargetDrive = null
+                  if (isStage1Orin) {
+                    def jenkinsRootUrl = env.JENKINS_URL.trim().replaceAll('/+$', '')
+                    hwImgUrl = "${jenkinsRootUrl}/${artifacts}/${build_target_name}"
+                    hwFlakeRef = target_flake_ref
+                    hwFlashTargetDrive = 'usb'
+                  }
                   job = hwTestUtils.run_hw_test(
                     build_shortname,
                     localTestRun.target,
@@ -388,7 +468,10 @@ def create_pipeline(
                     oci_result,
                     localTestRun.secureboot,
                     ci_env,
-                    localTestRun.get('device_tag', null)
+                    localTestRun.get('device_tag', null),
+                    hwImgUrl,
+                    hwFlakeRef,
+                    hwFlashTargetDrive
                   )
                   persist_test_result(localTestRun, [job: job])
                   artifactSupport.with_controller_workspace(ghaf_checkout) {
@@ -453,7 +536,7 @@ def create_pipeline(
           }
         }
         run_optional_stage(
-          ci_env != "vm",
+          ci_env != "vm" && oci_result != null,
           "Publish OCI test results ${build_shortname}"
         ) {
           artifactSupport.with_controller_workspace(ghaf_checkout) {

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -39,7 +39,8 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       name: 'IMG_URL',
       defaultValue: '',
       description: '''
-        Target image url. If specified, the target device is flashed with the given image before running the tests.
+        Target image URL. If specified, the target device is flashed with the given image before running the tests.
+        For Orin artifact-root flashing, use the target artifact root URL instead.
         Can be left empty, in which case DEVICE_TAG must be specified. With installer image this is mandatory to give!'''.stripIndent()),
     string(
       name: 'TEST_TARGET',
@@ -52,6 +53,11 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       description: '''
         Optional pinned Ghaf flake reference for flash-script. Leave empty to derive it from OCI metadata or IMG_URL.
         Set this explicitly for images built from refs that are not fetchable by commit SHA alone, such as PR merge refs.'''.stripIndent()),
+    string(
+      name: 'FLASH_TARGET_DRIVE',
+      defaultValue: 'usb',
+      description: '''
+        Flash target drive for the Orin initrd flasher, for example usb, nvme, or emmc.'''.stripIndent()),
     booleanParam(
       name: 'USE_LEGACY_DD_FLASH',
       defaultValue: false,
@@ -124,6 +130,12 @@ def init() {
   env.TEST_TARGET =
     params.TEST_TARGET?.trim() ?: env.BUILD_TARGET ?: (params.JOB_SELECTOR?.trim() ?: params.DEVICE_TAG) ?: ''
   env.JOB_TARGET = env.BUILD_TARGET ?: params.JOB_SELECTOR?.trim() ?: env.TEST_TARGET ?: params.DEVICE_TAG
+  env.ORIN_ARTIFACT_ROOT_MODE = hwTestUtils.is_orin_artifact_root_mode(
+    env.TEST_TARGET,
+    env.BUILD_TARGET,
+    params.IMG_URL,
+    params.OCI_IMAGE_REF
+  ) ? 'true' : 'false'
   def installerTarget = env.BUILD_TARGET ?: env.TEST_TARGET
   env.INSTALLER_FLOW = installerTarget.contains("installer") ? 'true' : 'false'
   def deviceInfo = null
@@ -275,9 +287,11 @@ pipeline {
                 echo { \\\"Job\\\": \\\"${env.JOB_TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}
               """
-              def mountCommands = hwTestUtils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
-              env.MOUNT_CMD = mountCommands.mount_cmd
-              env.UNMOUNT_CMD = mountCommands.unmount_cmd
+              if (env.ORIN_ARTIFACT_ROOT_MODE != 'true') {
+                def mountCommands = hwTestUtils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
+                env.MOUNT_CMD = mountCommands.mount_cmd
+                env.UNMOUNT_CMD = mountCommands.unmount_cmd
+              }
             }
           }
         }
@@ -292,26 +306,43 @@ pipeline {
                 if (!img_path) {
                   error("Unable to derive image file from OCI image '${params.OCI_IMAGE_REF}'")
                 }
+              } else if (env.ORIN_ARTIFACT_ROOT_MODE == 'true') {
+                if (params.USE_LEGACY_DD_FLASH) {
+                  error("USE_LEGACY_DD_FLASH is not supported for Orin artifact-root flashing")
+                }
+                def flashSetup = hwTestUtils.prepare_orin_artifact_root_flash(
+                  params.IMG_URL,
+                  TMP_IMG_DIR,
+                  env.BUILD_TARGET,
+                  env.TEST_TARGET,
+                  params.FLASH_TARGET_DRIVE
+                )
+                env.FLASH_TARGET_DRIVE = flashSetup.flash_target_drive
+                env.FLASH_INPUT_PATH = flashSetup.flash_input_path
+                env.ORIN_FLASH_ENTRYPOINT = flashSetup.flasher_entrypoint
+                env.ORIN_FLASH_PACKAGE_ATTR = flashSetup.flasher_package_attr
               } else {
                 img_path = artifactSupport.run_wget(params.IMG_URL, TMP_IMG_DIR)
               }
-              println "Downloaded image to workspace: ${img_path}"
-              if (params.USE_LEGACY_DD_FLASH) {
-                // Uncompress for the legacy dd flashing path.
-                if(img_path.endsWith(".zst")) {
-                  sh "zstd -dfv ${img_path}"
-                  // env.IMG_PATH stores the path to the uncompressed image
-                  env.IMG_PATH = img_path.substring(0, img_path.lastIndexOf('.'))
+              if (env.ORIN_ARTIFACT_ROOT_MODE != 'true') {
+                println "Downloaded image to workspace: ${img_path}"
+                if (params.USE_LEGACY_DD_FLASH) {
+                  // Uncompress for the legacy dd flashing path.
+                  if(img_path.endsWith('.zst')) {
+                    sh "zstd -dfv ${img_path}"
+                    // env.IMG_PATH stores the path to the uncompressed image
+                    env.IMG_PATH = img_path.substring(0, img_path.lastIndexOf('.'))
+                  } else {
+                    env.IMG_PATH = img_path
+                  }
+                  println "Uncompressed image at: ${env.IMG_PATH}"
+                  env.INSTALLER_FLOW = env.IMG_PATH.endsWith('.iso') ? 'true' : env.INSTALLER_FLOW
                 } else {
-                  env.IMG_PATH = img_path
+                  // flash-script handles .zst natively; pass the original download path.
+                  env.FLASH_INPUT_PATH = img_path
+                  env.INSTALLER_FLOW = img_path.endsWith('.iso') ? 'true' : env.INSTALLER_FLOW
+                  println "Flash input: ${env.FLASH_INPUT_PATH}"
                 }
-                println "Uncompressed image at: ${env.IMG_PATH}"
-                env.INSTALLER_FLOW = env.IMG_PATH.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
-              } else {
-                // flash-script handles .zst natively; pass the original download path.
-                env.FLASH_INPUT_PATH = img_path
-                env.INSTALLER_FLOW = img_path.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
-                println "Flash input: ${env.FLASH_INPUT_PATH}"
               }
             }
           }
@@ -320,48 +351,61 @@ pipeline {
           when { expression { params && (params.IMG_URL || params.OCI_IMAGE_REF) } }
           steps {
             script {
-              def dev = hwTestUtils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
-              if (params.USE_LEGACY_DD_FLASH) {
-                // Wipe possible ZFS leftovers, more details here:
-                // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
-                if(env.TEST_TARGET.contains("lenovo-x1")) {
-                  echo "Wiping filesystem..."
-                  def SECTOR = 512
-                  def MIB_TO_SECTORS = 20480
-                  // Disk size in 512-byte sectors
-                  def SECTORS = sh(script: "/run/wrappers/bin/sudo blockdev --getsz ${dev}", returnStdout: true).trim()
-                  // Unmount possible mounted filesystems
-                  sh "sync; /run/wrappers/bin/sudo umount -q ${dev}* || true"
-                  // Wipe first 10MiB of disk
-                  sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} conv=fsync status=none"
-                  // Wipe last 10MiB of disk
-                  sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} seek=\$(( ${SECTORS} - ${MIB_TO_SECTORS} )) conv=fsync status=none"
-                }
-                // Write the image
-                sh "/run/wrappers/bin/sudo dd if=${env.IMG_PATH} of=${dev} bs=1M status=progress conv=fsync"
-              } else {
-                if (env.FLASH_INPUT_PATH.endsWith('.raw')) {
-                  error("flash-script does not support '.raw' images. Enable USE_LEGACY_DD_FLASH to flash '${env.FLASH_INPUT_PATH}' with dd.")
-                }
-                def ghafFlakeRef = hwTestUtils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
-                if (!ghafFlakeRef) {
-                  if (params.OCI_IMAGE_REF) {
-                    error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
-                  }
-                  error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
-                }
-                println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-                def flashScriptPath = artifactSupport.run_cmd(
-                  "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
+              if (env.ORIN_ARTIFACT_ROOT_MODE == 'true') {
+                hwTestUtils.run_orin_artifact_root_flash(
+                  params.GHAF_FLAKE_REF,
+                  params.IMG_URL,
+                  env.OCI_SOURCE_REF,
+                  params.OCI_IMAGE_REF,
+                  env.ORIN_FLASH_PACKAGE_ATTR,
+                  env.ORIN_FLASH_ENTRYPOINT,
+                  env.FLASH_TARGET_DRIVE,
+                  env.FLASH_INPUT_PATH
                 )
-                // flash-script validates /dev/sdX format; resolve the by-id symlink.
-                def resolved_dev = artifactSupport.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
-                sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
+              } else {
+                def dev = hwTestUtils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
+                if (params.USE_LEGACY_DD_FLASH) {
+                  // Wipe possible ZFS leftovers, more details here:
+                  // https://github.com/tiiuae/ghaf/blob/454b18bc/packages/installer/ghaf-installer.sh#L75
+                  if(env.TEST_TARGET.contains("lenovo-x1")) {
+                    echo "Wiping filesystem..."
+                    def SECTOR = 512
+                    def MIB_TO_SECTORS = 20480
+                    // Disk size in 512-byte sectors
+                    def SECTORS = sh(script: "/run/wrappers/bin/sudo blockdev --getsz ${dev}", returnStdout: true).trim()
+                    // Unmount possible mounted filesystems
+                    sh "sync; /run/wrappers/bin/sudo umount -q ${dev}* || true"
+                    // Wipe first 10MiB of disk
+                    sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} conv=fsync status=none"
+                    // Wipe last 10MiB of disk
+                    sh "/run/wrappers/bin/sudo dd if=/dev/zero of=${dev} bs=${SECTOR} count=${MIB_TO_SECTORS} seek=\$(( ${SECTORS} - ${MIB_TO_SECTORS} )) conv=fsync status=none"
+                  }
+                  // Write the image
+                  sh "/run/wrappers/bin/sudo dd if=${env.IMG_PATH} of=${dev} bs=1M status=progress conv=fsync"
+                } else {
+                  if (env.FLASH_INPUT_PATH.endsWith('.raw')) {
+                    error("flash-script does not support '.raw' images. Enable USE_LEGACY_DD_FLASH to flash '${env.FLASH_INPUT_PATH}' with dd.")
+                  }
+                  def ghafFlakeRef = hwTestUtils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+                  if (!ghafFlakeRef) {
+                    if (params.OCI_IMAGE_REF) {
+                      error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
+                    }
+                    error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'. Set GHAF_FLAKE_REF or enable USE_LEGACY_DD_FLASH.")
+                  }
+                  println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
+                  def flashScriptPath = artifactSupport.run_cmd(
+                    "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
+                  )
+                  // flash-script validates /dev/sdX format; resolve the by-id symlink.
+                  def resolved_dev = artifactSupport.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
+                  sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
+                }
+                // Unmount
+                sh "${env.UNMOUNT_CMD}"
+                hwTestUtils.assert_flash_target_unmounted(dev)
               }
               env.FLASHED = 'true'
-              // Unmount
-              sh "${env.UNMOUNT_CMD}"
-              hwTestUtils.assert_flash_target_unmounted(dev)
               currentBuild.description = "${currentBuild.description}<br>✅ Device flashed"
             }
           }

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -31,7 +31,10 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
     string(name: 'CI_TEST_REPO_URL', defaultValue: 'https://github.com/tiiuae/ci-test-automation.git', description: 'Select ci-test-automation repository.'),
     string(name: 'CI_TEST_REPO_BRANCH', defaultValue: 'main', description: 'Select ci-test-automation branch to checkout.'),
     string(name: 'OCI_IMAGE_REF', defaultValue: '', description: 'Published OCI image reference.'),
-    string(name: 'IMG_URL', defaultValue: '', description: 'Target image url.'),
+    string(
+      name: 'IMG_URL',
+      defaultValue: '',
+      description: 'Target image URL. For Orin artifact-root flashing, use the target artifact root URL instead.'),
     string(
       name: 'TEST_TARGET',
       defaultValue: '',
@@ -41,6 +44,10 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
       defaultValue: '',
       description: 'Concrete device tag for agent selection. If empty, derive it from TEST_TARGET.'),
     string(name: 'GHAF_FLAKE_REF', defaultValue: '', description: 'Pinned Ghaf flake reference for flash-script. If empty, derive it from OCI metadata or IMG_URL commit.'),
+    string(
+      name: 'FLASH_TARGET_DRIVE',
+      defaultValue: 'usb',
+      description: 'Flash target drive for the Orin initrd flasher, for example usb, nvme, or emmc.'),
     string(name: 'TESTSET', defaultValue: '_relayboot_', description: 'Target testset, e.g.: _relayboot_, _relayboot_bat_, _relayboot_pre-merge_, etc.'),
     string(name: 'TESTAGENT_HOST', defaultValue: null, description: 'Target testagent host, e.g.: dev, prod, release'),
     booleanParam(name: 'SECUREBOOT', defaultValue: false, description: 'Test on secure boot enabled hardware'),
@@ -61,7 +68,7 @@ def init() {
   def imgUrl = params.IMG_URL?.trim()
   env.OCI_TARGET = ''
   env.OCI_SOURCE_REF = ''
-    env.OCI_IMAGE_REVISION = ''
+  env.OCI_IMAGE_REVISION = ''
   if (ociImageRef) {
     def annotations = artifactSupport.oci_annotations(ociImageRef)
     env.OCI_TARGET = annotations[TARGET_ANNOTATION] ?: ''
@@ -74,13 +81,20 @@ def init() {
   env.BUILD_TARGET = hwTestUtils.derive_target_name(imgUrl, env.OCI_TARGET) ?: ''
   env.TEST_TARGET = params.TEST_TARGET?.trim() ?: env.BUILD_TARGET ?: ''
   env.JOB_TARGET = env.BUILD_TARGET ?: env.TEST_TARGET
+  env.ORIN_ARTIFACT_ROOT_MODE = hwTestUtils.is_orin_artifact_root_mode(
+    env.TEST_TARGET,
+    env.BUILD_TARGET,
+    imgUrl,
+    ociImageRef
+  ) ? 'true' : 'false'
   env.TESTSET = params.TESTSET ?: ''
-  env.INSTALLER_FLOW = env.BUILD_TARGET.contains("installer") ? 'true' : 'false'
+  def installerTarget = env.BUILD_TARGET ?: env.TEST_TARGET
+  env.INSTALLER_FLOW = installerTarget.contains("installer") ? 'true' : 'false'
   def explicitDeviceTag = params.DEVICE_TAG?.trim()
   // Resolve the target here as well for controller-side fail-fast validation and
   // device/agent selection. The agent-side Resolve target stage repeats this so
   // it can initialize runtime state after node allocation.
-  if (imgUrl && !env.BUILD_TARGET) {
+  if (imgUrl && !env.BUILD_TARGET && !env.TEST_TARGET) {
     error("Unsupported IMG_URL layout '${params.IMG_URL}': expected a path containing commit_<sha>/<target>/...")
   }
   if (!env.TEST_TARGET) {
@@ -288,6 +302,10 @@ pipeline {
                 if (!provenance_path || !sig_path) {
                   error("Unable to derive provenance files from OCI referrer '${provenanceRef}'")
                 }
+              } else if (env.ORIN_ARTIFACT_ROOT_MODE == 'true') {
+                def urls = artifactSupport.orin_artifact_root_urls(params.IMG_URL)
+                provenance_path = artifactSupport.run_wget(urls.provenance_url, TMP_IMG_DIR)
+                sig_path = artifactSupport.run_wget(urls.provenance_signature_url, TMP_IMG_DIR)
               } else {
                 def split = split_img_url(params.IMG_URL)
                 def artifacts_url = split["artifacts_url"]
@@ -314,6 +332,18 @@ pipeline {
                 if (!img_path || !sig_path) {
                   error("Unable to derive image files from OCI image '${params.OCI_IMAGE_REF}'")
                 }
+              } else if (env.ORIN_ARTIFACT_ROOT_MODE == 'true') {
+                def flashSetup = hwTestUtils.prepare_orin_artifact_root_flash(
+                  params.IMG_URL,
+                  TMP_IMG_DIR,
+                  env.BUILD_TARGET,
+                  env.TEST_TARGET,
+                  params.FLASH_TARGET_DRIVE
+                )
+                env.FLASH_TARGET_DRIVE = flashSetup.flash_target_drive
+                env.FLASH_INPUT_PATH = flashSetup.flash_input_path
+                env.ORIN_FLASH_ENTRYPOINT = flashSetup.flasher_entrypoint
+                env.ORIN_FLASH_PACKAGE_ATTR = flashSetup.flasher_package_attr
               } else {
                 img_path = artifactSupport.run_wget(params.IMG_URL, TMP_IMG_DIR)
                 def split = split_img_url(params.IMG_URL)
@@ -323,42 +353,57 @@ pipeline {
                 def sig_url = "${artifacts_url}/${target}/${img_relpath}.sig"
                 sig_path = artifactSupport.run_wget(sig_url, TMP_IMG_DIR)
               }
-              println "Downloaded image to workspace: ${img_path}"
-              println "Downloaded SLSA signature file to workspace: ${sig_path}"
-              sh "verify-signature image ${img_path} ${sig_path}"
-              // flash-script handles .zst natively; pass the original download path.
-              env.FLASH_INPUT_PATH = img_path
-              env.INSTALLER_FLOW = img_path.endsWith(".iso") ? 'true' : env.INSTALLER_FLOW
-              println "Flash input: ${env.FLASH_INPUT_PATH}"
+              if (env.ORIN_ARTIFACT_ROOT_MODE != 'true') {
+                println "Downloaded image to workspace: ${img_path}"
+                println "Downloaded SLSA signature file to workspace: ${sig_path}"
+                sh "verify-signature image ${img_path} ${sig_path}"
+                // flash-script handles .zst natively; pass the original download path.
+                env.FLASH_INPUT_PATH = img_path
+                env.INSTALLER_FLOW = img_path.endsWith('.iso') ? 'true' : env.INSTALLER_FLOW
+                println "Flash input: ${env.FLASH_INPUT_PATH}"
+              }
             }
           }
         }
         stage('Flash') {
           steps {
             script {
-              def mountCommands = hwTestUtils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
-              env.MOUNT_CMD = mountCommands.mount_cmd
-              env.UNMOUNT_CMD = mountCommands.unmount_cmd
-              def dev = hwTestUtils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
-              def ghafFlakeRef = hwTestUtils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
-              if (!ghafFlakeRef) {
-                if (params.OCI_IMAGE_REF) {
-                  error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'")
+              if (env.ORIN_ARTIFACT_ROOT_MODE == 'true') {
+                env.GHAF_FLAKE_REF = hwTestUtils.run_orin_artifact_root_flash(
+                  params.GHAF_FLAKE_REF,
+                  params.IMG_URL,
+                  env.OCI_SOURCE_REF,
+                  params.OCI_IMAGE_REF,
+                  env.ORIN_FLASH_PACKAGE_ATTR,
+                  env.ORIN_FLASH_ENTRYPOINT,
+                  env.FLASH_TARGET_DRIVE,
+                  env.FLASH_INPUT_PATH
+                )
+              } else {
+                def ghafFlakeRef = hwTestUtils.resolve_ghaf_flake_ref(params.GHAF_FLAKE_REF, params.IMG_URL, env.OCI_SOURCE_REF)
+                if (!ghafFlakeRef) {
+                  if (params.OCI_IMAGE_REF) {
+                    error("Missing GHAF_FLAKE_REF and unable to derive it from OCI image '${params.OCI_IMAGE_REF}'")
+                  }
+                  error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'")
                 }
-                error("Missing GHAF_FLAKE_REF and unable to derive Ghaf commit from IMG_URL '${params.IMG_URL}'")
+                env.GHAF_FLAKE_REF = ghafFlakeRef
+                def mountCommands = hwTestUtils.setup_mount_commands(CONF_FILE_PATH, env.TEST_TARGET, env.DEVICE_NAME)
+                env.MOUNT_CMD = mountCommands.mount_cmd
+                env.UNMOUNT_CMD = mountCommands.unmount_cmd
+                def dev = hwTestUtils.resolve_flash_target(CONF_FILE_PATH, env.DEVICE_NAME, env.MOUNT_CMD, env.UNMOUNT_CMD)
+                println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
+                def flashScriptPath = artifactSupport.run_cmd(
+                  "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
+                )
+                // flash-script validates /dev/sdX format; resolve the by-id symlink
+                def resolved_dev = artifactSupport.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
+                sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
+                // Unmount
+                sh "${env.UNMOUNT_CMD}"
+                hwTestUtils.assert_flash_target_unmounted(dev)
               }
-              env.GHAF_FLAKE_REF = ghafFlakeRef
-              println "Building flash-script from GHAF_FLAKE_REF: ${ghafFlakeRef}"
-              def flashScriptPath = artifactSupport.run_cmd(
-                "nix build --no-link --print-out-paths '${ghafFlakeRef}#packages.x86_64-linux.flash-script'"
-              )
-              // flash-script validates /dev/sdX format; resolve the by-id symlink
-              def resolved_dev = artifactSupport.run_cmd("/run/wrappers/bin/sudo readlink -f ${dev}")
-              sh "/run/wrappers/bin/sudo ${flashScriptPath}/bin/flash-script -d ${resolved_dev} -i ${env.FLASH_INPUT_PATH} -f"
               env.FLASHED = 'true'
-              // Unmount
-              sh "${env.UNMOUNT_CMD}"
-              hwTestUtils.assert_flash_target_unmounted(dev)
             }
           }
         }

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -155,30 +155,41 @@ is_release_target() {
   return 1
 }
 
+read_flash_set_metadata() {
+  local manifest="$1"
+  local manifest_dir
+  manifest_dir=$(dirname "$manifest")
+
+  if ! flash_manifest_rel=$(jq -re '.flash_images.manifest_path' "$manifest"); then
+    print_err "missing flash_images manifest path in manifest: $manifest"
+    exit 1
+  fi
+  if ! signed_dir_rel=$(jq -re '.flash_images.signed_artifacts_dir' "$manifest"); then
+    print_err "missing flash_images signed artifact dir in manifest: $manifest"
+    exit 1
+  fi
+
+  flash_manifest="$manifest_dir/$flash_manifest_rel"
+  if [[ ! -f $flash_manifest ]]; then
+    print_err "missing flash manifest: $flash_manifest"
+    exit 1
+  fi
+  if ! esp_name=$(jq -re '.artifacts[] | select(.role == "esp") | .name' "$flash_manifest"); then
+    print_err "missing esp artifact in flash manifest: $flash_manifest"
+    exit 1
+  fi
+  if ! root_name=$(jq -re '.artifacts[] | select(.role == "root") | .name' "$flash_manifest"); then
+    print_err "missing root artifact in flash manifest: $flash_manifest"
+    exit 1
+  fi
+}
+
 verify_signatures() {
   dir="$1"
   manifest="$dir/manifest.json"
 
   if [[ ! -f $manifest ]]; then
     print_err "missing manifest: $dir"
-    exit 1
-  fi
-  if ! img_rel=$(jq -re '.image.path' "$manifest"); then
-    print_err "missing image entry in manifest: $manifest"
-    exit 1
-  fi
-  img="$dir/$img_rel"
-  if [[ -z $img_rel ]]; then
-    print_err "missing image: $dir"
-    exit 1
-  fi
-  if ! img_sig_rel=$(jq -re '.image.signature.path' "$manifest"); then
-    print_err "missing image signature entry in manifest: $manifest"
-    exit 1
-  fi
-  img_sig="$dir/$img_sig_rel"
-  if [[ -z $img_sig_rel ]]; then
-    print_err "missing image signature: $dir"
     exit 1
   fi
   if ! prov_rel=$(jq -re '.attestations.provenance.path' "$manifest"); then
@@ -199,12 +210,47 @@ verify_signatures() {
     print_err "missing nix_build provenance signature: $dir"
     exit 1
   fi
-  echo "[+] Verifying: $img"
-  if ! verify-signature image "$img" "$img_sig"; then
-    print_err "failed verifying image signature"
-    print_err "  image: $img"
-    print_err "  signature: $img_sig"
-    exit 1
+
+  if jq -e '.flash_images != null' "$manifest" >/dev/null; then
+    read_flash_set_metadata "$manifest"
+    signed_dir="$dir/$signed_dir_rel"
+    for artifact_name in "$esp_name" "$root_name"; do
+      artifact_path="$signed_dir/$artifact_name"
+      signature_path="$dir/$artifact_name.sig"
+      echo "[+] Verifying: $artifact_path"
+      if ! verify-signature image "$artifact_path" "$signature_path"; then
+        print_err "failed verifying image signature"
+        print_err "  image: $artifact_path"
+        print_err "  signature: $signature_path"
+        exit 1
+      fi
+    done
+  else
+    if ! img_rel=$(jq -re '.image.path' "$manifest"); then
+      print_err "missing image entry in manifest: $manifest"
+      exit 1
+    fi
+    img="$dir/$img_rel"
+    if [[ -z $img_rel ]]; then
+      print_err "missing image: $dir"
+      exit 1
+    fi
+    if ! img_sig_rel=$(jq -re '.image.signature.path' "$manifest"); then
+      print_err "missing image signature entry in manifest: $manifest"
+      exit 1
+    fi
+    img_sig="$dir/$img_sig_rel"
+    if [[ -z $img_sig_rel ]]; then
+      print_err "missing image signature: $dir"
+      exit 1
+    fi
+    echo "[+] Verifying: $img"
+    if ! verify-signature image "$img" "$img_sig"; then
+      print_err "failed verifying image signature"
+      print_err "  image: $img"
+      print_err "  signature: $img_sig"
+      exit 1
+    fi
   fi
   if ! verify-signature provenance "$prov" "$prov_sig"; then
     print_err "failed verifying provenance signature"
@@ -301,18 +347,25 @@ prepare_artifacts() {
     mkdir -p "$TMPDIR/$target_name"
     ln -s "$manifest" "$TMPDIR/$target_name/manifest.json"
 
-    if ! image=$(jq -re '.image.path' "$manifest"); then
-      print_err "missing image entry in manifest: $manifest"
-      exit 1
-    fi
-    if ! image_sig=$(jq -re '.image.signature.path' "$manifest"); then
-      print_err "missing image signature entry in manifest: $manifest"
-      exit 1
-    fi
+    if jq -e '.flash_images != null' "$manifest" >/dev/null; then
+      read_flash_set_metadata "$manifest"
+      ln -s "$dir/$signed_dir_rel" "$TMPDIR/$target_name/$signed_dir_rel"
+      ln -s "$dir/$esp_name.sig" "$TMPDIR/$target_name/$esp_name.sig"
+      ln -s "$dir/$root_name.sig" "$TMPDIR/$target_name/$root_name.sig"
+    else
+      if ! image=$(jq -re '.image.path' "$manifest"); then
+        print_err "missing image entry in manifest: $manifest"
+        exit 1
+      fi
+      if ! image_sig=$(jq -re '.image.signature.path' "$manifest"); then
+        print_err "missing image signature entry in manifest: $manifest"
+        exit 1
+      fi
 
-    # build output
-    ln -s "$dir/$image" "$TMPDIR/$target_name/$image"
-    ln -s "$dir/$image_sig" "$TMPDIR/$target_name/$image_sig"
+      # build output
+      ln -s "$dir/$image" "$TMPDIR/$target_name/$image"
+      ln -s "$dir/$image_sig" "$TMPDIR/$target_name/$image_sig"
+    fi
 
     # attestations
     if [[ -d "$dir/attestations" ]]; then

--- a/tests/jenkins/HwTestUtilsTest.groovy
+++ b/tests/jenkins/HwTestUtilsTest.groovy
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@interface NonCPS {}
+
+def repoRoot = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile.parentFile
+def hwTestUtils = new GroovyShell(this.class.classLoader).parse(
+  new File(repoRoot, 'hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy')
+)
+
+def expectFailure(String messagePart, Closure body) {
+  try {
+    body()
+    assert false : "Expected failure containing '${messagePart}'"
+  } catch (IllegalArgumentException e) {
+    assert e.message.contains(messagePart) : "Unexpected message: ${e.message}"
+  }
+}
+
+assert hwTestUtils.orin_flash_script_attr(
+  'packages.aarch64-linux.nvidia-jetson-orin-agx-debug'
+) == 'packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64-flash-script'
+
+assert hwTestUtils.orin_flash_script_attr(
+  'packages.aarch64-linux.nvidia-jetson-orin-nx-debug'
+) == 'packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64-flash-script'
+
+assert hwTestUtils.orin_flash_script_attr(
+  'packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'
+) == 'packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64-flash-script'
+
+assert hwTestUtils.orin_flash_script_attr(
+  'packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64'
+) == 'packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64-flash-script'
+
+expectFailure('Cannot derive Orin flash-script attribute') {
+  hwTestUtils.orin_flash_script_attr('packages.x86_64-linux.lenovo-x1-carbon-gen11-debug')
+}


### PR DESCRIPTION
## Summary

This PR adds a temporary `ghaf-infra` adaptation for the Orin flash-image output from `tiiuae/ghaf#1872`, mainly to enable Jenkins-side testing before the final upstream flashing and OCI model is settled.

## What it does

- detects Orin flash-image outputs by `flash-manifest.json`
- preserves the full flash set instead of collapsing it to one image
- retargets Jenkins-side Orin UEFI signing to `signed-output/`
- signs both flashed Orin artifacts (`esp` and `root`)
- skips the misleading single-image OCI publish path for Orin
- triggers hw tests from a Jenkins artifact-root `IMG_URL`
- uses the matching target-specific Orin flasher
- updates release archiving to preserve and verify the full Orin flash set
- adds temporary `ci-dbg` plumbing to exercise the new flow

## Why temporary

This is a testing/transition path, not the final design.

The current Orin flow still depends on:
- upstream resolution of the current `--target=usb` automation mismatch
- upstream `ci-yubi` changes for `initrd` signing
- upstream manifest metadata for the exact Jenkins-side ESP signing scope
- a later OCI-based flash-set model instead of Jenkins artifact-root transport
- See more details in the doc included in this PR


## Main remaining blocker

The main remaining blocker is the current `--target=usb` flashing behavior for Orin (see: [this comment](https://github.com/tiiuae/ghaf/pull/1872#issuecomment-4678628058)).

`ghaf-infra` automation expects `--target=usb` to mean: prepare the removable USB SSD from the test agent only, without requiring direct USB/recovery-mode access to the target device.

The current upstream Orin flasher does not yet match that model. It still expects direct access to the target board and may include board-side flashing steps.

Until that is resolved upstream, this branch is enough to test the new Orin artifact/signing flow in Jenkins, but it does not fully restore compatibility with the existing USB-media-only lab automation model.

