### PR TITLE
Support OTA sysupdate targets in the Jenkins pipeline

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "sbsigntools": "sbsigntools"
       },
       "locked": {
-        "lastModified": 1783588271,
-        "narHash": "sha256-Ueqk5fBxxgNNf1hg0DydygnsBDKHNef2wsDkbUucALA=",
+        "lastModified": 1784198023,
+        "narHash": "sha256-kk0t63KRtRJqgOj21ILRgfWFWc0dqSRtDy/1oeotiKA=",
         "owner": "tiiuae",
         "repo": "ci-yubi",
-        "rev": "8fa154a538b3d4f58852ecf0ac29a81238dad17e",
+        "rev": "e10912acf7fd1cbe325c0cdf2e96952bf82a6692",
         "type": "github"
       },
       "original": {

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -172,8 +172,6 @@ def create_pipeline(
 
     if (target_config.no_image) {
       manifest.uefi.reason = "no_image"
-    } else if (is_sysupdate_target && target_config.uefi_sign_requested) {
-      manifest.uefi.reason = "sysupdate_efi_signing_not_implemented"
     } else if (!signing_possible) {
       manifest.uefi.reason = "signing_not_possible"
     } else if (!target_config.uefi_sign_requested) {
@@ -354,7 +352,7 @@ def create_pipeline(
             ['root', 'verity', 'kernel'].each { role ->
               images << [
                 path: "${output}/unsigned-output/${sysupdate_manifest[role].file}",
-                role: "sysupdate-${role}",
+                role: role,
               ]
             }
             manifest.images = images.collect { image ->
@@ -383,18 +381,20 @@ def create_pipeline(
           }
         }
         run_optional_stage(
-          !target_config.no_image && !is_sysupdate_target && signing_possible && target_config.uefi_sign_requested,
+          !target_config.no_image && signing_possible && target_config.uefi_sign_requested,
           "Sign (UEFI) ${build_shortname}"
         ) {
           def tmpdir = artifactSupport.build_tmpdir("uefisign-${build_shortname}")
           def uefi_image = null
-          if (manifest.images.size() == 1) {
+          if (!is_sysupdate_target && manifest.images.size() == 1) {
             uefi_image = manifest.images[0]
           } else {
-            error("UEFI signing for multi-image target ${build_shortname} is not implemented yet")
+            uefi_image = manifest.images.find { it.role == 'kernel' }
+            if (uefi_image == null) {
+              error("UEFI signing for multi-image target requires an image with role 'kernel'")
+            }
           }
           def img_name = artifactSupport.path_basename(uefi_image.path)
-          def signer = build_target_name.contains("nvidia-jetson-orin") ? "uefisign-simple" : "uefisign"
 
           try {
             sh """
@@ -402,20 +402,52 @@ def create_pipeline(
               mkdir -p '${tmpdir}'
             """
 
-            withRedundancyRouter("uefi-ghaf-db") { ctx ->
-              sh """
-                ${signer} /etc/jenkins/keys/secboot/DB.pem \
-                  "${ctx.uri}" \
-                  ${output}/${uefi_image.path} \
-                  '${tmpdir}'
-              """
-              record_signature(manifest.uefi, ctx)
-            }
+            if (is_sysupdate_target) {
+              def sysupdate_manifest_image = manifest.images.find { it.role == 'sysupdate-manifest' }
+              if (sysupdate_manifest_image == null) {
+                error("sysupdate manifest not found")
+              }
+              def sysupdate_manifest_name = artifactSupport.path_basename(sysupdate_manifest_image.path)
 
-            sh """
-              mkdir -p '${output}/images'
-              mv '${tmpdir}/signed_${img_name}' '${output}/images/${img_name}'
-            """
+              withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                sh """
+                  uefi-sign-sysupdate /etc/jenkins/keys/secboot/DB.pem \
+                    "${ctx.uri}" \
+                    '${output}/${uefi_image.path}' \
+                    '${tmpdir}/${img_name}'
+                """
+                record_signature(manifest.uefi, ctx)
+              }
+
+              sh """
+                uefi-sign-sysupdate rehash \
+                  '${tmpdir}/${img_name}' \
+                  '${output}/${sysupdate_manifest_image.path}' \
+                  '${tmpdir}/${sysupdate_manifest_name}'
+              """
+              sh """
+                mkdir -p '${output}/images'
+                mv '${tmpdir}/${img_name}' '${output}/images/${img_name}'
+                mv '${tmpdir}/${sysupdate_manifest_name}' '${output}/images/${sysupdate_manifest_name}'
+              """
+              sysupdate_manifest_image.path = "images/${sysupdate_manifest_name}"
+            } else {
+              def signer = build_target_name.contains("nvidia-jetson-orin") ? "uefisign-simple" : "uefisign"
+              withRedundancyRouter("uefi-ghaf-db") { ctx ->
+                sh """
+                  ${signer} /etc/jenkins/keys/secboot/DB.pem \
+                    "${ctx.uri}" \
+                    ${output}/${uefi_image.path} \
+                    '${tmpdir}'
+                """
+                record_signature(manifest.uefi, ctx)
+              }
+
+              sh """
+                mkdir -p '${output}/images'
+                mv '${tmpdir}/signed_${img_name}' '${output}/images/${img_name}'
+              """
+            }
             uefi_image.path = "images/${img_name}"
             manifest.uefi.signed = true
             manifest.uefi.image_path = "images/${img_name}"

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -86,7 +86,7 @@ def create_pipeline(
     }
     def build_target_name = target_config.target
     def build_shortname = target_config.shortname
-    def is_sysupdate_target = build_target_name.endsWith('-sysupdate')
+    def is_sysupdate_target = target_config.sysupdate
     def normalized_test_runs = target_config.test_runs
     def output = "${artifacts_local_dir}/${build_target_name}"
     def local_target_ref = "${ghaf_checkout}#${build_target_name}"

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -86,6 +86,7 @@ def create_pipeline(
     }
     def build_target_name = target_config.target
     def build_shortname = target_config.shortname
+    def is_sysupdate_target = build_target_name.endsWith('-sysupdate')
     def normalized_test_runs = target_config.test_runs
     def output = "${artifacts_local_dir}/${build_target_name}"
     def local_target_ref = "${ghaf_checkout}#${build_target_name}"
@@ -171,6 +172,8 @@ def create_pipeline(
 
     if (target_config.no_image) {
       manifest.uefi.reason = "no_image"
+    } else if (is_sysupdate_target && target_config.uefi_sign_requested) {
+      manifest.uefi.reason = "sysupdate_efi_signing_not_implemented"
     } else if (!signing_possible) {
       manifest.uefi.reason = "signing_not_possible"
     } else if (!target_config.uefi_sign_requested) {
@@ -342,24 +345,45 @@ def create_pipeline(
           !target_config.no_image,
           "Find image ${build_shortname}"
         ) {
-          def img_paths = artifactSupport.run_cmd(
-            "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print | sort"
-          )
-          def images = img_paths.split('\n').findAll { it }
-          if (images.isEmpty()) {
-            error("No image found!")
-          }
-          manifest.images = images.collect { img_path ->
-            def relpath = img_path - "${output}/"
-            [
-              path: relpath,
-              role: artifactSupport.image_role(relpath),
-              signature: empty_signature(),
-            ]
+          if (is_sysupdate_target) {
+            def sysupdate_manifest_path = artifactSupport.run_cmd(
+              "find -L ${output}/unsigned-output -maxdepth 1 -name '*.manifest' -print -quit"
+            )
+            def sysupdate_manifest = readJSON file: sysupdate_manifest_path
+            def images = [[path: sysupdate_manifest_path, role: 'sysupdate-manifest']]
+            ['root', 'verity', 'kernel'].each { role ->
+              images << [
+                path: "${output}/unsigned-output/${sysupdate_manifest[role].file}",
+                role: "sysupdate-${role}",
+              ]
+            }
+            manifest.images = images.collect { image ->
+              [
+                path: image.path - "${output}/",
+                role: image.role,
+                signature: empty_signature(),
+              ]
+            }
+          } else {
+            def img_paths = artifactSupport.run_cmd(
+              "find -L ${output}/unsigned-output -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print | sort"
+            )
+            def images = img_paths.split('\n').findAll { it }
+            if (images.isEmpty()) {
+              error("No image found!")
+            }
+            manifest.images = images.collect { img_path ->
+              def relpath = img_path - "${output}/"
+              [
+                path: relpath,
+                role: artifactSupport.image_role(relpath),
+                signature: empty_signature(),
+              ]
+            }
           }
         }
         run_optional_stage(
-          !target_config.no_image && signing_possible && target_config.uefi_sign_requested,
+          !target_config.no_image && !is_sysupdate_target && signing_possible && target_config.uefi_sign_requested,
           "Sign (UEFI) ${build_shortname}"
         ) {
           def tmpdir = artifactSupport.build_tmpdir("uefisign-${build_shortname}")
@@ -446,12 +470,13 @@ def create_pipeline(
             oci_tags << "${ci_env}-latest"
             def oci_alias_args = oci_tags.collect { "--tag '${it}'" }.join(" \\\n                ")
             def oci_alias_args_block = oci_alias_args ? " \\\n                ${oci_alias_args}" : ""
+            def oci_sysupdate_arg = is_sysupdate_target ? " \\\n                --sysupdate" : ""
             sh """
               oci-publish target \
                 --target-dir '${output}' \
                 --repository '${oci_repository}' \
                 --primary-tag '${immutable_tag}' \
-                --result-json '${oci_result_json}'${oci_alias_args_block}
+                --result-json '${oci_result_json}'${oci_sysupdate_arg}${oci_alias_args_block}
             """
             oci_result = readJSON file: oci_result_json
           }

--- a/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
@@ -580,6 +580,7 @@ def normalize_build_config(
   def normalized = shallow_copy_map(targetConfig)
   normalized.shortname = short_target_name(targetName)
   normalized.no_image = normalized.get('no_image', false)
+  normalized.sysupdate = normalized.get('sysupdate', false)
   def uefiSignRequested = normalized.get('uefisign', false) || normalized.get('uefisigniso', false)
   normalized.uefi_sign_requested = uefiSignRequested
   normalized.provenance_requested = normalized.get('provenance', true)

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -110,7 +110,7 @@ pipeline {
             }
             if (params.lenovo_x1_carbon_gen11_debug_sysupdate) {
               TARGETS.push(
-                [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate", uefisign: params.UEFISIGN, testset: params.TESTSET ])
+                [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate", sysupdate: true, uefisign: params.UEFISIGN, testset: params.TESTSET ])
             }
             if (params.dell_latitude_7230_debug) {
               TARGETS.push(

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -16,6 +16,7 @@ properties([
     booleanParam(name: 'doc', defaultValue: false, description: 'Build target packages.x86_64-linux.doc'),
     booleanParam(name: 'lenovo_x1_carbon_gen11_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug'),
     booleanParam(name: 'lenovo_x1_carbon_gen11_debug_installer', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer'),
+    booleanParam(name: 'lenovo_x1_carbon_gen11_debug_sysupdate', defaultValue: false, description: 'Build target packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate'),
     booleanParam(name: 'dell_latitude_7230_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7230-debug'),
     booleanParam(name: 'dell_latitude_7330_debug', defaultValue: false, description: 'Build target packages.x86_64-linux.dell-latitude-7330-debug'),
     booleanParam(name: 'nvidia_jetson_orin_agx_debug_from_x86_64', defaultValue: false, description: 'Build target packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64'),
@@ -106,6 +107,10 @@ pipeline {
             if (params.lenovo_x1_carbon_gen11_debug_installer) {
               TARGETS.push(
                 [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer", uefisigniso: params.UEFISIGN, testset: params.TESTSET ])
+            }
+            if (params.lenovo_x1_carbon_gen11_debug_sysupdate) {
+              TARGETS.push(
+                [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate", uefisign: params.UEFISIGN, testset: params.TESTSET ])
             }
             if (params.dell_latitude_7230_debug) {
               TARGETS.push(

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -78,6 +78,9 @@ def TARGETS = [
   [ target: "packages.x86_64-linux.intel-laptop-storeDisk-debug",
     testset: null, sbom: true,
   ],
+  [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate",
+    uefisign: true, sbom: true,
+  ],
 ]
 
 pipeline {

--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -79,7 +79,7 @@ def TARGETS = [
     testset: null, sbom: true,
   ],
   [ target: "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate",
-    uefisign: true, sbom: true,
+    sysupdate: true, uefisign: true, sbom: true,
   ],
 ]
 

--- a/hosts/hetzci/signing.nix
+++ b/hosts/hetzci/signing.nix
@@ -58,6 +58,7 @@ let
       uefisign
       uefisigniso
       uefisign-simple
+      uefi-sign-sysupdate
     ])
     ++ (with self.packages.${pkgs.stdenv.hostPlatform.system}; [
       verify-signature

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -109,23 +109,6 @@ def annotation_args(annotations: dict[str, str]) -> list[str]:
     ]
 
 
-@contextmanager
-def staged_oci_layers(
-    target_dir: Path, files: list[tuple[str, str]]
-) -> Iterator[tuple[Path, list[str]]]:
-    """Stage layer inputs so ORAS records normalized layer paths."""
-    with tempfile.TemporaryDirectory(prefix="oci-layers-") as staging_dir_name:
-        staging_dir = Path(staging_dir_name)
-        push_files = []
-        for relpath, media_type in files:
-            layer_path = relpath.removeprefix("images/")
-            link_path = staging_dir / layer_path
-            link_path.parent.mkdir(parents=True, exist_ok=True)
-            link_path.symlink_to(target_dir / relpath)
-            push_files.append(f"{layer_path}:{media_type}")
-        yield staging_dir, push_files
-
-
 def normalize_repository(repository: str) -> str:
     """Normalize and validate an OCI repository path."""
     normalized = repository.strip().lower()
@@ -345,30 +328,29 @@ def publish_target_artifacts(
         TARGET_ANNOTATION: target,
     }
 
-    layer_files = []
+    push_files = []
     for image in images:
         image_path = image["path"]
         image_signature = image["signature"]["path"]
-        layer_files.append((image_path, "application/octet-stream"))
+        push_files.append(f"{image_path}:application/octet-stream")
         if image_signature:
-            layer_files.append((image_signature, DETACHED_SIGNATURE_MEDIA_TYPE))
+            push_files.append(f"{image_signature}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
 
-    with staged_oci_layers(target_dir, layer_files) as (staging_dir, push_files):
-        primary_output = run_oras(
-            [
-                "push",
-                *common_args,
-                *annotation_args(primary_annotations),
-                "--disable-path-validation",
-                "--artifact-type",
-                TARGET_ARTIFACT_TYPE,
-                "--config",
-                f"{manifest_path}:{TARGET_CONFIG_MEDIA_TYPE}",
-                primary_reference,
-                *push_files,
-            ],
-            cwd=staging_dir,
-        )
+    primary_output = run_oras(
+        [
+            "push",
+            *common_args,
+            *annotation_args(primary_annotations),
+            "--disable-path-validation",
+            "--artifact-type",
+            TARGET_ARTIFACT_TYPE,
+            "--config",
+            f"{manifest_path}:{TARGET_CONFIG_MEDIA_TYPE}",
+            primary_reference,
+            *push_files,
+        ],
+        cwd=target_dir,
+    )
     primary_digest = primary_output["digest"]
 
     referrers = publish_attestations(
@@ -440,33 +422,32 @@ def publish_sysupdate_artifacts(
         "org.ghaf.ota.system": sysupdate_manifest.get("system", ""),
     }
 
-    layer_files = []
+    push_files = []
     if sysupdate_manifest_signature_path:
-        layer_files.append(
-            (sysupdate_manifest_signature_path, DETACHED_SIGNATURE_MEDIA_TYPE)
+        push_files.append(
+            f"{sysupdate_manifest_signature_path}:{DETACHED_SIGNATURE_MEDIA_TYPE}"
         )
     for file in files:
-        layer_files.append((file["path"], file["media_type"]))
+        push_files.append(f"{file['path']}:{file['media_type']}")
         signature_path = file.get("signature_path")
         if signature_path:
-            layer_files.append((signature_path, DETACHED_SIGNATURE_MEDIA_TYPE))
+            push_files.append(f"{signature_path}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
 
-    with staged_oci_layers(target_dir, layer_files) as (staging_dir, push_files):
-        primary_output = run_oras(
-            [
-                "push",
-                *common_args,
-                *annotation_args(annotations),
-                "--disable-path-validation",
-                "--artifact-type",
-                SYSUPDATE_MANIFEST_MEDIA_TYPE,
-                "--config",
-                f"{target_dir / sysupdate_manifest_path}:{SYSUPDATE_MANIFEST_MEDIA_TYPE}",
-                primary_reference,
-                *push_files,
-            ],
-            cwd=staging_dir,
-        )
+    primary_output = run_oras(
+        [
+            "push",
+            *common_args,
+            *annotation_args(annotations),
+            "--disable-path-validation",
+            "--artifact-type",
+            SYSUPDATE_MANIFEST_MEDIA_TYPE,
+            "--config",
+            f"{target_dir / sysupdate_manifest_path}:{SYSUPDATE_MANIFEST_MEDIA_TYPE}",
+            primary_reference,
+            *push_files,
+        ],
+        cwd=target_dir,
+    )
     primary_digest = primary_output["digest"]
 
     referrers = publish_attestations(

--- a/pkgs/oci-publish/src/oci_publish.py
+++ b/pkgs/oci-publish/src/oci_publish.py
@@ -27,6 +27,15 @@ TARGET_CONFIG_MEDIA_TYPE = "application/vnd.ghaf.manifest.v1+json"
 TEST_RESULTS_ARTIFACT_TYPE = "application/vnd.ghaf.test-results.v1"
 TEST_RESULTS_MEDIA_TYPE = "application/x-tar"
 RELEASE_ATTESTATION_ARTIFACT_TYPE = "application/vnd.ghaf.release-attestation.v1+json"
+SYSUPDATE_MANIFEST_MEDIA_TYPE = "application/vnd.ghaf.ota.manifest.v1+json"
+SYSUPDATE_KERNEL_MEDIA_TYPE = "application/vnd.ghaf.ota.uki.v1+efi"
+SYSUPDATE_ROOT_MEDIA_TYPE = "application/vnd.ghaf.ota.root.v1+raw"
+SYSUPDATE_VERITY_MEDIA_TYPE = "application/vnd.ghaf.ota.verity.v1+raw"
+SYSUPDATE_MEDIA_TYPES = {
+    "root": SYSUPDATE_ROOT_MEDIA_TYPE,
+    "verity": SYSUPDATE_VERITY_MEDIA_TYPE,
+    "kernel": SYSUPDATE_KERNEL_MEDIA_TYPE,
+}
 REFERRER_MEDIA_TYPES = {
     "provenance": "application/vnd.in-toto+json",
     "release_policy": RELEASE_ATTESTATION_ARTIFACT_TYPE,
@@ -100,6 +109,23 @@ def annotation_args(annotations: dict[str, str]) -> list[str]:
     ]
 
 
+@contextmanager
+def staged_oci_layers(
+    target_dir: Path, files: list[tuple[str, str]]
+) -> Iterator[tuple[Path, list[str]]]:
+    """Stage layer inputs so ORAS records normalized layer paths."""
+    with tempfile.TemporaryDirectory(prefix="oci-layers-") as staging_dir_name:
+        staging_dir = Path(staging_dir_name)
+        push_files = []
+        for relpath, media_type in files:
+            layer_path = relpath.removeprefix("images/")
+            link_path = staging_dir / layer_path
+            link_path.parent.mkdir(parents=True, exist_ok=True)
+            link_path.symlink_to(target_dir / relpath)
+            push_files.append(f"{layer_path}:{media_type}")
+        yield staging_dir, push_files
+
+
 def normalize_repository(repository: str) -> str:
     """Normalize and validate an OCI repository path."""
     normalized = repository.strip().lower()
@@ -117,15 +143,16 @@ def normalize_repository(repository: str) -> str:
 
 
 @contextmanager
-def oras_common_args(
-    registry: str, username: str, password: str
-) -> Iterator[list[str]]:
-    """Return ORAS auth arguments and keep temporary registry config alive."""
+def oras_publish_context() -> Iterator[tuple[list[str], str, bool]]:
+    """Return ORAS arguments and reference mode, keeping auth config alive."""
     layout_path = os.environ.get("OCI_LAYOUT_PATH", "")
     if layout_path:
-        yield ["--oci-layout-path", layout_path]
+        yield ["--oci-layout-path", layout_path], "", False
         return
 
+    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
+    username = os.environ.get("OCI_USERNAME", "jenkins")
+    password = os.environ.get("OCI_PASSWORD", "")
     if not password:
         fail("OCI_PASSWORD is required when publishing to the registry")
 
@@ -147,7 +174,7 @@ def oras_common_args(
             stdin_text=f"{password}\n",
         )
 
-        yield ["--registry-config", str(registry_config)]
+        yield ["--registry-config", str(registry_config)], f"{registry}/", True
 
 
 def publish_referrer(
@@ -192,6 +219,38 @@ def publish_referrer(
     return result
 
 
+def publish_attestations(
+    *,
+    manifest: dict[str, Any],
+    common_args: list[str],
+    subject_reference: str,
+    target_dir: Path,
+) -> dict[str, Any]:
+    """Attach attestation referrers declared in the build manifest."""
+    referrers: dict[str, Any] = {}
+    attestations = manifest["attestations"]
+    for role in ("provenance", "sbom_cyclonedx", "sbom_spdx", "sbom_csv"):
+        relpath = attestations[role]["path"]
+        if not relpath:
+            continue
+
+        signature_relpath = None
+        signature = attestations[role].get("signature")
+        if signature:
+            signature_relpath = attestations[role]["signature"]["path"]
+
+        referrers[role] = publish_referrer(
+            common_args=common_args,
+            subject_reference=subject_reference,
+            target_dir=target_dir,
+            role=role,
+            relpath=relpath,
+            signature_relpath=signature_relpath,
+        )
+
+    return referrers
+
+
 def normalized_images(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     """Return manifest images, accepting the legacy single-image field."""
     images = manifest.get("images")
@@ -203,6 +262,45 @@ def normalized_images(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         fail("manifest must contain at least one image")
 
     return images
+
+
+def parse_sysupdate_artifacts(
+    *, manifest: dict[str, Any], target_dir: Path
+) -> tuple[dict[str, Any], str, str | None, list[dict[str, str]]]:
+    """Parse signed sysupdate image entries and return OCI file entries."""
+    images = normalized_images(manifest)
+    sysupdate_manifest_image = next(
+        image
+        for image in images
+        if image.get("role") == "sysupdate-manifest"
+        or image["path"].endswith(".manifest")
+    )
+    sysupdate_manifest_path = sysupdate_manifest_image["path"]
+    sysupdate_manifest = read_json(target_dir / sysupdate_manifest_path)
+    sysupdate_manifest_signature_path = sysupdate_manifest_image.get(
+        "signature", {}
+    ).get("path")
+
+    images_by_name = {Path(image["path"]).name: image for image in images}
+    files = []
+    for role in ("kernel", "root", "verity"):
+        image = images_by_name[sysupdate_manifest[role]["file"]]
+        file_entry = {
+            "role": role,
+            "path": image["path"],
+            "media_type": SYSUPDATE_MEDIA_TYPES[role],
+        }
+        signature_relpath = image.get("signature", {}).get("path")
+        if signature_relpath:
+            file_entry["signature_path"] = signature_relpath
+        files.append(file_entry)
+
+    return (
+        sysupdate_manifest,
+        sysupdate_manifest_path,
+        sysupdate_manifest_signature_path,
+        files,
+    )
 
 
 def create_test_results_archive(results_dir: Path, archive_path: Path) -> None:
@@ -247,56 +345,42 @@ def publish_target_artifacts(
         TARGET_ANNOTATION: target,
     }
 
-    push_files = []
+    layer_files = []
     for image in images:
         image_path = image["path"]
         image_signature = image["signature"]["path"]
-        push_files.append(f"{image_path}:application/octet-stream")
+        layer_files.append((image_path, "application/octet-stream"))
         if image_signature:
-            push_files.append(f"{image_signature}:{DETACHED_SIGNATURE_MEDIA_TYPE}")
+            layer_files.append((image_signature, DETACHED_SIGNATURE_MEDIA_TYPE))
 
-    primary_output = run_oras(
-        [
-            "push",
-            *common_args,
-            *annotation_args(primary_annotations),
-            "--disable-path-validation",
-            "--artifact-type",
-            TARGET_ARTIFACT_TYPE,
-            "--config",
-            f"{manifest_path}:{TARGET_CONFIG_MEDIA_TYPE}",
-            primary_reference,
-            *push_files,
-        ],
-        cwd=target_dir,
-    )
+    with staged_oci_layers(target_dir, layer_files) as (staging_dir, push_files):
+        primary_output = run_oras(
+            [
+                "push",
+                *common_args,
+                *annotation_args(primary_annotations),
+                "--disable-path-validation",
+                "--artifact-type",
+                TARGET_ARTIFACT_TYPE,
+                "--config",
+                f"{manifest_path}:{TARGET_CONFIG_MEDIA_TYPE}",
+                primary_reference,
+                *push_files,
+            ],
+            cwd=staging_dir,
+        )
     primary_digest = primary_output["digest"]
 
-    attestations = manifest["attestations"]
-
-    referrers: dict[str, Any] = {}
-    for role in ("provenance", "sbom_cyclonedx", "sbom_spdx", "sbom_csv"):
-        relpath = attestations[role]["path"]
-        if not relpath:
-            continue
-
-        signature_relpath = None
-        signature = attestations[role].get("signature")
-        if signature:
-            signature_relpath = attestations[role]["signature"]["path"]
-
-        referrers[role] = publish_referrer(
-            common_args=common_args,
-            subject_reference=(
-                f"{result_reference_prefix}{primary_digest}"
-                if subject_uses_digest
-                else primary_reference
-            ),
-            target_dir=target_dir,
-            role=role,
-            relpath=relpath,
-            signature_relpath=signature_relpath,
-        )
+    referrers = publish_attestations(
+        manifest=manifest,
+        common_args=common_args,
+        subject_reference=(
+            f"{result_reference_prefix}{primary_digest}"
+            if subject_uses_digest
+            else primary_reference
+        ),
+        target_dir=target_dir,
+    )
 
     if tags:
         run_command(["oras", "tag", *common_args, primary_reference, *tags])
@@ -322,6 +406,113 @@ def publish_target_artifacts(
     return 0
 
 
+def publish_sysupdate_artifacts(
+    *,
+    manifest: dict[str, Any],
+    target_dir: Path,
+    result_json: Path,
+    repository: str,
+    common_args: list[str],
+    primary_reference: str,
+    primary_tag: str,
+    tags: list[str],
+    subject_uses_digest: bool,
+) -> int:
+    """Publish sysupdate artifacts, referrers, and result metadata."""
+    result_reference_prefix = f"{primary_reference.rsplit(':', 1)[0]}@"
+    target = manifest["target"]
+    source = manifest.get("source", {})
+    (
+        sysupdate_manifest,
+        sysupdate_manifest_path,
+        sysupdate_manifest_signature_path,
+        files,
+    ) = parse_sysupdate_artifacts(manifest=manifest, target_dir=target_dir)
+
+    annotations = {
+        "org.opencontainers.image.description": "OTA update",
+        "org.opencontainers.image.title": target,
+        "org.opencontainers.image.source": source.get("repository", ""),
+        "org.opencontainers.image.revision": source.get("revision", ""),
+        SOURCE_REF_ANNOTATION: source.get("flake_ref", ""),
+        TARGET_ANNOTATION: target,
+        "org.ghaf.ota.version": sysupdate_manifest.get("version", ""),
+        "org.ghaf.ota.system": sysupdate_manifest.get("system", ""),
+    }
+
+    layer_files = []
+    if sysupdate_manifest_signature_path:
+        layer_files.append(
+            (sysupdate_manifest_signature_path, DETACHED_SIGNATURE_MEDIA_TYPE)
+        )
+    for file in files:
+        layer_files.append((file["path"], file["media_type"]))
+        signature_path = file.get("signature_path")
+        if signature_path:
+            layer_files.append((signature_path, DETACHED_SIGNATURE_MEDIA_TYPE))
+
+    with staged_oci_layers(target_dir, layer_files) as (staging_dir, push_files):
+        primary_output = run_oras(
+            [
+                "push",
+                *common_args,
+                *annotation_args(annotations),
+                "--disable-path-validation",
+                "--artifact-type",
+                SYSUPDATE_MANIFEST_MEDIA_TYPE,
+                "--config",
+                f"{target_dir / sysupdate_manifest_path}:{SYSUPDATE_MANIFEST_MEDIA_TYPE}",
+                primary_reference,
+                *push_files,
+            ],
+            cwd=staging_dir,
+        )
+    primary_digest = primary_output["digest"]
+
+    referrers = publish_attestations(
+        manifest=manifest,
+        common_args=common_args,
+        subject_reference=(
+            f"{result_reference_prefix}{primary_digest}"
+            if subject_uses_digest
+            else primary_reference
+        ),
+        target_dir=target_dir,
+    )
+
+    if tags:
+        run_command(["oras", "tag", *common_args, primary_reference, *tags])
+
+    result = {
+        "target": target,
+        "repository": repository,
+        "primary_tag": primary_tag,
+        "primary": {
+            "artifact_type": SYSUPDATE_MANIFEST_MEDIA_TYPE,
+            "media_type": primary_output["mediaType"],
+            "digest": primary_digest,
+            "reference": f"{result_reference_prefix}{primary_digest}",
+            "tag_reference": primary_reference,
+        },
+        "sysupdate": {
+            "version": sysupdate_manifest.get("version"),
+            "system": sysupdate_manifest.get("system"),
+            "root_verity_hash": sysupdate_manifest.get("root_verity_hash"),
+            "manifest_path": sysupdate_manifest_path,
+            "files": files,
+        },
+        "referrers": referrers,
+        "tags": tags,
+    }
+    write_json(result_json, result)
+
+    print(
+        f"[+] Published {target} sysupdate as {result_reference_prefix}{primary_digest}"
+    )
+    print(f"[+] Wrote publish result: {result_json}")
+    return 0
+
+
 def publish_target(args: argparse.Namespace) -> int:
     """Publish one target artifact and its referrers."""
     target_dir = Path(args.target_dir).expanduser().resolve()
@@ -334,17 +525,16 @@ def publish_target(args: argparse.Namespace) -> int:
     manifest = read_json(manifest_path)
     repository = normalize_repository(args.repository)
 
-    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
-    username = os.environ.get("OCI_USERNAME", "jenkins")
-    password = os.environ.get("OCI_PASSWORD", "")
-    with oras_common_args(registry, username, password) as common_args:
-        if os.environ.get("OCI_LAYOUT_PATH", ""):
-            primary_reference = f"{repository}:{args.primary_tag}"
-            subject_uses_digest = False
-        else:
-            primary_reference = f"{registry}/{repository}:{args.primary_tag}"
-            subject_uses_digest = True
-        return publish_target_artifacts(
+    with oras_publish_context() as (
+        common_args,
+        reference_prefix,
+        subject_uses_digest,
+    ):
+        primary_reference = f"{reference_prefix}{repository}:{args.primary_tag}"
+        publish_artifacts = (
+            publish_sysupdate_artifacts if args.sysupdate else publish_target_artifacts
+        )
+        return publish_artifacts(
             manifest=manifest,
             target_dir=target_dir,
             result_json=result_json,
@@ -361,10 +551,11 @@ def publish_test_results(args: argparse.Namespace) -> int:
     """Publish test results as a referrer attached to a target artifact."""
     results_dir = Path(args.results_dir).expanduser().resolve()
 
-    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
-    username = os.environ.get("OCI_USERNAME", "jenkins")
-    password = os.environ.get("OCI_PASSWORD", "")
-    with oras_common_args(registry, username, password) as common_args:
+    with oras_publish_context() as (
+        common_args,
+        _reference_prefix,
+        _subject_uses_digest,
+    ):
         with tempfile.TemporaryDirectory(prefix="oci-test-results-") as archive_dir:
             archive_path = Path(archive_dir) / "test-results.tar"
             create_test_results_archive(results_dir, archive_path)
@@ -397,10 +588,11 @@ def publish_release_attestation(args: argparse.Namespace) -> int:
     relpath = "attestations/release-policy.json"
     signature_relpath = "attestations/release-policy.json.sig"
 
-    registry = os.environ.get("OCI_REGISTRY", "registry.vedenemo.dev")
-    username = os.environ.get("OCI_USERNAME", "jenkins")
-    password = os.environ.get("OCI_PASSWORD", "")
-    with oras_common_args(registry, username, password) as common_args:
+    with oras_publish_context() as (
+        common_args,
+        _reference_prefix,
+        _subject_uses_digest,
+    ):
         result = publish_referrer(
             common_args=common_args,
             subject_reference=args.subject_reference,
@@ -428,6 +620,11 @@ def build_parser() -> argparse.ArgumentParser:
     target_parser.add_argument("--primary-tag", required=True)
     target_parser.add_argument("-o", "--result-json", required=True)
     target_parser.add_argument("-t", "--tag", action="append", default=[], dest="tags")
+    target_parser.add_argument(
+        "--sysupdate",
+        action="store_true",
+        help="publish target as a sysupdate artifact",
+    )
     target_parser.set_defaults(handler=publish_target)
 
     test_results_parser = subparsers.add_parser(


### PR DESCRIPTION
- Add `packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-sysupdate` to manual and nightly pipelines.
- Implement the custom OCI artifact format required by ghaf's `ota-update` tooling under `--sysupdate` flag on our `oci-upload` script.
- Implement UEFI signing for the kernel image https://github.com/tiiuae/ci-yubi/pull/58, and rehashing of the sysupdate manifest.