### PR TITLE
tasks: Read updatable sops secret files straight from .sops.yaml

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -52,6 +52,7 @@
             python3.pkgs.invoke
             python3.pkgs.loguru
             python3.pkgs.pycodestyle
+            python3.pkgs.pyyaml
             python3.pkgs.pytest
             python3.pkgs.pylint
             python3.pkgs.tabulate

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -87,6 +87,7 @@
           pycodestyle
           pytest
           pylint
+          pyyaml
           requests
           tabulate
           urllib3

--- a/tasks.py
+++ b/tasks.py
@@ -32,6 +32,7 @@ import getpass
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import socket
@@ -48,6 +49,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any, TextIO
 
+import yaml
 from deploykit import DeployHost, HostKeyCheck
 from invoke.context import Context
 from invoke.tasks import task
@@ -233,6 +235,31 @@ def _run_json(cmd: list[str]) -> Any:
         _log_error(f"Command failed: {shlex.join(cmd)}\n{detail}")
         sys.exit(1)
     return json.loads(proc.stdout)
+
+
+def _sops_files_from_config(sops_config: Path) -> list[Path]:
+    """Return existing files matched by path_regex entries in a sops config."""
+    root = sops_config.parent
+    sops_data = yaml.safe_load(sops_config.read_text(encoding="utf-8"))
+    path_regexes = [
+        re.compile(rule["path_regex"])
+        for rule in sops_data["creation_rules"]
+        if "path_regex" in rule
+    ]
+
+    sops_files = []
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames[:] = [dirname for dirname in dirnames if dirname != ".git"]
+        for filename in filenames:
+            path = Path(current_root) / filename
+            relative_path = path.relative_to(root)
+            if any(
+                path_regex.search(relative_path.as_posix())
+                for path_regex in path_regexes
+            ):
+                sops_files.append(relative_path)
+
+    return sorted(sops_files)
 
 
 def _current_output_stream() -> TextIO:
@@ -790,19 +817,13 @@ def alias_list(_c: Context) -> None:
 @task
 def update_sops_files(c: Context) -> None:
     """
-    Update all sops yaml and json files according to .sops.yaml rules.
+    Update all sops files according to .sops.yaml rules.
 
     Example usage:
     inv update-sops-files
     """
-    c.run(
-        r"""
-find . \
-        -type f \
-        \( -iname '*.enc.json' -o -iname 'secrets.yaml' \) \
-        -exec sops updatekeys --yes {} \;
-"""
-    )
+    for sops_file in _sops_files_from_config(Path(".sops.yaml")):
+        c.run(f"sops updatekeys --yes {shlex.quote(sops_file.as_posix())}")
 
 
 @task

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -725,6 +725,95 @@ def test_decrypt_host_key_respects_yes_on_sops_failure(
     tasks._decrypt_host_key(target, str(tmp_path / "out"), yes=True)
 
 
+def test_sops_files_from_config_matches_existing_creation_rules(tmp_path: Path) -> None:
+    sops_config = tmp_path / ".sops.yaml"
+    sops_config.write_text(
+        "\n".join(
+            [
+                "keys:",
+                "  - &admin age1demo",
+                "creation_rules:",
+                "  - path_regex: hosts/testagent/credentials.yaml$",
+                "    key_groups:",
+                "      - age:",
+                "          - *admin",
+                "  - path_regex: 'services/nebula/ca\\.crt\\.crypt$'",
+                "    key_groups:",
+                "      - age:",
+                "          - *admin",
+                "  - path_regex: hosts/.*/secrets.yaml$",
+                "    key_groups:",
+                "      - age:",
+                "          - *admin",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    for path in [
+        "hosts/testagent/credentials.yaml",
+        "hosts/testagent/dev/secrets.yaml",
+        "services/nebula/ca.crt.crypt",
+        "services/nebula/ca.key.crypt",
+    ]:
+        secret = tmp_path / path
+        secret.parent.mkdir(parents=True, exist_ok=True)
+        secret.write_text("encrypted", encoding="utf-8")
+
+    assert tasks._sops_files_from_config(sops_config) == [
+        Path("hosts/testagent/credentials.yaml"),
+        Path("hosts/testagent/dev/secrets.yaml"),
+        Path("services/nebula/ca.crt.crypt"),
+    ]
+
+
+def test_update_sops_files_uses_sops_config_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    commands: list[str] = []
+
+    class FakeContext:
+        """Minimal invoke context stub that records commands."""
+
+        def run(self, command: str) -> None:
+            commands.append(command)
+
+    (tmp_path / ".sops.yaml").write_text(
+        "\n".join(
+            [
+                "keys:",
+                "  - &admin age1demo",
+                "creation_rules:",
+                "  - path_regex: hosts/testagent/credentials.yaml$",
+                "    key_groups:",
+                "      - age:",
+                "          - *admin",
+                "  - path_regex: services/nebula/ca.key.crypt$",
+                "    key_groups:",
+                "      - age:",
+                "          - *admin",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for path in [
+        "hosts/testagent/credentials.yaml",
+        "services/nebula/ca.key.crypt",
+        "hosts/testagent/dev/secrets.yaml",
+    ]:
+        secret = tmp_path / path
+        secret.parent.mkdir(parents=True, exist_ok=True)
+        secret.write_text("encrypted", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    tasks.update_sops_files.body(FakeContext())
+
+    assert commands == [
+        "sops updatekeys --yes hosts/testagent/credentials.yaml",
+        "sops updatekeys --yes services/nebula/ca.key.crypt",
+    ]
+
+
 def test_warn_and_confirm_exits_when_declined(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
`inv update-sops-files` currently updates only files which are named `secrets.yaml`.

We don't need to manually search for secret files, as they are all recorded in `.sops.yaml` internally. We can simply read the `path_regex` from there and use it to find all encrypted files. This allows `update-sops-files` to update every secret reliably.