### PR TITLE
Standardize all hosts to use systemd-boot

### DIFF
--- a/hosts/common.nix
+++ b/hosts/common.nix
@@ -21,6 +21,13 @@ in
     "ghaf-dev"
   ];
 
+  boot.loader.systemd-boot = {
+    enable = true;
+    configurationLimit = 3;
+  };
+
+  boot.loader.timeout = 1;
+
   # revision of the flake the configuration was built from.
   # $ nixos-version --configuration-revision
   system.configurationRevision = toString (

--- a/hosts/hetzner-cloud.nix
+++ b/hosts/hetzner-cloud.nix
@@ -25,18 +25,9 @@ in
   # disable firewall on hetzner internal network
   networking.firewall.trustedInterfaces = [ "eth1" ];
 
-  boot = {
-    # disable predictable NIC names as they vary between hetzner servers
-    # this forces the creation of standard names like eth0 and eth1
-    kernelParams = [ "net.ifnames=0" ];
-
-    # grub boot loader with EFI
-    loader.grub = {
-      efiSupport = true;
-      efiInstallAsRemovable = true;
-      configurationLimit = 3;
-    };
-  };
+  # disable predictable NIC names as they vary between hetzner servers
+  # this forces the creation of standard names like eth0 and eth1
+  boot.kernelParams = [ "net.ifnames=0" ];
 
   warnings = [
     (lib.mkIf

--- a/hosts/hetzner-robot.nix
+++ b/hosts/hetzner-robot.nix
@@ -34,11 +34,6 @@
     networkConfig.DHCP = "ipv4";
   };
 
-  boot.loader = {
-    systemd-boot.enable = true;
-    systemd-boot.configurationLimit = 5;
-  };
-
   environment.systemPackages = with pkgs; [
     efibootmgr
   ];

--- a/hosts/nethsm-gateway/common.nix
+++ b/hosts/nethsm-gateway/common.nix
@@ -30,12 +30,9 @@
     cpu.intel.updateMicrocode = true;
   };
 
-  boot = {
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
+  boot.loader.efi.canTouchEfiVariables = true;
 
+  boot = {
     kernelModules = [ "kvm-intel" ];
     initrd.availableKernelModules = [
       "xhci_pci"

--- a/hosts/testagent/agents-common.nix
+++ b/hosts/testagent/agents-common.nix
@@ -109,10 +109,7 @@ in
 
     networking.useDHCP = true;
 
-    boot.loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
+    boot.loader.efi.canTouchEfiVariables = true;
 
     hardware = {
       enableRedistributableFirmware = true;

--- a/hosts/uae/azureci/azure-common.nix
+++ b/hosts/uae/azureci/azure-common.nix
@@ -82,18 +82,6 @@ in
       "virtio_gpu"
     ];
 
-    # EFI configurations for boot
-    # boot.loader.grub = {
-    #  efiSupport = true;
-    #  efiInstallAsRemovable = true;
-    # };
-
-    # Switch to systemd-boot on Azure
-    boot.loader = {
-      systemd-boot.enable = true;
-      systemd-boot.configurationLimit = 5;
-    };
-
     environment.systemPackages = with pkgs; [
       efibootmgr
     ];

--- a/hosts/uae/azureci/builders/az86-1/configuration.nix
+++ b/hosts/uae/azureci/builders/az86-1/configuration.nix
@@ -49,10 +49,6 @@
   boot = {
     # use predictable network interface names (eth0)
     kernelParams = [ "net.ifnames=0" ];
-    loader.grub = {
-      efiSupport = true;
-      efiInstallAsRemovable = true;
-    };
   };
 
   environment.systemPackages = with pkgs; [

--- a/hosts/uae/azureci/registry/configuration.nix
+++ b/hosts/uae/azureci/registry/configuration.nix
@@ -42,10 +42,6 @@
   boot = {
     # use predictable network interface names (eth0)
     kernelParams = [ "net.ifnames=0" ];
-    loader.grub = {
-      efiSupport = true;
-      efiInstallAsRemovable = true;
-    };
   };
 
   environment.systemPackages = with pkgs; [

--- a/hosts/uae/lab/node1/configuration.nix
+++ b/hosts/uae/lab/node1/configuration.nix
@@ -45,10 +45,6 @@
   boot = {
     # use predictable network interface names (eth0)
     kernelParams = [ "net.ifnames=0" ];
-    loader = {
-      systemd-boot.enable = true;
-      systemd-boot.configurationLimit = 5;
-    };
   };
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
ALl hosts now use systemd-boot instead of grub and the config lives in one place in `hosts/common.nix`

when deploying a bootloader change the following command should be used instead of deploy-rs:

```
nixos-rebuild switch --flake .#HOST --target-host HOST --use-remote-sudo --install-bootloader
```