### PR TITLE
Add release policy with checker and attestation file

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,19 @@ Object Storage (an S3-compatible service, bucket `ghaf-artifacts`) using
 minio-client. The [ghaf-archive](https://github.com/tiiuae/ghaf-archive) web
 application provides a browsable frontend to the archived releases.
 
+Release image artifacts also get a signed release-policy attestation after
+their configured hardware tests have completed. The policy is configured in
+`slsa/release-policy.yaml`; each criterion runs, and the `required` flag
+determines whether a failed criterion fails the release step. The attestation
+records the per-criterion result for image signature verification, SLSA
+provenance verification, the pre-test provenance trust policy verdict saved in
+`test-results.json`, SBOM presence, and hardware test status. Jenkins signs the
+attestation with the SLSA provenance signing key and publishes it as an OCI
+referrer without changing the already-published target manifest. Release
+archival requires a passing signed release-policy attestation by default and can
+be bypassed only by setting
+`REQUIRE_RELEASE_ATTESTATION=false` for transitional use.
+
 ### Repository CI (ghaf-infra)
 
 The ghaf-infra repository has its own GitHub Actions workflows

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -233,6 +233,7 @@ in
         ++ lib.optionals cfg.withRegistryPublish [
           pkgs.oras
           self.packages.${pkgs.stdenv.hostPlatform.system}.oci-publish
+          self.packages.${pkgs.stdenv.hostPlatform.system}.policy-checker
         ];
 
       environment = {
@@ -293,6 +294,8 @@ in
       {
         "jenkins/nix-fast-build.sh".source = "${self.outPath}/scripts/nix-fast-build.sh";
         "jenkins/remote-stores.json".text = builtins.toJSON remoteStoresFromBuildMachines;
+        "jenkins/provenance-trust-policy.yaml".source = "${self.outPath}/slsa/provenance-trust-policy.yaml";
+        "jenkins/release-policy.yaml".source = "${self.outPath}/slsa/release-policy.yaml";
         "jenkins/pipelines".source = filteredPipelines;
         "jenkins/pipeline-library".source = pipelineSharedLibrary;
         "jenkins/casc/common.yaml".source = ./casc/common.yaml;

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -133,8 +133,23 @@ def create_pipeline(
       ],
     ]
     def oci_result = null
+    def provenance_policy_passed = null
+    def provenance_policy_failure = null
     def result_file_for = { Map testRun ->
       "${output}/test-results/${testRun.test_path_key}/result.json"
+    }
+    def write_test_results = { List finalTestEntries ->
+      def testResults = [
+        target: build_target_name,
+        tests: finalTestEntries,
+      ]
+      if (provenance_policy_passed != null) {
+        testResults.provenance_policy_passed = provenance_policy_passed
+      }
+      writeFile(
+        file: "${output}/test-results.json",
+        text: JsonOutput.prettyPrint(JsonOutput.toJson(testResults))
+      )
     }
     def write_manifest = {
       writeFile(
@@ -305,6 +320,25 @@ def create_pipeline(
           }
         }
         run_optional_stage(
+          ci_env == "release" && !target_config.no_image && target_config.provenance_requested,
+          "Provenance policy ${build_shortname}"
+        ) {
+          def policy_status = sh(
+            script: """
+            policy-checker '${output}/attestations/provenance.json' \
+              --sig '${output}/attestations/provenance.json.sig' \
+              --policy /etc/jenkins/provenance-trust-policy.yaml
+            """,
+            returnStatus: true
+          )
+          provenance_policy_passed = policy_status == 0
+          write_test_results([])
+          if (!provenance_policy_passed) {
+            provenance_policy_failure = "Provenance trust policy failed for ${build_shortname}"
+            echo(provenance_policy_failure)
+          }
+        }
+        run_optional_stage(
           !target_config.no_image,
           "Find image ${build_shortname}"
         ) {
@@ -424,6 +458,7 @@ def create_pipeline(
         }
       }
 
+      def test_failure_message = null
       if (!normalized_test_runs.isEmpty()) {
         if (manifest.images.size() != 1) {
           error("Multi-image hardware tests are not implemented for ${build_shortname}; found ${manifest.images.size()} images")
@@ -497,8 +532,11 @@ def create_pipeline(
             }
           }
         } catch (Exception e) {
+          if (e.getClass().getName() == 'org.jenkinsci.plugins.workflow.steps.FlowInterruptedException') {
+            throw e
+          }
           tests_completed = false
-          throw e
+          test_failure_message = e.message ?: e.toString()
         } finally {
           stage("Publish test results ${build_shortname}") {
             artifactSupport.with_controller_workspace(ghaf_checkout) {
@@ -517,13 +555,7 @@ def create_pipeline(
                   ])
                 }
               }
-              writeFile(
-                file: "${output}/test-results.json",
-                text: JsonOutput.prettyPrint(JsonOutput.toJson([
-                  target: build_target_name,
-                  tests: finalTestEntries,
-                ]))
-              )
+              write_test_results(finalTestEntries)
               if (ci_env != "vm" && tests_completed) {
                 if (sh(
                   script: "test -d '${output}/test-results'",
@@ -544,6 +576,56 @@ def create_pipeline(
             }
           }
         }
+      }
+      run_optional_stage(
+        ci_env == "release" && !target_config.no_image && target_config.provenance_requested,
+        "Release policy ${build_shortname}"
+      ) {
+        artifactSupport.with_controller_workspace(ghaf_checkout) {
+          def outdir = "${output}/attestations"
+          def policy_status = sh(
+            script: """
+            policy-checker release '${output}' \
+              --oci-result '${output}/oci-result.json' \
+              --policy /etc/jenkins/release-policy.yaml \
+              --out '${outdir}/release-policy.json'
+            """,
+            returnStatus: true
+          )
+          if (
+            policy_status != 0 &&
+            sh(script: "test -f '${outdir}/release-policy.json'", returnStatus: true) != 0
+          ) {
+            error("Release policy failed before writing attestation for ${build_shortname}")
+          }
+
+          withRedundancyRouter("GhafInfraSignProv") { ctx ->
+            sh """
+              openssl pkeyutl -sign -rawin \
+                -inkey "${ctx.uri}" \
+                -out ${outdir}/release-policy.json.sig \
+                -in ${outdir}/release-policy.json
+            """
+          }
+
+          withCredentials([string(credentialsId: 'oci_registry_password', variable: 'OCI_PASSWORD')]) {
+            sh """
+              oci-publish release-attestation \
+                --target-dir '${output}' \
+                --subject-reference '${oci_result.primary.reference}'
+            """
+          }
+
+          if (policy_status != 0) {
+            unstable("Release policy failed for ${build_shortname}")
+          }
+        }
+      }
+      if (test_failure_message != null) {
+        error("Hardware tests failed for ${build_shortname}: ${test_failure_message}")
+      }
+      if (provenance_policy_failure != null) {
+        error(provenance_policy_failure)
       }
     }
   }

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -26,14 +26,17 @@ TARGET_ARTIFACT_TYPE = "application/vnd.ghaf.image.v1"
 TARGET_CONFIG_MEDIA_TYPE = "application/vnd.ghaf.manifest.v1+json"
 TEST_RESULTS_ARTIFACT_TYPE = "application/vnd.ghaf.test-results.v1"
 TEST_RESULTS_MEDIA_TYPE = "application/x-tar"
+RELEASE_ATTESTATION_ARTIFACT_TYPE = "application/vnd.ghaf.release-attestation.v1+json"
 REFERRER_MEDIA_TYPES = {
     "provenance": "application/vnd.in-toto+json",
+    "release_policy": RELEASE_ATTESTATION_ARTIFACT_TYPE,
     "sbom_cyclonedx": "application/vnd.cyclonedx+json",
     "sbom_spdx": "application/spdx+json",
     "sbom_csv": "text/csv",
 }
 REFERRER_DESCRIPTIONS = {
     "provenance": "SLSA Provenance",
+    "release_policy": "Ghaf release policy attestation",
     "sbom_cyclonedx": "CycloneDX SBOM",
     "sbom_spdx": "SPDX SBOM",
     "sbom_csv": "CSV SBOM",
@@ -272,7 +275,7 @@ def publish_target_artifacts(
     attestations = manifest["attestations"]
 
     referrers: dict[str, Any] = {}
-    for role in REFERRER_MEDIA_TYPES:
+    for role in ("provenance", "sbom_cyclonedx", "sbom_spdx", "sbom_csv"):
         relpath = attestations[role]["path"]
         if not relpath:
             continue
@@ -388,6 +391,32 @@ def publish_test_results(args: argparse.Namespace) -> int:
         return 0
 
 
+def publish_release_attestation(args: argparse.Namespace) -> int:
+    """Publish a release policy attestation as a referrer."""
+    target_dir = Path(args.target_dir).expanduser().resolve()
+    relpath = "attestations/release-policy.json"
+    signature_relpath = "attestations/release-policy.json.sig"
+
+    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
+    username = os.environ.get("OCI_USERNAME", "jenkins")
+    password = os.environ.get("OCI_PASSWORD", "")
+    with oras_common_args(registry, username, password) as common_args:
+        result = publish_referrer(
+            common_args=common_args,
+            subject_reference=args.subject_reference,
+            target_dir=target_dir,
+            role="release_policy",
+            relpath=relpath,
+            signature_relpath=signature_relpath,
+        )
+
+    print(
+        "[+] Published release policy attestation for "
+        f"{args.subject_reference}: {result['digest']}"
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
     parser = argparse.ArgumentParser(description="Publish Ghaf OCI artifacts")
@@ -407,6 +436,13 @@ def build_parser() -> argparse.ArgumentParser:
     test_results_parser.add_argument("-d", "--results-dir", required=True)
     test_results_parser.add_argument("-s", "--subject-reference", required=True)
     test_results_parser.set_defaults(handler=publish_test_results)
+
+    release_attestation_parser = subparsers.add_parser(
+        "release-attestation", help="attach release policy attestation"
+    )
+    release_attestation_parser.add_argument("-d", "--target-dir", required=True)
+    release_attestation_parser.add_argument("-s", "--subject-reference", required=True)
+    release_attestation_parser.set_defaults(handler=publish_release_attestation)
 
     return parser
 

--- a/pkgs/policy-checker/src/main.go
+++ b/pkgs/policy-checker/src/main.go
@@ -1,14 +1,19 @@
-// SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+// SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 // SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -16,31 +21,73 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+const (
+	releaseAttestationType = "https://ghaf.tii.ae/attestation/release-policy/v1"
+	releasePredicateType   = "https://ghaf.tii.ae/predicate/release-policy/v1"
+)
+
 type Criteria struct {
-	Id          string
-	Cel         string
-	Description string
-	Required    bool
+	Id          string `json:"id" yaml:"id"`
+	Cel         string `json:"cel" yaml:"cel"`
+	Description string `json:"description" yaml:"description"`
+	Required    bool   `json:"required" yaml:"required"`
 }
 
 type SignaturePolicy struct {
-	Verify bool
+	Verify bool `json:"verify" yaml:"verify"`
 }
 
 type TrustPolicy struct {
-	Version   string
-	Signature SignaturePolicy
-	Criteria  []Criteria
+	Name      string          `json:"name" yaml:"name"`
+	URI       string          `json:"uri" yaml:"uri"`
+	Version   string          `json:"version" yaml:"version"`
+	Signature SignaturePolicy `json:"signature" yaml:"signature"`
+	Criteria  []Criteria      `json:"criteria" yaml:"criteria"`
 }
 
-func VerifySignature(provenance_file string, provenance_signature string, policy SignaturePolicy) {
-	fmt.Println("Verifying signature")
-	cmd := exec.Command(
-		"verify-signature",
-		"provenance",
-		provenance_file,
-		provenance_signature,
-	)
+type CriterionResult struct {
+	CriterionID string `json:"criterion_id"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required"`
+	Status      string `json:"status"`
+	Details     string `json:"details,omitempty"`
+}
+
+func readJSON(path string) (map[string]any, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var input map[string]any
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return nil, err
+	}
+	return input, nil
+}
+
+func readPolicy(path string) (TrustPolicy, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return TrustPolicy{}, err
+	}
+	var config TrustPolicy
+	if err := yaml.Unmarshal(raw, &config); err != nil {
+		return TrustPolicy{}, err
+	}
+	return config, nil
+}
+
+func fileSHA256(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func verifySignature(mode string, artifact string, signature string) error {
+	cmd := exec.Command("verify-signature", mode, artifact, signature)
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
 	cmd.Stderr = &stderr
@@ -48,77 +95,412 @@ func VerifySignature(provenance_file string, provenance_signature string, policy
 	err := cmd.Run()
 	fmt.Print(stdout.String())
 	if err != nil {
-		fmt.Println("Verification command failed")
-		fmt.Println(stderr.String())
-		os.Exit(1)
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return fmt.Errorf("verification command failed: %s", message)
 	}
+	return nil
 }
 
-func provenanceCheck(provenance_file string, config TrustPolicy) {
-	// Read and unmarshal the provenance file into a map
-	raw, err := os.ReadFile(provenance_file)
+func evaluateCriteria(
+	input map[string]any,
+	criteria []Criteria,
+	variables ...cel.EnvOption,
+) ([]CriterionResult, bool, error) {
+	// Declare the CEL environment.
+	env, err := cel.NewEnv(variables...)
 	if err != nil {
-		panic(err)
+		return nil, false, fmt.Errorf("environment declaration error: %w", err)
 	}
-	var input map[string]any
-	_ = json.Unmarshal(raw, &input)
-
-	// Declare the CEL environment
-	env, err := cel.NewEnv(
-		cel.Variable("_type", cel.StringType),
-		cel.Variable("predicateType", cel.StringType),
-		// subject and predicate are dynamic to avoid verbose type specification
-		cel.Variable("subject", cel.ListType(cel.DynType)),
-		cel.Variable("predicate", cel.DynType),
-		cel.Variable("now", cel.TimestampType),
-	)
-	if err != nil {
-		panic(fmt.Sprintf("environment declaration error: %s", err))
-	}
-
-	// add current time into the input so it can be used in the queries
-	input["now"] = time.Now()
-	fmt.Printf("Current time is: %s\n\n", input["now"])
 
 	failures := false
-	for _, ruleset := range config.Criteria {
-		fmt.Printf(":: %s\n", ruleset.Description)
+	results := []CriterionResult{}
+	for _, criterion := range criteria {
+		result := CriterionResult{
+			CriterionID: criterion.Id,
+			Description: criterion.Description,
+			Required:    criterion.Required,
+		}
 
-		ast, issues := env.Compile(ruleset.Cel)
+		fmt.Printf(":: %s\n", criterion.Description)
+		ast, issues := env.Compile(criterion.Cel)
 		if issues != nil && issues.Err() != nil {
-			panic(fmt.Sprintf("type-check error: %s", issues.Err()))
+			return nil, false, fmt.Errorf("type-check error in %q: %w", criterion.Id, issues.Err())
 		}
 
 		prg, err := env.Program(ast)
 		if err != nil {
-			panic(fmt.Sprintf("program construction error: %s", err))
+			return nil, false, fmt.Errorf("program construction error in %q: %w", criterion.Id, err)
 		}
 
-		// Evaluate
+		// Evaluate.
 		out, _, err := prg.Eval(input)
 		if err != nil {
-			panic(fmt.Sprintf("evaluation error: %s", err))
+			return nil, false, fmt.Errorf("evaluation error in %q: %w", criterion.Id, err)
 		}
 
-		pass := out.Value().(bool)
+		pass, ok := out.Value().(bool)
+		if !ok {
+			return nil, false, fmt.Errorf("criterion %q did not evaluate to a boolean", criterion.Id)
+		}
 		fmt.Printf("-> %v\n\n", pass)
 
-		if !pass && ruleset.Required {
-			failures = true
+		if pass {
+			result.Status = "pass"
+		} else {
+			result.Status = "fail"
+			if criterion.Required {
+				failures = true
+			}
+		}
+		results = append(results, result)
+	}
+
+	return results, failures, nil
+}
+
+func provenanceVariables() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Variable("_type", cel.StringType),
+		cel.Variable("predicateType", cel.StringType),
+		// subject and predicate are dynamic to avoid verbose type specification.
+		cel.Variable("subject", cel.ListType(cel.DynType)),
+		cel.Variable("predicate", cel.DynType),
+		cel.Variable("now", cel.TimestampType),
+	}
+}
+
+func provenanceCheck(provenanceFile string, config TrustPolicy) ([]CriterionResult, bool, error) {
+	// Read and unmarshal the provenance file into a map.
+	input, err := readJSON(provenanceFile)
+	if err != nil {
+		return nil, false, err
+	}
+	// Add current time into the input so it can be used in queries.
+	input["now"] = time.Now()
+	fmt.Printf("Current time is: %s\n\n", input["now"])
+	return evaluateCriteria(input, config.Criteria, provenanceVariables()...)
+}
+
+func stringAt(root any, keys ...string) string {
+	current := root
+	for _, key := range keys {
+		asMap, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = asMap[key]
+	}
+	value, ok := current.(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func fileExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func verifyFileSignature(mode string, artifact string, signature string) map[string]any {
+	result := map[string]any{
+		"verified": false,
+		"error":    "",
+	}
+	if !fileExists(artifact) {
+		result["error"] = fmt.Sprintf("missing artifact: %s", artifact)
+		return result
+	}
+	if !fileExists(signature) {
+		result["error"] = fmt.Sprintf("missing signature: %s", signature)
+		return result
+	}
+	if err := verifySignature(mode, artifact, signature); err != nil {
+		result["error"] = err.Error()
+		return result
+	}
+	result["verified"] = true
+	return result
+}
+
+func releaseVariables() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Variable("manifest", cel.DynType),
+		cel.Variable("oci", cel.DynType),
+		cel.Variable("provenance", cel.DynType),
+		cel.Variable("test_results", cel.DynType),
+		cel.Variable("files", cel.DynType),
+		cel.Variable("signatures", cel.DynType),
+		cel.Variable("provenance_policy", cel.DynType),
+		cel.Variable("now", cel.TimestampType),
+	}
+}
+
+func digestMap(digest string) map[string]string {
+	parts := strings.SplitN(digest, ":", 2)
+	if len(parts) != 2 {
+		return map[string]string{}
+	}
+	return map[string]string{parts[0]: parts[1]}
+}
+
+func releasePolicyInput(
+	targetDir string,
+	ociResultPath string,
+) (map[string]any, map[string]any, map[string]any, error) {
+	manifestPath := filepath.Join(targetDir, "manifest.json")
+	manifest, err := readJSON(manifestPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	ociResult, err := readJSON(ociResultPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	testResultsPath := filepath.Join(targetDir, "test-results.json")
+	testResults := map[string]any{
+		"configured": false,
+		"tests":      []any{},
+	}
+	if fileExists(testResultsPath) {
+		testResults, err = readJSON(testResultsPath)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		testResults["configured"] = true
+	}
+
+	imagePath := filepath.Join(targetDir, stringAt(manifest, "image", "path"))
+	imageSignaturePath := filepath.Join(targetDir, stringAt(manifest, "image", "signature", "path"))
+	provenancePath := filepath.Join(targetDir, stringAt(manifest, "attestations", "provenance", "path"))
+	provenanceSignaturePath := filepath.Join(targetDir, stringAt(manifest, "attestations", "provenance", "signature", "path"))
+
+	imageSignature := verifyFileSignature("image", imagePath, imageSignaturePath)
+	provenanceSignature := verifyFileSignature("provenance", provenancePath, provenanceSignaturePath)
+	provenance := map[string]any{}
+	if fileExists(provenancePath) {
+		provenance, err = readJSON(provenancePath)
+		if err != nil {
+			return nil, nil, nil, err
 		}
 	}
 
+	provenancePolicy := map[string]any{
+		"passed": false,
+	}
+	if passed, ok := testResults["provenance_policy_passed"].(bool); ok {
+		provenancePolicy["passed"] = passed
+	}
+
+	sbomCSV := filepath.Join(targetDir, stringAt(manifest, "attestations", "sbom_csv", "path"))
+	sbomCycloneDX := filepath.Join(targetDir, stringAt(manifest, "attestations", "sbom_cyclonedx", "path"))
+	sbomSPDX := filepath.Join(targetDir, stringAt(manifest, "attestations", "sbom_spdx", "path"))
+
+	input := map[string]any{
+		"manifest":     manifest,
+		"oci":          ociResult,
+		"provenance":   provenance,
+		"test_results": testResults,
+		"files": map[string]any{
+			"image":           fileExists(imagePath),
+			"image_signature": fileExists(imageSignaturePath),
+			"provenance":      fileExists(provenancePath),
+			"provenance_signature": fileExists(
+				provenanceSignaturePath,
+			),
+			"sbom_csv":       fileExists(sbomCSV),
+			"sbom_cyclonedx": fileExists(sbomCycloneDX),
+			"sbom_spdx":      fileExists(sbomSPDX),
+		},
+		"signatures": map[string]any{
+			"image":      imageSignature,
+			"provenance": provenanceSignature,
+		},
+		"provenance_policy": provenancePolicy,
+		"now":               time.Now(),
+	}
+	return input, manifest, ociResult, nil
+}
+
+func evaluateReleasePolicy(
+	targetDir string,
+	ociResultPath string,
+	policyPath string,
+) (map[string]any, bool, error) {
+	policyDigest, err := fileSHA256(policyPath)
+	if err != nil {
+		return nil, false, err
+	}
+	policy, err := readPolicy(policyPath)
+	if err != nil {
+		return nil, false, err
+	}
+	input, manifest, ociResult, err := releasePolicyInput(
+		targetDir,
+		ociResultPath,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	results, failures, err := evaluateCriteria(input, policy.Criteria, releaseVariables()...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	primary := ociResult["primary"]
+	digest := stringAt(primary, "digest")
+	reference := stringAt(primary, "reference")
+	attestation := map[string]any{
+		"_type":         releaseAttestationType,
+		"predicateType": releasePredicateType,
+		"subject": []map[string]any{
+			{
+				"name":   reference,
+				"digest": digestMap(digest),
+			},
+		},
+		"predicate": map[string]any{
+			"policy": map[string]any{
+				"name":    policy.Name,
+				"uri":     policy.URI,
+				"version": policy.Version,
+				"digest": map[string]string{
+					"sha256": policyDigest,
+				},
+			},
+			"artifact": map[string]any{
+				"target":     manifest["target"],
+				"repository": ociResult["repository"],
+				"reference":  reference,
+				"digest":     digest,
+			},
+			"source":      manifest["source"],
+			"passed":      !failures,
+			"results":     results,
+			"timestamp":   time.Now().UTC().Format(time.RFC3339),
+			"attested_by": "policy-checker",
+		},
+	}
+	return attestation, failures, nil
+}
+
+func writeAttestation(path string, attestation map[string]any) error {
+	raw, err := json.MarshalIndent(attestation, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o644)
+}
+
+func runProvenanceAction(cmd *cli.Command) error {
+	provenanceFile := cmd.StringArg("provenance")
+	provenanceSignature := cmd.String("sig")
+	configFile := cmd.String("policy")
+
+	if provenanceFile == "" {
+		return errors.New("provenance file must be provided")
+	}
+	if configFile == "" {
+		return errors.New("trust policy file must be provided")
+	}
+
+	config, err := readPolicy(configFile)
+	if err != nil {
+		return err
+	}
+
+	if config.Signature.Verify {
+		if provenanceSignature == "" {
+			return errors.New("trust policy requires verified signature, but no signature file was provided")
+		}
+		fmt.Println("Verifying signature")
+		if err := verifySignature("provenance", provenanceFile, provenanceSignature); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println()
+	_, failures, err := provenanceCheck(provenanceFile, config)
+	if err != nil {
+		return err
+	}
 	if failures {
-		fmt.Println("Some required checks did not pass!")
-		os.Exit(1)
+		return errors.New("some required checks did not pass")
+	}
+	return nil
+}
+
+func releaseCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "release",
+		Usage:     "Evaluate release policy and emit a release attestation",
+		UsageText: "policy-checker release TARGET_DIR --oci-result FILE --policy FILE --out FILE",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "oci-result",
+				Usage:    "OCI publish result `FILE`.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "policy",
+				Usage:    "Release policy `FILE`.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "out",
+				Usage:    "Output release attestation `FILE`.",
+				Required: true,
+			},
+		},
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "target-dir",
+				UsageText: "Target artifact directory.",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			targetDir := cmd.StringArg("target-dir")
+			if targetDir == "" {
+				return errors.New("target artifact directory must be provided")
+			}
+			attestation, failures, err := evaluateReleasePolicy(
+				targetDir,
+				cmd.String("oci-result"),
+				cmd.String("policy"),
+			)
+			if err != nil {
+				return err
+			}
+			if err := writeAttestation(cmd.String("out"), attestation); err != nil {
+				return err
+			}
+			fmt.Printf("[+] Wrote release attestation: %s\n", cmd.String("out"))
+			if failures {
+				return errors.New("some required release policy checks did not pass")
+			}
+			return nil
+		},
 	}
 }
 
 func main() {
 	cmd := &cli.Command{
-		Name:      "Provenance policy checker",
-		Usage:     "Verify SLSA provenance file meets policies",
+		Name:      "policy-checker",
+		Usage:     "Verify SLSA provenance or release policy",
 		UsageText: "policy-checker PROVENANCE_FILE [--sig FILE --policy FILE]",
+		Commands:  []*cli.Command{releaseCommand()},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "sig",
@@ -126,10 +508,9 @@ func main() {
 				Usage: "Signature `FILE` to verify the provenance with.",
 			},
 			&cli.StringFlag{
-				Name:     "policy",
-				Value:    "",
-				Usage:    "`FILE` containing the trust policy configuration.",
-				Required: true,
+				Name:  "policy",
+				Value: "",
+				Usage: "`FILE` containing the trust policy configuration.",
 			},
 		},
 		Arguments: []cli.Argument{
@@ -139,43 +520,12 @@ func main() {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			provenance_file := cmd.StringArg("provenance")
-			provenance_signature := cmd.String("sig")
-			config_file := cmd.String("policy")
-
-			if provenance_file == "" {
-				fmt.Println("Provenance file must be provided.")
-				os.Exit(1)
-			}
-
-			// read the trust policy file
-			raw, err := os.ReadFile(config_file)
-			if err != nil {
-				panic(err)
-			}
-			var config TrustPolicy
-			err = yaml.Unmarshal(raw, &config)
-			if err != nil {
-				panic(err)
-			}
-
-			if config.Signature.Verify {
-				if provenance_signature != "" {
-					VerifySignature(provenance_file, provenance_signature, config.Signature)
-				} else {
-					fmt.Println("Trust policy requires verified signature, but no signature file was provided.")
-					os.Exit(1)
-				}
-			}
-
-			fmt.Println()
-			provenanceCheck(provenance_file, config)
-
-			return nil
+			return runProvenanceAction(cmd)
 		},
 	}
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
 	}
 }

--- a/pkgs/policy-checker/src/main.go
+++ b/pkgs/policy-checker/src/main.go
@@ -277,12 +277,40 @@ func releasePolicyInput(
 		testResults["configured"] = true
 	}
 
-	imagePath := filepath.Join(targetDir, stringAt(manifest, "image", "path"))
-	imageSignaturePath := filepath.Join(targetDir, stringAt(manifest, "image", "signature", "path"))
+	images := []any{}
+	rawImages, hasImages := manifest["images"]
+	if hasImages && rawImages != nil {
+		if imageList, ok := rawImages.([]any); ok {
+			images = imageList
+		}
+	} else if image, ok := manifest["image"]; ok {
+		images = []any{image}
+	}
+	imageExists := len(images) > 0
+	imageSignatureExists := len(images) > 0
+	imageSignaturesVerified := len(images) > 0
+	imageSignatureErrors := []string{}
+	for _, image := range images {
+		imagePath := filepath.Join(targetDir, stringAt(image, "path"))
+		imageSignaturePath := filepath.Join(targetDir, stringAt(image, "signature", "path"))
+		imageSignature := verifyFileSignature("image", imagePath, imageSignaturePath)
+
+		if !fileExists(imagePath) {
+			imageExists = false
+		}
+		if !fileExists(imageSignaturePath) {
+			imageSignatureExists = false
+		}
+		if verified, ok := imageSignature["verified"].(bool); !ok || !verified {
+			imageSignaturesVerified = false
+			if message, ok := imageSignature["error"].(string); ok && message != "" {
+				imageSignatureErrors = append(imageSignatureErrors, message)
+			}
+		}
+	}
 	provenancePath := filepath.Join(targetDir, stringAt(manifest, "attestations", "provenance", "path"))
 	provenanceSignaturePath := filepath.Join(targetDir, stringAt(manifest, "attestations", "provenance", "signature", "path"))
 
-	imageSignature := verifyFileSignature("image", imagePath, imageSignaturePath)
 	provenanceSignature := verifyFileSignature("provenance", provenancePath, provenanceSignaturePath)
 	provenance := map[string]any{}
 	if fileExists(provenancePath) {
@@ -309,8 +337,8 @@ func releasePolicyInput(
 		"provenance":   provenance,
 		"test_results": testResults,
 		"files": map[string]any{
-			"image":           fileExists(imagePath),
-			"image_signature": fileExists(imageSignaturePath),
+			"image":           imageExists,
+			"image_signature": imageSignatureExists,
 			"provenance":      fileExists(provenancePath),
 			"provenance_signature": fileExists(
 				provenanceSignaturePath,
@@ -320,7 +348,10 @@ func releasePolicyInput(
 			"sbom_spdx":      fileExists(sbomSPDX),
 		},
 		"signatures": map[string]any{
-			"image":      imageSignature,
+			"image": map[string]any{
+				"verified": imageSignaturesVerified,
+				"error":    strings.Join(imageSignatureErrors, "; "),
+			},
 			"provenance": provenanceSignature,
 		},
 		"provenance_policy": provenancePolicy,

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -24,6 +24,7 @@ BUCKET="${BUCKET:=ghaf-artifacts-dev}"
 ACCESS_KEY="${ACCESS_KEY:=}"
 SECRET_KEY="${SECRET_KEY:=}"
 OCI_REPOSITORY_PREFIX="${OCI_REPOSITORY_PREFIX:=registry.vedenemo.dev/ghaf/release-candidate}"
+REQUIRE_RELEASE_ATTESTATION="${REQUIRE_RELEASE_ATTESTATION:=true}"
 
 release_targets=(
   "packages.aarch64-linux.nvidia-jetson-orin-agx-debug"
@@ -214,6 +215,69 @@ verify_signatures() {
     print_err "  signature: $prov_sig"
     exit 1
   fi
+  verify_release_attestation "$dir"
+}
+
+expected_oci_digest() {
+  dir="$1"
+  if [[ -f "$dir/oci-reference" ]]; then
+    reference="$(<"$dir/oci-reference")"
+    if [[ $reference == *@* ]]; then
+      printf '%s\n' "${reference##*@}"
+      return
+    fi
+  fi
+  if [[ -f "$dir/oci-result.json" ]]; then
+    jq -re '.primary.digest | select(type == "string" and length > 0)' "$dir/oci-result.json"
+    return
+  fi
+  return 1
+}
+
+verify_release_attestation() {
+  dir="$1"
+  if [[ $REQUIRE_RELEASE_ATTESTATION != "true" ]]; then
+    echo "[+] Skipping release attestation verification"
+    return 0
+  fi
+
+  release_attestation="$dir/attestations/release-policy.json"
+  release_attestation_sig="$release_attestation.sig"
+  if [[ ! -f $release_attestation ]]; then
+    print_err "missing release policy attestation: $release_attestation"
+    exit 1
+  fi
+  if [[ ! -f $release_attestation_sig ]]; then
+    print_err "missing release policy attestation signature: $release_attestation_sig"
+    exit 1
+  fi
+
+  if ! verify-signature release "$release_attestation" "$release_attestation_sig"; then
+    print_err "failed verifying release policy attestation signature"
+    print_err "  attestation: $release_attestation"
+    print_err "  signature: $release_attestation_sig"
+    exit 1
+  fi
+
+  if ! jq -e '.predicate.passed == true' "$release_attestation" >/dev/null; then
+    print_err "release policy attestation did not pass: $release_attestation"
+    exit 1
+  fi
+
+  if ! digest="$(expected_oci_digest "$dir")"; then
+    print_err "missing or unreadable OCI digest metadata for release attestation: $dir"
+    exit 1
+  fi
+  if ! attested_digest="$(jq -re '.predicate.artifact.digest' "$release_attestation")"; then
+    print_err "release policy attestation is missing artifact digest: $release_attestation"
+    exit 1
+  fi
+  if [[ $attested_digest != "$digest" ]]; then
+    print_err "release policy attestation digest mismatch"
+    print_err "  expected: $digest"
+    print_err "  attested: $attested_digest"
+    exit 1
+  fi
 }
 
 pull_artifacts_from_oci() {
@@ -257,7 +321,6 @@ pull_artifacts_from_oci() {
       print_err "failed pulling OCI target: $resolved_reference"
       exit 1
     fi
-
     manifest="$target_dir/manifest.json"
     if [[ ! -f $manifest ]]; then
       print_err "missing manifest pulled from OCI reference: $resolved_reference"
@@ -350,7 +413,9 @@ prepare_artifacts() {
     if [[ -d "$dir/attestations" ]]; then
       ln -s "$dir/attestations" "$TMPDIR/$target_name/attestations"
     fi
-
+    if [[ -f "$dir/oci-result.json" ]]; then
+      ln -s "$dir/oci-result.json" "$TMPDIR/$target_name/oci-result.json"
+    fi
     # test-results output
     if [[ -d "$dir/test-results" ]]; then
       ln -s "$dir/test-results" "$TMPDIR/$target_name/test-results"
@@ -383,6 +448,18 @@ main() {
     NONE='\033[0m'
   fi
   argparse "$@"
+  case "${REQUIRE_RELEASE_ATTESTATION,,}" in
+  true | 1 | yes | y | on)
+    REQUIRE_RELEASE_ATTESTATION="true"
+    ;;
+  false | 0 | no | n | off)
+    REQUIRE_RELEASE_ATTESTATION="false"
+    ;;
+  *)
+    print_err "invalid REQUIRE_RELEASE_ATTESTATION value: '$REQUIRE_RELEASE_ATTESTATION' (expected true or false)"
+    exit 1
+    ;;
+  esac
   if [[ $DEBUG == "true" ]]; then set -x; fi
   trap on_exit EXIT
   exit_unless_command_exists mc

--- a/scripts/verify-signature.sh
+++ b/scripts/verify-signature.sh
@@ -9,10 +9,11 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") MODE ARTIFACT SIGNATURE
 
-Verify the signature of image or provenance file with the currently valid certificates.
+Verify the signature of image, provenance, or release attestation file with the
+currently valid certificates.
 
 Options:
-  MODE: either 'provenance' or 'image'.
+  MODE: either 'provenance', 'release', or 'image'.
   ARTIFACT: the original file to verify.
   SIGNATURE: the signature file to verify against.
 EOF
@@ -29,6 +30,13 @@ SIGNATURE=$3
 verify-provenance() {
   echo "Using certificate $PROV_CERT"
   openssl pkeyutl -verify -inkey "$PROV_CERT" -certin -sigfile "$SIGNATURE" -in "$ARTIFACT" -rawin
+}
+
+verify-release() {
+  # Release policy attestations are signed with the provenance signing key for now.
+  # Keep a separate mode so callers do not need to change if a dedicated release
+  # signing key is introduced later.
+  verify-provenance
 }
 
 verify-image() {
@@ -50,6 +58,12 @@ elif [[ $1 == "provenance" ]]; then
     exit 1
   fi
   verify-provenance
+elif [[ $1 == "release" ]]; then
+  if [[ -z $PROV_CERT ]]; then
+    echo 'Certificate PROV_CERT is not defined in the running environment!'
+    exit 1
+  fi
+  verify-release
 else
   usage
 fi

--- a/slsa/provenance-trust-policy.yaml
+++ b/slsa/provenance-trust-policy.yaml
@@ -3,6 +3,16 @@ signature:
   verify: true
 
 criteria:
+  - id: predicate-type-slsa-provenance-v1
+    description: Provenance predicate type is SLSA Provenance v1
+    required: true
+    cel: predicateType == 'https://slsa.dev/provenance/v1'
+
+  - id: build-type-ghaf-jenkins
+    description: Provenance build type is the Ghaf Jenkins Nix build type
+    required: true
+    cel: predicate.buildDefinition.buildType == 'https://github.com/tiiuae/ghaf-infra/blob/ea938e90/slsa/v1.0/L1/buildtype.md'
+
   - id: target-repo-ghaf
     description: Target repository is tiiuae/ghaf
     required: true

--- a/slsa/release-policy.yaml
+++ b/slsa/release-policy.yaml
@@ -1,0 +1,41 @@
+version: '1.0'
+name: Ghaf Release Policy
+uri: https://github.com/tiiuae/ghaf-infra/blob/main/slsa/release-policy.yaml
+
+criteria:
+  - id: release-builder
+    description: Artifact provenance identifies a release CI builder
+    required: true
+    cel: |
+      files.provenance &&
+      provenance.predicate.runDetails.builder.id in [
+        'https://ci-release.vedenemo.dev/',
+        'https://ci-release.uaenorth.cloudapp.azure.com/'
+      ]
+
+  - id: image-signature
+    description: Image signature exists and verifies successfully
+    required: true
+    cel: files.image && files.image_signature && signatures.image.verified
+
+  - id: provenance-signature
+    description: SLSA provenance signature exists and verifies successfully
+    required: true
+    cel: files.provenance && files.provenance_signature && signatures.provenance.verified
+
+  - id: provenance-policy
+    description: SLSA provenance satisfies the configured provenance trust policy
+    required: true
+    cel: provenance_policy.passed
+
+  - id: sbom-present
+    description: SBOM outputs are present
+    required: true
+    cel: files.sbom_csv && files.sbom_cyclonedx && files.sbom_spdx
+
+  - id: hardware-tests
+    description: Configured hardware tests completed successfully or were explicitly skipped
+    required: false
+    cel: |
+      !test_results.configured ||
+      test_results.tests.all(test, test.status in ['SUCCESS', 'SKIPPED'])


### PR DESCRIPTION
Run policy checker in release mode at the end of release candidate pipeline. It checks the items defined in release policy file and outputs a signed attestation file with fail/pass fields and relevant subject data.