### PR TITLE
Support DarterSB-prod

### DIFF
--- a/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
+++ b/hosts/hetzci/pipeline-library/vars/hwTestUtils.groovy
@@ -35,7 +35,7 @@ def extra_tag_suffix(String target, String deviceTag) {
   if (target.contains("lenovo-x1")) {
     filters.add(deviceTag == 'x1-sec-boot' ? 'NOTexcl-secboot' : 'NOTsecboot-only')
   }
-  if (target.contains("darter")) {
+  if (target.contains("darp11-b")) {
     filters.add(deviceTag == 'darter-sec-boot' ? 'NOTexcl-secboot' : 'NOTsecboot-only')
   }
   return filters.unique().join('')

--- a/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineModel.groovy
@@ -95,7 +95,12 @@ private def display_device_tag(Map testRun) {
 
   def explicitTag = normalize_optional_string(testRun.get('device_tag', null))
   if (explicitTag != null) {
-    return explicitTag == 'x1-sec-boot' ? 'lenovo-x1' : explicitTag
+    if (explicitTag == 'x1-sec-boot') {
+      return 'lenovo-x1'
+    } else if (explicitTag == 'darter-sec-boot') {
+      return 'darter-pro'
+    }
+    return explicitTag
   }
 
   def inferredInfo = device_info(testRun.target, testRun.get('secureboot', false))
@@ -108,7 +113,12 @@ private def display_device_tag(Map testRun) {
     return null
   }
 
-  return inferredTag == 'x1-sec-boot' ? 'lenovo-x1' : inferredTag
+  if (inferredTag == 'x1-sec-boot') {
+    return 'lenovo-x1'
+  } else if (inferredTag == 'darter-sec-boot') {
+    return 'darter-pro'
+  }
+  return inferredTag
 }
 
 private def target_stage_subject(Map testRun) {
@@ -196,6 +206,10 @@ private def inferred_device_info(String targetName, boolean secureboot) {
     return info_for_device_tag('x1-sec-boot')
   }
 
+  if (normalizedTarget.contains('system76-darp11-b') && secureboot) {
+    return info_for_device_tag('darter-sec-boot')
+  }
+
   return device_catalog().findResult { String deviceTag, Map device ->
     def targetSubstrings = device.target_substrings
     if (targetSubstrings instanceof List && targetSubstrings.any { normalizedTarget.contains(it as String) }) {
@@ -220,10 +234,16 @@ def device_info(String targetName, boolean secureboot, String explicitDeviceTag 
     }
 
     def explicitTag = normalizedDeviceTag
-    if (explicitTag == 'lenovo-x1' && inferredInfo.tag == 'x1-sec-boot') {
+    if (
+      (explicitTag == 'lenovo-x1' && inferredInfo.tag == 'x1-sec-boot') ||
+      (explicitTag == 'darter-pro' && inferredInfo.tag == 'darter-sec-boot')
+    ) {
       return inferredInfo
     }
-    if (explicitTag == 'x1-sec-boot' && inferredInfo.tag == 'lenovo-x1') {
+    if (
+      (explicitTag == 'x1-sec-boot' && inferredInfo.tag == 'lenovo-x1') ||
+      (explicitTag == 'darter-sec-boot' && inferredInfo.tag == 'darter-pro')
+    ) {
       return explicitInfo
     }
 

--- a/hosts/hetzci/pipelines/ghaf-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-manual.groovy
@@ -164,6 +164,7 @@ pipeline {
                   [
                     device_tag: 'darter-pro',
                     variant: 'debug',
+                    test_secboot: params.SECUREBOOT,
                   ],
                 ],
               ))

--- a/hosts/testagent/prod/configuration.nix
+++ b/hosts/testagent/prod/configuration.nix
@@ -107,8 +107,8 @@
         };
         Darter-Secure-Boot = {
           inherit location;
-          device_id = "00-4f-32-0a-e1";
-          netvm_hostname = "ghaf-1328679649";
+          device_id = "00-b9-63-24-20";
+          netvm_hostname = "ghaf-3110282272";
           serial_port = "/dev/ttyDARTERSB";
           device_ip_address = "172.18.16.14";
           socket_ip_address = "NONE";


### PR DESCRIPTION
Add Darter secure-boot support for `intel-laptop-debug` tests by enabling it in the manual pipeline, wiring `darter-pro` to `darter-sec-boot` in the pipeline model, and updating Darter-Secure-Boot configuration.