### PR TITLE
Use remote store for all nix builds

### DIFF
--- a/hosts/hetzci/dbg/configuration.nix
+++ b/hosts/hetzci/dbg/configuration.nix
@@ -65,7 +65,10 @@ in
   sops = {
     defaultSopsFile = ./secrets.yaml;
     secrets = {
-      vedenemo_builder_ssh_key.owner = "root";
+      vedenemo_builder_ssh_key = {
+        owner = "jenkins";
+        mode = "0400";
+      };
     };
   };
 
@@ -95,6 +98,7 @@ in
     buildMachines =
       let
         commonOptions = {
+          protocol = "ssh-ng";
           speedFactor = 10;
           supportedFeatures = [
             "kvm"

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -12,6 +12,24 @@
 let
   cfg = config.hetzci.jenkins;
 
+  remoteStoresFromBuildMachines = builtins.listToAttrs (
+    map (
+      builder:
+      let
+        sshKey = builder.sshKey or null;
+        sshUser = builder.sshUser or null;
+      in
+      {
+        name = builder.system;
+        value =
+          "${builder.protocol}://"
+          + (if sshUser == null then "" else "${sshUser}@")
+          + builder.hostName
+          + (if sshKey == null then "" else "&ssh-key=${sshKey}");
+      }
+    ) config.nix.buildMachines
+  );
+
   # copies only pipelines declared in cfg.pipelines
   filteredPipelines = pkgs.runCommand "pipelines" { } ''
     mkdir -p $out
@@ -263,6 +281,9 @@ in
         builtins.listToAttrs (map mkJenkinsPlugin manifest);
     };
 
+    # Jenkins needs to be trusted user to use nix build --store
+    nix.settings.trusted-users = [ "jenkins" ];
+
     # Caddy needs to be able to access files under /var/lib/jenkins/artifacts.
     # Use traverse-only access on JENKINS_HOME and scope group access to caddy.service.
     users.users.jenkins.homeMode = "710";
@@ -271,6 +292,7 @@ in
     environment.etc = lib.mkMerge [
       {
         "jenkins/nix-fast-build.sh".source = "${self.outPath}/scripts/nix-fast-build.sh";
+        "jenkins/remote-stores.json".text = builtins.toJSON remoteStoresFromBuildMachines;
         "jenkins/pipelines".source = filteredPipelines;
         "jenkins/pipeline-library".source = pipelineSharedLibrary;
         "jenkins/casc/common.yaml".source = ./casc/common.yaml;

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -167,11 +167,54 @@ def create_pipeline(
         stage("Build ${build_shortname}") {
           sh "mkdir -v -p ${output}"
 
-          manifest.build.ts_begin = artifactSupport.run_cmd('date +%s')
           lock(label: 'nix-build', quantity: 1) {
-            sh "nix build --fallback -v .#${build_target_name} --out-link ${output}/unsigned-output"
+            def system = build_target_name.tokenize('.')[1]
+            def remote_stores = readJSON file: '/etc/jenkins/remote-stores.json'
+            def remote_store = remote_stores[system]
+            if (!remote_store) {
+              error("No remote store configured for '${system}'")
+            }
+            def quoted_remote_store = artifactSupport.shell_quote(remote_store)
+
+            manifest.build.ts_begin = artifactSupport.run_cmd('date +%s')
+
+            def build_result = readJSON text: sh(
+              script: """
+                nix build \
+                  --fallback \
+                  --store ${quoted_remote_store} \
+                  --eval-store auto \
+                  --json \
+                  --no-link \
+                  .#${build_target_name}
+              """,
+              returnStdout: true
+            ).trim()
+
+            manifest.build.ts_finished = artifactSupport.run_cmd('date +%s')
+
+            def remote_store_path = build_result[0]?.outputs?.out
+            if (!remote_store_path) {
+              error("Unable to read output path from nix build JSON output")
+            }
+
+            // The SSH builder is trusted, but its local build outputs are not binary-cache signed
+            // so we need --no-check-sigs
+            sh """
+              nix copy \
+                --from ${quoted_remote_store} \
+                --no-check-sigs \
+                ${artifactSupport.shell_quote(remote_store_path)}
+            """
+
+            sh """
+              nix-store --add-root ${output}/unsigned-output \
+                --realise ${artifactSupport.shell_quote(remote_store_path)}
+            """
+
+            manifest.build.remote_store = remote_store
+            manifest.build.remote_output = remote_store_path
           }
-          manifest.build.ts_finished = artifactSupport.run_cmd('date +%s')
         }
         run_optional_stage(
           target_config.provenance_requested,

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -23,6 +23,9 @@ let
     cpus = 16;
     ramGiB = 30;
   };
+
+  x86BuilderSshKey = "/etc/ssh/certs/hetz86-rel-2-builder";
+  armBuilderSshKey = "/etc/ssh/certs/hetzarm-rel-1-builder";
 in
 {
   imports = [
@@ -84,12 +87,20 @@ in
   nix.settings.min-free = lib.mkOverride 60 controllerDisk.minFreeBytes;
   nix.settings.max-free = lib.mkOverride 60 controllerDisk.maxFreeBytes;
 
+  # install-release copies these generated private keys as root-owned extra files.
+  # Jenkins opens them directly through the remote-store ssh-key URI.
+  systemd.tmpfiles.rules = [
+    "z ${x86BuilderSshKey} 0400 jenkins root - -"
+    "z ${armBuilderSshKey} 0400 jenkins root - -"
+  ];
+
   # Configure (release) remote builders
   nix = {
     distributedBuilds = true;
     buildMachines =
       let
         commonOptions = {
+          protocol = "ssh-ng";
           supportedFeatures = [
             "kvm"
             "nixos-test"
@@ -107,7 +118,7 @@ in
             maxJobs = x86Builder.maxJobs;
             speedFactor = 12;
             sshUser = "hetz86-rel-2-builder";
-            sshKey = "/etc/ssh/certs/hetz86-rel-2-builder";
+            sshKey = x86BuilderSshKey;
           }
         )
         (
@@ -118,7 +129,7 @@ in
             maxJobs = armBuilder.maxJobs;
             speedFactor = 2;
             sshUser = "hetzarm-rel-1-builder";
-            sshKey = "/etc/ssh/certs/hetzarm-rel-1-builder";
+            sshKey = armBuilderSshKey;
           }
         )
       ];

--- a/hosts/hetzci/remote-builders.nix
+++ b/hosts/hetzci/remote-builders.nix
@@ -25,7 +25,10 @@ in
 {
   sops = {
     secrets = {
-      vedenemo_builder_ssh_key.owner = "root";
+      vedenemo_builder_ssh_key = {
+        owner = "jenkins";
+        mode = "0400";
+      };
     };
   };
 
@@ -34,6 +37,7 @@ in
     buildMachines =
       let
         commonOptions = {
+          protocol = "ssh-ng";
           speedFactor = 10;
           supportedFeatures = [
             "kvm"

--- a/hosts/uae/azureci/remote-builders.nix
+++ b/hosts/uae/azureci/remote-builders.nix
@@ -24,7 +24,10 @@ in
 {
   sops = {
     secrets = {
-      azureci_builder_ssh_key.owner = "root";
+      azureci_builder_ssh_key = {
+        owner = "jenkins";
+        mode = "0400";
+      };
     };
   };
 
@@ -33,6 +36,7 @@ in
     buildMachines =
       let
         commonOptions = {
+          protocol = "ssh-ng";
           speedFactor = 10;
           supportedFeatures = [
             "kvm"


### PR DESCRIPTION
Use the configured remote builders as remote nix stores for the main target builds. The build connects to the remote builder's nix-daemon over ssh. This avoids copying intermediate derivations back and forth, making builds faster. After the build, copy the final closure back.

Note that this requires making the ssh keys readable by the jenkins user.