### PR TITLE
Prevent 'switch' deployment over nixos release boundary

### DIFF
--- a/docs/deploy-rs.md
+++ b/docs/deploy-rs.md
@@ -44,6 +44,7 @@ Running just `deploy` without any arguments will deploy every host defined in th
 Do not use a normal deploy with immediate activation ('switch') when the target host is still running a different NixOS release than the configuration being deployed, for example `25.11 -> 26.05`.
 
 Those upgrades can fail during activation while reloading systemd user units.
+The shared host module therefore adds a `system.switch.inhibitors.nixos-release` guard so the switch is refused before activation starts.
 
 Use a boot deployment instead:
 

--- a/modules/common/nix.nix
+++ b/modules/common/nix.nix
@@ -72,6 +72,11 @@ in
     Restart = "on-failure";
   };
 
+  # Direct `switch` deployments across NixOS release boundaries can fail during
+  # user-unit activation. Require a `boot` deployment followed by a reboot
+  # instead of switching releases on a running system.
+  system.switch.inhibitors.nixos-release = config.system.nixos.release;
+
   systemd.services.trim-profiles = {
     description = "Delete older profiles";
     serviceConfig.Type = "oneshot";


### PR DESCRIPTION
Inhibit 'switch' deployment over release boundary, to have a clear error message when one tries that, instead of some mysterious failure.