### PR TITLE
hetzci: stop deleting config json files before tests

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -270,7 +270,6 @@ pipeline {
               env.FLASHED = 'false'
               sh """
                 mkdir -p ${TEST_CONFIG_DIR}
-                rm -f ${TEST_CONFIG_DIR}/*.json
                 ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
                 echo { \\\"Job\\\": \\\"${env.JOB_TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -257,7 +257,6 @@ pipeline {
               env.FLASHED = 'false'
               sh """
                 mkdir -p ${TEST_CONFIG_DIR}
-                rm -f ${TEST_CONFIG_DIR}/*.json
                 ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
                 echo { \\\"Job\\\": \\\"${env.JOB_TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
                 ls -la ${TEST_CONFIG_DIR}


### PR DESCRIPTION
Remove `rm -f ${TEST_CONFIG_DIR}/*.json` step from hw-test pipelines. `deleteDir()` already ensures that nothing is left over from previous runs, so this step was unnecessary.

This change allows json files to be added to the `ci-test-automation` config. Currently they are deleted before the test starts.