### PR TITLE
Add capability for multiple images in pipeline

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -108,14 +108,11 @@ def create_pipeline(
         ts_begin: null,
         ts_finished: null,
       ],
-      image: [
-        path: null,
-        role: null,
-        signature: empty_signature(),
-      ],
+      images: [],
       uefi: [
         signed: false,
         reason: null,
+        image_path: null,
         signing_key: null,
         signing_proxy: null,
       ],
@@ -268,21 +265,34 @@ def create_pipeline(
           !target_config.no_image,
           "Find image ${build_shortname}"
         ) {
-          def img_path = artifactSupport.run_cmd(
-            "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit"
+          def img_paths = artifactSupport.run_cmd(
+            "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print | sort"
           )
-          if (!img_path) {
+          def images = img_paths.split('\n').findAll { it }
+          if (images.isEmpty()) {
             error("No image found!")
           }
-          manifest.image.path = img_path - "${output}/"
-          manifest.image.role = artifactSupport.image_role(manifest.image.path)
+          manifest.images = images.collect { img_path ->
+            def relpath = img_path - "${output}/"
+            [
+              path: relpath,
+              role: artifactSupport.image_role(relpath),
+              signature: empty_signature(),
+            ]
+          }
         }
         run_optional_stage(
           !target_config.no_image && signing_possible && target_config.uefi_sign_requested,
           "Sign (UEFI) ${build_shortname}"
         ) {
           def tmpdir = artifactSupport.build_tmpdir("uefisign-${build_shortname}")
-          def img_name = artifactSupport.path_basename(manifest.image.path)
+          def uefi_image = null
+          if (manifest.images.size() == 1) {
+            uefi_image = manifest.images[0]
+          } else {
+            error("UEFI signing for multi-image target ${build_shortname} is not implemented yet")
+          }
+          def img_name = artifactSupport.path_basename(uefi_image.path)
           def signer = build_target_name.contains("nvidia-jetson-orin") ? "uefisign-simple" : "uefisign"
 
           try {
@@ -295,15 +305,19 @@ def create_pipeline(
               sh """
                 ${signer} /etc/jenkins/keys/secboot/DB.pem \
                   "${ctx.uri}" \
-                  ${output}/${manifest.image.path} \
+                  ${output}/${uefi_image.path} \
                   '${tmpdir}'
               """
               record_signature(manifest.uefi, ctx)
             }
 
-            sh "mv '${tmpdir}/signed_${img_name}' '${output}/${img_name}'"
-            manifest.image.path = img_name
+            sh """
+              mkdir -p '${output}/images'
+              mv '${tmpdir}/signed_${img_name}' '${output}/images/${img_name}'
+            """
+            uefi_image.path = "images/${img_name}"
             manifest.uefi.signed = true
+            manifest.uefi.image_path = "images/${img_name}"
             manifest.uefi.reason = null
           } finally {
             sh "rm -rf '${tmpdir}'"
@@ -314,21 +328,28 @@ def create_pipeline(
           "Sign (SLSA) image ${build_shortname}"
         ) {
           withRedundancyRouter("GhafInfraSignECP256") { ctx ->
-            def img_name = artifactSupport.path_basename(manifest.image.path)
-            record_signature(manifest.image.signature, ctx, "${img_name}.sig")
-            sh """
-              openssl dgst -sha256 -sign \
-                "${ctx.uri}" \
-                -out ${output}/${manifest.image.signature.path} \
-                ${output}/${manifest.image.path}
-            """
+            sh "mkdir -p ${output}/images"
+            manifest.images.each { image ->
+              def img_name = artifactSupport.path_basename(image.path)
+              record_signature(image.signature, ctx, "images/${img_name}.sig")
+              sh """
+                openssl dgst -sha256 -sign \
+                  "${ctx.uri}" \
+                  -out ${output}/${image.signature.path} \
+                  ${output}/${image.path}
+              """
+            }
           }
         }
         stage("Link artifacts ${build_shortname}") {
-          if (manifest.image.path && !manifest.uefi.signed) {
-            def img_name = artifactSupport.path_basename(manifest.image.path)
-            sh "ln -s ${output}/${manifest.image.path} ${output}/${img_name}"
-            manifest.image.path = img_name
+          sh "mkdir -p ${output}/images"
+          manifest.images.each { image ->
+            def img_name = artifactSupport.path_basename(image.path)
+            def image_link = "images/${img_name}"
+            if (image.path && image.path != image_link) {
+              sh "ln -s ${output}/${image.path} ${output}/${image_link}"
+              image.path = image_link
+            }
           }
 
           write_manifest()
@@ -361,6 +382,9 @@ def create_pipeline(
       }
 
       if (!normalized_test_runs.isEmpty()) {
+        if (manifest.images.size() != 1) {
+          error("Multi-image hardware tests are not implemented for ${build_shortname}; found ${manifest.images.size()} images")
+        }
         def tests_completed = true
         try {
           def test_branches = [:]

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -189,6 +189,19 @@ def publish_referrer(
     return result
 
 
+def normalized_images(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return manifest images, accepting the legacy single-image field."""
+    images = manifest.get("images")
+    if images is None:
+        image = manifest.get("image")
+        images = [image] if image else []
+
+    if not isinstance(images, list) or not images:
+        fail("manifest must contain at least one image")
+
+    return images
+
+
 def create_test_results_archive(results_dir: Path, archive_path: Path) -> None:
     """Create a tar archive containing the test results."""
     if not results_dir.is_dir():
@@ -220,9 +233,7 @@ def publish_target_artifacts(
     manifest_path = target_dir / "manifest.json"
     result_reference_prefix = f"{primary_reference.rsplit(':', 1)[0]}@"
     target = manifest["target"]
-    image = manifest["image"]
-    image_path = image["path"]
-    image_signature = image["signature"]["path"]
+    images = normalized_images(manifest)
     source = manifest.get("source", {})
     primary_annotations = {
         "org.opencontainers.image.description": "Disk image",
@@ -233,9 +244,13 @@ def publish_target_artifacts(
         TARGET_ANNOTATION: target,
     }
 
-    push_files = [f"{image_path}:application/octet-stream"]
-    if image_signature:
-        push_files.append(f"{image_signature}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
+    push_files = []
+    for image in images:
+        image_path = image["path"]
+        image_signature = image["signature"]["path"]
+        push_files.append(f"{image_path}:application/octet-stream")
+        if image_signature:
+            push_files.append(f"{image_signature}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
 
     primary_output = run_oras(
         [

--- a/scripts/archive-ghaf-release.sh
+++ b/scripts/archive-ghaf-release.sh
@@ -163,22 +163,12 @@ verify_signatures() {
     print_err "missing manifest: $dir"
     exit 1
   fi
-  if ! img_rel=$(jq -re '.image.path' "$manifest"); then
-    print_err "missing image entry in manifest: $manifest"
+  if ! image_count=$(jq -re '(.images // (if .image then [.image] else [] end)) | length' "$manifest"); then
+    print_err "missing images entry in manifest: $manifest"
     exit 1
   fi
-  img="$dir/$img_rel"
-  if [[ -z $img_rel ]]; then
+  if [[ $image_count -eq 0 ]]; then
     print_err "missing image: $dir"
-    exit 1
-  fi
-  if ! img_sig_rel=$(jq -re '.image.signature.path' "$manifest"); then
-    print_err "missing image signature entry in manifest: $manifest"
-    exit 1
-  fi
-  img_sig="$dir/$img_sig_rel"
-  if [[ -z $img_sig_rel ]]; then
-    print_err "missing image signature: $dir"
     exit 1
   fi
   if ! prov_rel=$(jq -re '.attestations.provenance.path' "$manifest"); then
@@ -199,13 +189,25 @@ verify_signatures() {
     print_err "missing nix_build provenance signature: $dir"
     exit 1
   fi
-  echo "[+] Verifying: $img"
-  if ! verify-signature image "$img" "$img_sig"; then
-    print_err "failed verifying image signature"
-    print_err "  image: $img"
-    print_err "  signature: $img_sig"
-    exit 1
-  fi
+  while IFS=$'\t' read -r img_rel img_sig_rel; do
+    img="$dir/$img_rel"
+    if [[ -z $img_rel ]]; then
+      print_err "missing image: $dir"
+      exit 1
+    fi
+    img_sig="$dir/$img_sig_rel"
+    if [[ -z $img_sig_rel ]]; then
+      print_err "missing image signature: $dir"
+      exit 1
+    fi
+    echo "[+] Verifying: $img"
+    if ! verify-signature image "$img" "$img_sig"; then
+      print_err "failed verifying image signature"
+      print_err "  image: $img"
+      print_err "  signature: $img_sig"
+      exit 1
+    fi
+  done < <(jq -re '(.images // (if .image then [.image] else [] end))[] | [.path // "", .signature.path // ""] | @tsv' "$manifest")
   if ! verify-signature provenance "$prov" "$prov_sig"; then
     print_err "failed verifying provenance signature"
     print_err "  provenance: $prov"
@@ -327,18 +329,22 @@ prepare_artifacts() {
     mkdir -p "$TMPDIR/$target_name"
     ln -s "$manifest" "$TMPDIR/$target_name/manifest.json"
 
-    if ! image=$(jq -re '.image.path' "$manifest"); then
-      print_err "missing image entry in manifest: $manifest"
+    if ! image_count=$(jq -re '(.images // (if .image then [.image] else [] end)) | length' "$manifest"); then
+      print_err "missing images entry in manifest: $manifest"
       exit 1
     fi
-    if ! image_sig=$(jq -re '.image.signature.path' "$manifest"); then
-      print_err "missing image signature entry in manifest: $manifest"
+    if [[ $image_count -eq 0 ]]; then
+      print_err "missing image: $dir"
       exit 1
     fi
 
     # build output
-    ln -s "$dir/$image" "$TMPDIR/$target_name/$image"
-    ln -s "$dir/$image_sig" "$TMPDIR/$target_name/$image_sig"
+    while IFS=$'\t' read -r image image_sig; do
+      mkdir -p "$(dirname "$TMPDIR/$target_name/$image")"
+      mkdir -p "$(dirname "$TMPDIR/$target_name/$image_sig")"
+      ln -s "$dir/$image" "$TMPDIR/$target_name/$image"
+      ln -s "$dir/$image_sig" "$TMPDIR/$target_name/$image_sig"
+    done < <(jq -re '(.images // (if .image then [.image] else [] end))[] | [.path // "", .signature.path // ""] | @tsv' "$manifest")
 
     # attestations
     if [[ -d "$dir/attestations" ]]; then


### PR DESCRIPTION
Current single-image builds continue to behave like they do currently, but there is capability for multi-image targets in the future.
- `manifest.json` now has `images` array instead of a single `image` field.
- Images are moved under /images/ instead of target root.

> [!NOTE]
> HW tests and UEFI signing are not implemented for multi-image targets yet, will be added in future PRs once we have those targets stabilized, but it's out of scope for this PR.