### PR TITLE
Zot registry version to 2.1.14

### DIFF
--- a/pkgs/zot/default.nix
+++ b/pkgs/zot/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  version = "2.1.18";
+  version = "2.1.14";
   asset = if stdenv.hostPlatform.isAarch64 then "zot-linux-arm64" else "zot-linux-amd64";
 in
 stdenvNoCC.mkDerivation {
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/project-zot/zot/releases/download/v${version}/${asset}";
-    sha256 = "sha256-o1mgrxWdtnWLJPjibWokSq6VyvP/OCxGKHX0LZ4IKJg=";
+    sha256 = "sha256-yW4jlOHZTd00OfOxnR0rcH5by/NP7ElTKAW/PNc0v8c=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
Fixes the stream reset by peer errors in UAE observed [here](https://ci-prod.uaenorth.cloudapp.azure.com/job/ghaf-hw-test/3525/stages/) found with 2.1.18 and 2.1.16. Large downloads of ~5G images breaks the oras pull commands at half way stage. Zot server throws "failed to copy data into http response" with both with and without nginx. On oras pull commands errors point to stream reset by peer with internal error stream ID 5.

Tested 2.1.14 to work fine with both nginx and without nginx configurations. Test [runs](https://ci-prod.uaenorth.cloudapp.azure.com/job/ghaf-manual/322/).