### PR TITLE
Remove Dell7330 hardware

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,15 +70,15 @@ Build results are pushed to three Cachix binary caches:
 ### Test Agents
 
 Test agents are on-prem machines in the Tampere office with physical hardware
-devices (Orin AGX/NX, Lenovo X1, Dell, etc.) attached. They connect to Jenkins
+devices (Orin AGX/NX, Lenovo X1, etc.) attached. They connect to Jenkins
 controllers over the Nebula overlay and run one Jenkins agent service per
 device, effectively acting as a lock for each piece of hardware.
 
 | Host | Variant | Hardware |
 |---|---|---|
 | `testagent-dbg` | dbg | Orin NX |
-| `testagent-dev` | dev | Orin AGX, Orin NX, Orin AGX-64, Lenovo X1, Dell 7330, Darter Pro |
-| `testagent-prod` | prod | Lenovo X1, Dell 7330, Darter Pro |
+| `testagent-dev` | dev | Orin AGX, Orin NX, Orin AGX-64, Lenovo X1, Darter Pro |
+| `testagent-prod` | prod | Lenovo X1, Darter Pro |
 | `testagent2-prod` | prod | (secondary prod agent) |
 | `testagent-release` | release | Orin AGX, Orin NX, Lenovo X1, Darter Pro |
 

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -102,7 +102,6 @@ in
         description = "Devices to create agent nodes for";
         default = [
           "darter-pro"
-          "dell-7330"
           "lenovo-x1"
           "orin-agx"
           "orin-agx-64"

--- a/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
@@ -73,13 +73,6 @@ private def device_catalog() {
     'x1-sec-boot': [
       name: 'X1-Secure-Boot',
     ],
-    'dell-7330': [
-      name: 'Dell7330',
-      target_substrings: ['dell-latitude-7330'],
-      variants: [
-        'debug': 'dell-latitude-7330-debug',
-      ],
-    ],
     'darter-pro': [
       name: 'DarterPRO',
       target_substrings: ['system76-darp11-b'],

--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -69,7 +69,7 @@ def pipelineParameters(boolean useFlakePinnedDefault = false) {
         script: [
           classpath: [],
           sandbox: true,
-          script: "return ['orin-agx','orin-agx-64','orin-nx','lenovo-x1','dell-7330','darter-pro', 'x1-sec-boot']"
+          script: "return ['orin-agx','orin-agx-64','orin-nx','lenovo-x1','darter-pro', 'x1-sec-boot']"
         ]
       ]
     ],

--- a/hosts/hetzci/pipelines/ghaf-main.groovy
+++ b/hosts/hetzci/pipelines/ghaf-main.groovy
@@ -23,13 +23,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
-    tests: [[
-      device_tag: 'dell-7330',
-      variant: 'debug',
-      testset: '_relayboot_bat_',
-    ]],
-  ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
     testset: '_relayboot_bat_',
   ],

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -113,7 +113,7 @@ pipeline {
             }
             if (params.dell_latitude_7330_debug) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: params.TESTSET ])
+                [ target: "packages.x86_64-linux.dell-latitude-7330-debug", testset: null ])
             }
             if (params.nvidia_jetson_orin_agx_debug_from_x86_64) {
               TARGETS.push(
@@ -191,13 +191,8 @@ pipeline {
               ))
             }
             if (params.intel_laptop_low_mem_debug) {
-              TARGETS.push(addExplicitTests(
-                [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug", uefisign: params.UEFISIGN ],
-                [[
-                  device_tag: 'dell-7330',
-                  variant: 'debug',
-                ]],
-              ))
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug", uefisign: params.UEFISIGN, testset: null ])
             }
             if (params.intel_laptop_low_mem_debug_installer) {
               TARGETS.push(

--- a/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly-perftest.groovy
@@ -20,13 +20,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
-    tests: [[
-      device_tag: 'dell-7330',
-      variant: 'debug',
-      testset: '_relayboot_perf_',
-    ]],
-  ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
     testset: '_relayboot_perf_',
   ],

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -48,12 +48,7 @@ def TARGETS = [
     testset: null, sbom: true,
   ],
   [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
-    sbom: true,
-    tests: [[
-      device_tag: 'dell-7330',
-      variant: 'debug',
-      testset: '_relayboot_regression_',
-    ]],
+    testset: null, sbom: true,
   ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
     testset: '_relayboot_regression_', uefisign: true, sbom: true,

--- a/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge-manual.groovy
@@ -23,13 +23,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
-    tests: [[
-      device_tag: 'dell-7330',
-      variant: 'debug',
-      testset: '_relayboot_pre-merge_',
-    ]],
-  ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
     testset: '_relayboot_pre-merge_',
   ],

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -23,13 +23,6 @@ def TARGETS = [
       ],
     ],
   ],
