### PR TITLE
Allow unsafe checkout after actions/checkout v7

### DIFF
--- a/.github/workflows/test-ghaf-infra.yml
+++ b/.github/workflows/test-ghaf-infra.yml
@@ -63,6 +63,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - name: Install nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       - name: Add builders to ssh_known_hosts


### PR DESCRIPTION
checkout v7 includes this change https://github.com/actions/checkout/pull/2454 but we can accept the risks because we have the authorize step