### PR TITLE
Update zot version and reduce log spam

### DIFF
--- a/hosts/registry.nix
+++ b/hosts/registry.nix
@@ -122,7 +122,7 @@ let
         metrics.users = [ "prometheus" ];
       };
     };
-    log.level = "info";
+    log.level = "warn";
     extensions = {
       ui.enable = true;
       search.enable = true;

--- a/pkgs/zot/default.nix
+++ b/pkgs/zot/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "2.1.14";
+  version = "2.1.18";
   asset = if stdenv.hostPlatform.isAarch64 then "zot-linux-arm64" else "zot-linux-amd64";
 in
 stdenvNoCC.mkDerivation {
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/project-zot/zot/releases/download/v${version}/${asset}";
-    sha256 = "sha256-yW4jlOHZTd00OfOxnR0rcH5by/NP7ElTKAW/PNc0v8c=";
+    sha256 = "sha256-o1mgrxWdtnWLJPjibWokSq6VyvP/OCxGKHX0LZ4IKJg=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
There has been a lot of bug fixes since 2.1.14 https://github.com/project-zot/zot/releases

also changed log level to warn so the logs are easier to read