### PR TITLE
Limit Hetzner Cloud GRUB generations

### DIFF
--- a/hosts/hetzner-cloud.nix
+++ b/hosts/hetzner-cloud.nix
@@ -34,6 +34,7 @@ in
     loader.grub = {
       efiSupport = true;
       efiInstallAsRemovable = true;
+      configurationLimit = 3;
     };
   };
 


### PR DESCRIPTION
Hetzner Cloud hosts use a 256 MiB EFI System Partition mounted at /boot. Recent kernel and initrd pairs are large enough that a few extra boot entries can push the partition below the alert threshold.

Before this change, profile cleanup and bootloader retention used different limits. The common trim-profiles service kept three system generations, but GRUB still used its default configurationLimit of
100. That allowed old profile links to be removed while GRUB kept stale menu entries and the kernel files they referenced.

Set the GRUB limit to three so /boot retention matches the existing system generation retention.