### PR TITLE
Use environment specific mutable tags for all pipelines

### DIFF
--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -40,6 +40,12 @@ let
             deleteUntagged = true;
             keepTags = [
               {
+                patterns = [
+                  ".*-latest"
+                  "ghaf-.*"
+                ];
+              }
+              {
                 patterns = [ "release-.*" ];
                 # Keep at least three builds in each repository
                 mostRecentlyPushedCount = 3;

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -344,12 +344,16 @@ def create_pipeline(
             def oci_repository =
               "ghaf/${env.JOB_BASE_NAME.replaceFirst('^ghaf-', '')}/${build_target_name.replaceFirst('^packages\\.', '')}"
             def oci_result_json = "${output}/oci-result.json"
+            def oci_tags = []
+            oci_tags << "${ci_env}-latest"
+            def oci_alias_args = oci_tags.collect { "--tag '${it}'" }.join(" \\\n                ")
+            def oci_alias_args_block = oci_alias_args ? " \\\n                ${oci_alias_args}" : ""
             sh """
               oci-publish target \
                 --target-dir '${output}' \
                 --repository '${oci_repository}' \
-                --tag '${immutable_tag}' \
-                --result-json '${oci_result_json}'
+                --primary-tag '${immutable_tag}' \
+                --result-json '${oci_result_json}'${oci_alias_args_block}
             """
             oci_result = readJSON file: oci_result_json
           }
@@ -357,6 +361,7 @@ def create_pipeline(
       }
 
       if (!normalized_test_runs.isEmpty()) {
+        def tests_completed = true
         try {
           def test_branches = [:]
           def runCount = normalized_test_runs.size()
@@ -424,6 +429,9 @@ def create_pipeline(
               )
             }
           }
+        } catch (Exception e) {
+          tests_completed = false
+          throw e
         } finally {
           stage("Publish test results ${build_shortname}") {
             artifactSupport.with_controller_workspace(ghaf_checkout) {
@@ -449,26 +457,23 @@ def create_pipeline(
                   tests: finalTestEntries,
                 ]))
               )
-            }
-          }
-        }
-        run_optional_stage(
-          ci_env != "vm",
-          "Publish OCI test results ${build_shortname}"
-        ) {
-          artifactSupport.with_controller_workspace(ghaf_checkout) {
-            if (sh(
-              script: "test -d '${output}/test-results'",
-              returnStatus: true
-            ) != 0) {
-              error("Missing test results for ${build_shortname}: ${output}/test-results")
-            }
-            withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
-              sh """
-                oci-publish test-results \
-                  --results-dir '${output}/test-results' \
-                  --subject-reference '${oci_result.primary.reference}'
-              """
+              if (ci_env != "vm" && tests_completed) {
+                if (sh(
+                  script: "test -d '${output}/test-results'",
+                  returnStatus: true
+                ) != 0) {
+                  error("Missing test results for ${build_shortname}: ${output}/test-results")
+                }
+                withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
+                  sh """
+                    oci-publish test-results \
+                      --results-dir '${output}/test-results' \
+                      --subject-reference '${oci_result.primary.reference}'
+                  """
+                }
+              } else if (ci_env != "vm") {
+                echo("Skipping OCI test result publish for failed ${build_shortname} tests")
+              }
             }
           }
         }

