### PR TITLE
Release ghaf-log old disk

### DIFF
--- a/hosts/ghaf-log/disk-config.nix
+++ b/hosts/ghaf-log/disk-config.nix
@@ -41,14 +41,5 @@
         mountpoint = "/data";
       };
     };
-    data = {
-      device = "/dev/disk/by-id/scsi-0HC_Volume_103952564";
-      type = "disk";
-      content = {
-        type = "filesystem";
-        format = "ext4";
-        mountpoint = "/data-old";
-      };
-    };
   };
 }


### PR DESCRIPTION
Decommission old data disk from ghaf-log.
Release the disk from hetzner block storage.