### PR TITLE
Remove transitional dhparams cleanup unit

### DIFF
--- a/services/nginx/default.nix
+++ b/services/nginx/default.nix
@@ -19,10 +19,6 @@
       if config.networking.nameservers == [ ] then [ "1.1.1.1" ] else config.networking.nameservers;
   };
 
-  # Keep the cleanup unit active for one rollout after removing the nginx
-  # dhparams consumer so stateful files under /var/lib/dhparams get removed.
-  security.dhparams.enable = true;
-
   security.acme = {
     acceptTerms = true;
     defaults.email = "trash@unikie.com";


### PR DESCRIPTION
All host have been deployed with the transitional version. Now we can move forward to finalize the transition by removing the transition code itself.