### PR TITLE
ci: add flakevuln workflow

### DIFF
--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: flakevuln
+
+on:
+    workflow_dispatch:
+    schedule:
+        # 02:33 EET every day, expressed as UTC
+        - cron: "33 0 * * *"
+
+concurrency:
+    group: ${{ github.workflow }}.${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    scan:
+        name: Scan hetzci-prod vulnerabilities
+        runs-on: ubuntu-latest
+        timeout-minutes: 180
+        steps:
+            - name: Harden the runner (Audit all outbound calls)
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+              with:
+                  egress-policy: audit
+
+            - name: Checkout
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  persist-credentials: false
+
+            - name: Run flakevuln
+              uses: tiiuae/flakevuln@9a98dd90933c5250a34f86db580ca6d9f8ed41d1
+              with:
+                  targets: |
+                      nixosConfigurations.hetzci-prod.config.system.build.toplevel
+                  unstable-ref: github:NixOS/nixpkgs/nixos-unstable
+                  nixprs: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,6 +230,8 @@ The ghaf-infra repository has its own GitHub Actions workflows
 - `codeql.yml` — CodeQL static analysis on Python code.
 - `dependency-review.yml` — blocks PRs that introduce known-vulnerable
   dependencies.
+- `flakevuln.yml` — scheduled and manual vulnerability scanning for
+  `nixosConfigurations.hetzci-prod.config.system.build.toplevel`.
 - `scorecards.yml` — [OSSF Scorecard](https://securityscorecards.dev/)
   supply chain security analysis.
 


### PR DESCRIPTION
Add a GitHub Actions workflow that runs [flakevuln](https://github.com/tiiuae/flakevuln) against the hetzci-prod system build on a daily schedule and through workflow_dispatch.

Document the new workflow in the architecture guide so the repository's security checks stay discoverable.