--- a/hosts/hetzci/pipelines/ghaf-release-publish.groovy
+++ b/hosts/hetzci/pipelines/ghaf-release-publish.groovy
@@ -123,9 +123,11 @@ pipeline {
                   env.BUCKET=params.BUCKET
                 }
                 if (env.OCI_TAG) {
-                  sh """
-                    archive-ghaf-release -o "$OCI_TAG" -t "${params.GHAF_VERSION}"
-                  """
+                  withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
+                    sh """
+                      archive-ghaf-release -o "$OCI_TAG" -t "${params.GHAF_VERSION}"
+                    """
+                  }
                 } else {
                   sh """
                     archive-ghaf-release -a "$ARTIFACTS_DIR" -t "${params.GHAF_VERSION}"

--- a/hosts/uae/azureci/registry/configuration.nix
+++ b/hosts/uae/azureci/registry/configuration.nix
@@ -42,6 +42,12 @@ let
             deleteUntagged = true;
             keepTags = [
               {
+                patterns = [
+                  ".*-latest"
+                  "ghaf-.*"
+                ];
+              }
+              {
                 patterns = [ "release-.*" ];
                 # Keep at least three builds in each repository
                 mostRecentlyPushedCount = 3;

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -212,8 +212,8 @@ def publish_target_artifacts(
     repository: str,
     common_args: list[str],
     primary_reference: str,
-    immutable_tag: str,
-    mutable_tags: list[str],
+    primary_tag: str,
+    tags: list[str],
     subject_uses_digest: bool,
 ) -> int:
     """Publish the primary artifact, referrers, and result metadata."""
@@ -280,13 +280,13 @@ def publish_target_artifacts(
             signature_relpath=signature_relpath,
         )
 
-    if mutable_tags:
-        run_command(["oras", "tag", *common_args, primary_reference, *mutable_tags])
+    if tags:
+        run_command(["oras", "tag", *common_args, primary_reference, *tags])
 
     result = {
         "target": target,
         "repository": repository,
-        "immutable_tag": immutable_tag,
+        "primary_tag": primary_tag,
         "primary": {
             "artifact_type": TARGET_ARTIFACT_TYPE,
             "media_type": primary_output["mediaType"],
@@ -295,7 +295,7 @@ def publish_target_artifacts(
             "tag_reference": primary_reference,
         },
         "referrers": referrers,
-        "mutable_tags": mutable_tags,
+        "tags": tags,
     }
     write_json(result_json, result)
 
@@ -321,10 +321,10 @@ def publish_target(args: argparse.Namespace) -> int:
     password = os.environ.get("OCI_PASSWORD", "")
     with oras_common_args(registry, username, password) as common_args:
         if os.environ.get("OCI_LAYOUT_PATH", ""):
-            primary_reference = f"{repository}:{args.tag}"
+            primary_reference = f"{repository}:{args.primary_tag}"
             subject_uses_digest = False
         else:
-            primary_reference = f"{registry}/{repository}:{args.tag}"
+            primary_reference = f"{registry}/{repository}:{args.primary_tag}"
             subject_uses_digest = True
         return publish_target_artifacts(
             manifest=manifest,
@@ -333,8 +333,8 @@ def publish_target(args: argparse.Namespace) -> int:
             repository=repository,
             common_args=common_args,
             primary_reference=primary_reference,
-            immutable_tag=args.tag,
-            mutable_tags=list(args.mutable_tags),
+            primary_tag=args.primary_tag,
+            tags=list(args.tags),
             subject_uses_digest=subject_uses_digest,
         )
 
@@ -381,11 +381,9 @@ def build_parser() -> argparse.ArgumentParser:
     target_parser = subparsers.add_parser("target", help="publish one target artifact")
     target_parser.add_argument("-d", "--target-dir", required=True)
     target_parser.add_argument("-r", "--repository", required=True)
-    target_parser.add_argument("-t", "--tag", required=True)
+    target_parser.add_argument("--primary-tag", required=True)
     target_parser.add_argument("-o", "--result-json", required=True)
-    target_parser.add_argument(
-        "-m", "--mutable-tag", action="append", default=[], dest="mutable_tags"
-    )
+    target_parser.add_argument("-t", "--tag", action="append", default=[], dest="tags")
     target_parser.set_defaults(handler=publish_target)
 
     test_results_parser = subparsers.add_parser(

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -234,7 +234,7 @@ pull_artifacts_from_oci() {
     mkdir -p "$target_dir"
     echo "[+] Pulling release artifacts from OCI: $target_reference"
     manifest_log="$target_dir/oras-manifest-fetch.log"
-    if ! oras manifest fetch --format json "$target_reference" >/dev/null 2>"$manifest_log"; then
+    if ! resolved_digest=$(oras resolve "$target_reference" 2>"$manifest_log"); then
       if grep -Eiq "(not found|manifest unknown|name unknown)" "$manifest_log"; then
         echo "[+] Skipping missing OCI target: $target_reference"
         rm -rf "$target_dir"
@@ -245,18 +245,20 @@ pull_artifacts_from_oci() {
       exit 1
     fi
     rm -f "$manifest_log"
+    resolved_reference="$OCI_REPOSITORY_PREFIX/$oci_target_name@$resolved_digest"
+    printf '%s\n' "$resolved_reference" >"$target_dir/oci-reference"
 
     if ! (
       cd "$target_dir"
-      ghaf-fetch --all "$target_reference"
+      ghaf-fetch --all "$resolved_reference"
     ); then
-      print_err "failed pulling OCI target: $target_reference"
+      print_err "failed pulling OCI target: $resolved_reference"
       exit 1
     fi
 
     manifest="$target_dir/manifest.json"
     if [[ ! -f $manifest ]]; then
-      print_err "missing manifest pulled from OCI reference: $target_reference"
+      print_err "missing manifest pulled from OCI reference: $resolved_reference"
       exit 1
     fi
 
@@ -282,6 +284,30 @@ pull_artifacts_from_oci() {
   fi
 
   ARTIFACTS="$artifactsdir"
+}
+
+tag_oci_release_artifacts() {
+  for dir in "$ARTIFACTS"/*/; do
+    target_name="$(basename "$dir")"
+    if ! is_release_target "$target_name"; then
+      continue
+    fi
+
+    source_reference_file="$dir/oci-reference"
+    if [[ ! -f $source_reference_file ]]; then
+      print_err "missing resolved OCI reference for release artifact: $target_name"
+      exit 1
+    fi
+    source_reference="$(<"$source_reference_file")"
+
+    echo "[+] Tagging OCI release artifact: $source_reference"
+    oras manifest fetch --registry-config "$OCI_REGISTRY_CONFIG" "$source_reference" >/dev/null
+    oras tag \
+      --registry-config "$OCI_REGISTRY_CONFIG" \
+      "$source_reference" \
+      "$GHAF_VERSION" \
+      ghaf-latest
+  done
 }
 
 prepare_artifacts() {
@@ -361,7 +387,19 @@ main() {
 
   # Prepare the release archive from artifacts
   if [[ -n $OCI_TAG ]]; then
+    if [[ -z ${OCI_PASSWORD:-} ]]; then
+      print_err "OCI_PASSWORD is required when tagging release artifacts"
+      exit 1
+    fi
+    exit_unless_command_exists oras
     exit_unless_command_exists ghaf-fetch
+    OCI_REGISTRY_CONFIG="$TMPDIR/oras-auth/config.json"
+    mkdir -p "${OCI_REGISTRY_CONFIG%/*}"
+    printf '%s\n' "$OCI_PASSWORD" | oras login \
+      -u "${OCI_USERNAME:-jenkins}" \
+      --password-stdin \
+      --registry-config "$OCI_REGISTRY_CONFIG" \
+      "${OCI_REPOSITORY_PREFIX%%/*}"
     pull_artifacts_from_oci "$OCI_TAG"
   else
     ARTIFACTS="$(realpath "$ARTIFACTS")"
@@ -372,6 +410,10 @@ main() {
   echo "[+] Uploading release tar archives to Hetzner"
   mc alias set hetzner "$STORAGE_URL" "$ACCESS_KEY" "$SECRET_KEY" >/dev/null
   mc mirror "$TMPDIR/archived" "hetzner/$BUCKET/$GHAF_VERSION"
+
+  if [[ -n $OCI_TAG ]]; then
+    tag_oci_release_artifacts
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Pipelines now tag artifacts as `${env}-latest` during OCI publish step. This tag will always point to the latest build for the target in this pipeline.

Additionally, tag release builds when they are published with the ghaf version.