### PR TITLE
hetzci: support new systemd user settings option

### DIFF
--- a/hosts/hetzci/common.nix
+++ b/hosts/hetzci/common.nix
@@ -5,6 +5,7 @@
   pkgs,
   inputs,
   lib,
+  options,
   ...
 }:
 {
@@ -34,7 +35,15 @@
       value = "8192";
     }
   ];
-  systemd.user.extraConfig = "DefaultLimitNOFILE=8192";
+  systemd.user =
+    if options.systemd.user ? settings then
+      {
+        settings.Manager.DefaultLimitNOFILE = "8192";
+      }
+    else
+      {
+        extraConfig = "DefaultLimitNOFILE=8192";
+      };
 
   # Enable early out-of-memory killing.
   # Make nix builds more likely to be killed over more important services.


### PR DESCRIPTION
Fix `hetzci` evaluation with newer `nixos-unstable` by using `systemd.user.settings.Manager.DefaultLimitNOFILE` when available, while keeping the current `systemd.user.extraConfig` fallback for pinned `nixpkgs`.

This is needed to fix an evaluation error in flakevuln runs, e.g.: https://github.com/tiiuae/ghaf-infra/actions/runs/29881930321.