### PR TITLE
Introduce jenkins access control for auth

### DIFF
--- a/hosts/hetzci/casc/auth.yaml
+++ b/hosts/hetzci/casc/auth.yaml
@@ -15,6 +15,17 @@ jenkins:
             name: testagents
             permissions:
               - Agent/Connect
+        - group:
+            name: 'tiiuae:ci-dev-admins'
+            permissions:
+              - Overall/Read
+              - Overall/SystemRead
+              - Job/Build
+              - Job/Cancel
+              - Job/Read
+              - Job/Configure
+              - Run/Replay
+              - Run/Update
   securityRealm:
     reverseProxy:
       customLogOutUrl: /oauth2/sign_out


### PR DESCRIPTION
This is the initial implementation of the wider access groups to be created.
A group was created in github for ci-dev partial admin operations. And roles defined in jenkins auth for the group.
The access avoids disruptive permissions to avoid any issues.