### PR TITLE
jenkins: retry transient ORAS pulls

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/artifactSupport.groovy
+++ b/hosts/hetzci/pipeline-library/vars/artifactSupport.groovy
@@ -21,9 +21,24 @@ def oci_annotations(String reference) {
 }
 
 def oras_pull_json(String reference, String outputDir) {
-  return readJSON(
-    text: run_cmd("oras pull --format json -o '${outputDir}' '${reference}'")
-  )
+  def pullResult = null
+  retry(3) {
+    def pullDir = "${outputDir}/oras-pull-${UUID.randomUUID()}"
+    def quotedPullDir = shell_quote(pullDir)
+    def quotedReference = shell_quote(reference)
+    echo "Pulling OCI artifact '${reference}' into ${pullDir}"
+    sh "rm -rf ${quotedPullDir} && mkdir -p ${quotedPullDir}"
+    try {
+      pullResult = readJSON(
+        text: run_cmd("oras pull --format json -o ${quotedPullDir} ${quotedReference}")
+      )
+    } catch (err) {
+      echo "ORAS pull failed for '${reference}', removing partial output from ${pullDir}"
+      sh "rm -rf ${quotedPullDir} || true"
+      throw err
+    }
+  }
+  return pullResult
 }
 
 @NonCPS


### PR DESCRIPTION
## Summary

  Retry transient oras pull failures in Jenkins hw-test pipelines.

  ## What changed

  Updated artifactSupport.oras_pull_json() to:

  - retry oras pull up to 3 times
  - use a fresh per-attempt output directory
  - remove partial output before retrying

  ## Why

  We have seen intermittent OCI download failures in Jenkins with errors like:

  failed to copy content ... copy failed: unexpected EOF

  Before this change, a single transient pull failure failed the whole job immediately.

  ## Risk / rollback

  Low risk and limited to OCI download handling in Jenkins hw-test jobs.

  Rollback: revert this commit.

  ## Validation

  - groovy-jenkins-tests passed
  - groovyc passed
