### PR TITLE
Revert to GRUB on hetzner cloud hosts that don't have UEFI support

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -155,6 +155,8 @@ creation_rules:
     - age:
       - *ghaf-webserver
       - *cazfi
+      - *jrautiola
+      - *hrosten
   - path_regex: hosts/ghaf-auth/secrets.yaml$
     key_groups:
     - age:

--- a/hosts/builders/hetzarm-dbg-1/configuration.nix
+++ b/hosts/builders/hetzarm-dbg-1/configuration.nix
@@ -31,6 +31,7 @@
   };
 
   networking.hostName = "hetzarm-dbg-1";
+  virtualisation.hetzner.withEfiSupport = true;
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~300 GiB root disk.
   builder.tuning = {

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -33,6 +33,7 @@
   };
 
   networking.hostName = "hetzarm-rel-1";
+  virtualisation.hetzner.withEfiSupport = true;
 
   # Current host sizing: 16 vCPU, 30 GiB RAM, ~300 GiB root disk.
   builder.tuning = {

--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -22,6 +22,7 @@
   sops.defaultSopsFile = ./secrets.yaml;
   system.stateVersion = lib.mkForce "25.11";
   networking.hostName = "ghaf-registry";
+  virtualisation.hetzner.withEfiSupport = true;
 
   services.zot-registry = {
     clientId = "zot-registry";

--- a/hosts/ghaf-webserver/configuration.nix
+++ b/hosts/ghaf-webserver/configuration.nix
@@ -26,7 +26,7 @@
   # List packages installed in system profile
   environment.systemPackages = with pkgs; [ emacs ];
 
-  system.stateVersion = lib.mkForce "24.05";
+  system.stateVersion = lib.mkForce "26.05";
   networking.hostName = "ghaf-webserver";
 
   services.nginx.virtualHosts."vedenemo.dev" = {

--- a/hosts/ghaf-webserver/secrets.yaml
+++ b/hosts/ghaf-webserver/secrets.yaml
@@ -1,30 +1,43 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:LrX77m0elP4dxO0MlG4d3ZDUUsstvSUHOGxmCezoBmqMIo6lwj+8edMUrfKwiEQeYiOwZvInqZaQkjwYu/7q13tHX+P0VDdwNR51P8ot3QzCPxA4f6cXoMzYo/Bg+VtIDw1IdN87yM0Q8tLSMJNckvK1wQQbNDGann1smaSse6PWQ3kQ2M/lv3dud9RcIPZjFYXUvmYQQjrGWEyoQsMhQqUsXktk2n363uofBec0Jk2RwBjpV29wX6zhAXo1wny23XCRDLSltUhcvjPS8E/uutAJDnVgnLBRpPn1BqBIihRfnYTavD9Ru9P1iqGEEcLUgmxN/I7HlzaIzIbmbGbp/JDkGCeVisbCtID2opVAd+TnACZvQYi4awSJLTEjz3alP9X2lFAq5qhqBdk7449f41apqwjfFufZN1ZL0OlS70L74O1av46ZIt/3kvXo7YwMrHaJgtYfRzepxAitSeEh2upW1qG4XzfRqbzgHQUp7QV0YWC3Sst+OPKe5IENycReeedqr1x5AMjs5bOklv6Y9qskj8AVu1J4ys6D,iv:yx2QLsp7WD7Z1DPtfEirhkARukNIokqKCf62XSWow5s=,tag:ejZphUeRP9pkCmHrT93jIQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age1f643hcr8xvzm6fha93xhn6dw552tfd6zvu7eulxk7vedgt09d9ysljsayq
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJVnZmeldGYWdOOTdNQkJx
-            LzhpS3JwVXAxTXc2MngvUlZ2TG0rbS9LQ0hrCkEwcmJvMGFZam5CelhCdzdGSXhl
-            alUrbkM3WjVXV25oVXV1MXh2RkdvMjQKLS0tIDF5WTBzT0IxbUJOT3RnR1hXZTNQ
-            MTRGU3AyNnZIUEpKVFVoZ1NkWW1hMmsKVccUTFP6+QaOr86/BhyuV0p0I8+As0Fo
-            KVvkHENvBue8ziuwqTCK1jEkKGhpazXMPF9AXGu/s0QNAIsI4U/oeQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5Q2FaeldKeVBnMzhoVXRh
+            cFdzUllnVW1nNTFuLy9DMHBrVWs0REJIYW5BCm1SVXNxdzE3QUJOU2tUWXV3eGYx
+            SzhFV2VrVnFrZHpqU0ozOHZYTGtiaXMKLS0tIG1sN2c5SVlxMXZkcnJaZDBBci9V
+            S1h2NHF1ZldhalM0YWoyMzVaUWllUGcKeI/9Gfq6ztikcVFlX9dARzi47moRG1XJ
+            hc6G6pOGe1aFU2pOwHCzOG/LzJW4OymZPpwQC+vGNcXJX6HWatrIug==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
-          enc: |
+          recipient: age1f643hcr8xvzm6fha93xhn6dw552tfd6zvu7eulxk7vedgt09d9ysljsayq
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqVUk2VEYwcXVwMEZUdFps
-            cUhPZGtzTmdDZkFXbEIwTmhoZDNYSGZ1bFdrCitDS2tuRi8zOVZTTWdyNFFvdG5m
-            ckRIVUxBcnM3QmZxcUx3SDVlLzZSSmMKLS0tICs3ckhXVFp4NnlTaTFVOVMzOXV4
-            TFlIMGhkS0ZvcXVQNWYvV2phb1N0cTQKNGJ31lLdr9uk/DOrlLe3M7DsBhczmvSq
-            eWjj3TNekZpUGrlyVv4CE4D3pwyit8mbwbROZsZjUkToYo6nMQS1Zw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6VEEyazJJTEtMNEhWM1Rj
+            MUplTmJBbkNISXpEM1JFR2l2dWNYRmNlRWljCnkwOWRJR3Y5c2Q3VmlWdFl6YUwz
+            ejZoMGt3T3lUM0JZMENCYmxoTmlzVTQKLS0tIHB3L0dVc3o4cjlzWnQxMldCdWJt
+            Y0l5ME96cjVzMzdjVGtoMm9IMERuK3cKgxDb5KwFVJklNvUZ4CC24/LMQtDBXaJ2
+            j8nkxmUgCT6HqmqDiSPSQRx6+PPu6sCbCFtSqSwsLgY218z86GchAw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-11-04T06:30:19Z"
-    mac: ENC[AES256_GCM,data:ZaDdsxYfjlpI7AvogRNS4LyylXobOvqtq8Uam3IZcjVcKTunq4bCCC1cTqnNkTXaGtVLj0XxW7C4P+KireyX0pqgRNERavGbqgxfCaMEZQXtDE6vIgqBBVgmhqBulqxxUmVRKQdTJZHB7SNLgM2zjTwI6bEBp3gPBSKZE1aNFsg=,iv:oFnWH/ghy279cJfKty3J6GioDOUa+VJ0ZVNBY07n6Pg=,tag:GmdTjBd05vm/5AFrrBL99g==,type:str]
-    pgp: []
+          recipient: age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnb1RSR0pWRVFKbFZjVG9u
+            a3M4aDRCWlJJRTlLS1NhV3Q4OG5sVDlVS21vClU2VHZZYmFiRjFhNnE2cGpDajV6
+            c2RvMml6bmRiZEhuSFptdk10VnNXRnMKLS0tIGplWFhwS1V2L04yMHBySDZnZk9G
+            ZWFVWFdYSTRsOHdRYmRyUFFtb1dEOGMKStH5OrBS50OPX7ingqe3SKmo9z2xEvHF
+            P8xWZwQURcZ/5xzkYdWuumYLeq1BPKc9HROPpdfJwYEuFdiSLJLwDA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5blBjWU4zWlJhQjFCZlNa
+            eUU3OCtoZHRRYkMrU0dkT0ttTVZkT2EvajB3CjBkSk0yNEE2cEYrWkVxUWFRYmdo
+            QnlLaVhsa0hZSm1EejhYMm02a3ZYZFkKLS0tIEQvOHJlTzkvWGZyQU9Mem9vamZH
+            Q1lDMTVOc1pCU1daSGpSUkxnOVdUcUEKirkMjylDCXYTmnHcYal7S7Ec4NTrDpvH
+            fCMfOaS0IG/dN6ul0z4J1+Z6unPftzoEmcqFYEFHOiZtdCmwZRL59g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+    lastmodified: "2026-07-31T08:09:25Z"
+    mac: ENC[AES256_GCM,data:XlGnV/m5ib/T/wTYwQZbuDlJ1ks/qryk515zf10nr90nfF+vpJ1I54xi3Uyb6IC+SWGrvQT8l7teEb3QFWbRak5sLffxIVi1c0+2at2mBL5SkbWF1PN1Oo9yhbtCEPiDsh1Dod+JB11aZ0Gjafw69JO6yqhTc9OXBwPLQwQIyig=,iv:ywVAy5Bd2p88fjk2yBOtu1EE0SfZN7Z/74DSe/S7AdA=,tag:6ixyh//+9bY28paRWsD/eA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.8.1
+    version: 3.13.2

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -22,7 +22,7 @@
   ];
 
   boot.loader.systemd-boot = {
-    enable = true;
+    enable = lib.mkDefault true;
     configurationLimit = 3;
   };
 

--- a/modules/environment/hetzner-cloud.nix
+++ b/modules/environment/hetzner-cloud.nix
@@ -5,35 +5,55 @@
   lib,
   machines,
   config,
+  pkgs,
   ...
 }:
 let
   defaultLoki = "http://${machines.ghaf-monitoring.internal_ip}:3100";
+  cfg = config.virtualisation.hetzner;
 in
 {
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
   ];
 
-  services.monitoring.logs.lokiAddress = lib.mkDefault defaultLoki;
-
-  networking = {
-    useDHCP = true;
-    usePredictableInterfaceNames = false;
+  options.virtualisation.hetzner.withEfiSupport = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Whether the cloud server boots using UEFI rather than legacy BIOS.";
   };
 
-  # disable firewall on hetzner internal network
-  networking.firewall.trustedInterfaces = [ "eth1" ];
+  config = {
+    services.monitoring.logs.lokiAddress = lib.mkDefault defaultLoki;
 
-  warnings = [
-    (lib.mkIf
-      (
-        config.services.monitoring.logs.enable
-        && (config.services.monitoring.logs.lokiAddress == defaultLoki)
-        # naively assume name in machines matches hostname for now
-        && (!builtins.hasAttr "internal_ip" machines.${config.networking.hostName})
+    networking = {
+      useDHCP = true;
+      usePredictableInterfaceNames = false;
+    };
+
+    # disable firewall on hetzner internal network
+    networking.firewall.trustedInterfaces = [ "eth1" ];
+
+    boot.loader = {
+      systemd-boot.enable = cfg.withEfiSupport;
+      grub = lib.mkIf (!cfg.withEfiSupport) {
+        enable = true;
+        configurationLimit = 3;
+      };
+    };
+
+    environment.systemPackages = lib.optionals cfg.withEfiSupport [ pkgs.efibootmgr ];
+
+    warnings = [
+      (lib.mkIf
+        (
+          config.services.monitoring.logs.enable
+          && (config.services.monitoring.logs.lokiAddress == defaultLoki)
+          # naively assume name in machines matches hostname for now
+          && (!builtins.hasAttr "internal_ip" machines.${config.networking.hostName})
+        )
+        "${config.networking.hostName} sends logs to hetzner internal network but has no internal ip defined! is it part of the network?"
       )
-      "${config.networking.hostName} sends logs to hetzner internal network but has no internal ip defined! is it part of the network?"
-    )
-  ];
+    ];
+  };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -66,6 +66,7 @@
             minio-client
             tree
             oras
+            hcloud
           ])
           ++ (with inputs'; [
             deploy-rs.packages.default


### PR DESCRIPTION
Hetzner Cloud hosts do not all use the same firmware mode. Some boot with UEFI, while others use legacy BIOS.

Hetzner documents that newer server types use UEFI by default but this does not apply retroactively to every existing Cloud instance or older server type. See https://docs.hetzner.com/robot/dedicated-server/operating-systems/uefi/.

Each new cloud instance should be verified for EFI support (with `bootctl` or something else)

Enabling systemd-boot globally caused legacy BIOS hosts to become unbootable once grub files were deleted from the system, because systemd-boot requires UEFI. `ghaf-webserver` had to be reinstalled after encountering this issue.

### Changes

- Add `virtualisation.hetzner.withEfiSupport` to the Hetzner Cloud module.
  - Defaults to `false`.
  - Legacy hosts use GRUB.
  - UEFI hosts use systemd-boot.
- Enable UEFI support explicitly for the verified UEFI Cloud hosts:
  - `ghaf-registry`
  - `hetzarm-dbg-1`
  - `hetzarm-rel-1`
- Keep systemd-boot as the default for non-Hetzner-Cloud hosts.
- Add `hcloud` to the development shell for inspecting Hetzner Cloud server metadata.

Hetzner Robot hosts are unaffected by the new option. Their boot mode was verified separately, and all currently use UEFI.