-  [ target: "packages.x86_64-linux.intel-laptop-low-mem-debug",
-    tests: [[
-      device_tag: 'dell-7330',
-      variant: 'debug',
-      testset: '_relayboot_pre-merge_',
-    ]],
-  ],
   [ target: "packages.aarch64-linux.nvidia-jetson-orin-agx-debug",
     testset: '_relayboot_pre-merge_',
   ],

--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -20,7 +20,6 @@
       "orin-nx"
       "orin-agx-64"
       "lenovo-x1"
-      "dell-7330"
       "darter-pro"
     ];
   };
@@ -62,10 +61,6 @@
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTFMF0L2", SYMLINK+="ttyX1", MODE="0666", GROUP="dialout"
     # SSD-drive
     SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XPNS0W606188E", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
-
-    # Dell 7330
-    # SSD-drive
-    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S6XNNS0W500904J", SYMLINK+="ssdDELL7330", MODE="0666", GROUP="dialout"
 
     # Darter Pro
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTFMF6RS", SYMLINK+="ttyDARTER", MODE="0666", GROUP="dialout"
@@ -141,19 +136,6 @@
           usbhub_serial = "0x99EB9D84";
           ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
-        };
-        Dell7330 = {
-          inherit location;
-          device_id = "00-0b-40-32-ff";
-          netvm_hostname = "ghaf-0188756735";
-          serial_port = "NONE";
-          device_ip_address = "172.18.16.23";
-          socket_ip_address = "NONE";
-          plug_type = "NONE";
-          switch_bot = "Dell7330-dev";
-          usbhub_serial = "5AC2B4AD";
-          ext_drive_by-id = "/dev/ssdDELL7330";
-          threads = 8;
         };
         DarterPRO = {
           inherit location;

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -18,7 +18,6 @@
     variant = "prod";
     hardware = [
       "lenovo-x1"
-      "dell-7330"
       "darter-pro"
       "x1-sec-boot"
     ];
@@ -30,10 +29,6 @@
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTEOH72L", SYMLINK+="ttyX1", MODE="0666", GROUP="dialout"
     # SSD-drive
     SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S7MLNS0X532696T", SYMLINK+="ssdX1", MODE="0666", GROUP="dialout"
-
-    # Dell 7330
-    # SSD-drive
-    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="50026B72836E78E0", SYMLINK+="ssdDELL7330", MODE="0666", GROUP="dialout"
 
     # Darter Pro
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTFMF0X0", SYMLINK+="ttyDARTER", MODE="0666", GROUP="dialout"
@@ -76,19 +71,6 @@
           usbhub_serial = "641B6D74";
           ext_drive_by-id = "/dev/ssdX1";
           threads = 20;
-        };
-        Dell7330 = {
-          inherit location;
-          device_id = "00-32-e0-be-f3";
-          netvm_hostname = "ghaf-0853589747";
-          serial_port = "NONE";
-          device_ip_address = "172.18.16.7";
-          socket_ip_address = "NONE";
-          plug_type = "NONE";
-          switch_bot = "Dell7330-prod";
-          usbhub_serial = "FF62140D";
-          ext_drive_by-id = "/dev/ssdDELL7330";
-          threads = 8;
         };
         DarterPRO = {
           inherit location;


### PR DESCRIPTION
Remove HW testing for Dell7330, there will be no Dell laptop in the lab anymore.
Building intel-laptop-low-mem-debug was left only in nightly pipeline.