### PR TITLE
Flakevuln whitelist ci

### DIFF
--- a/.github/flakevuln/manual_analysis.csv
+++ b/.github/flakevuln/manual_analysis.csv
@@ -21,10 +21,7 @@ CVE-2016-7543,True,bash,2.05b-builder,,,,Build-time bootstrap artifact: all curr
 CVE-2016-9401,True,bash,2.05b-builder,,,,Build-time bootstrap artifact: all current rows for this CVE/package key are bash 2.05b or bash 2.05b-builder derivations in the build closure; runtime bash 5.x is scanned separately.
 CVE-2019-18276,True,bash,2.05b-builder,,,,Build-time bootstrap artifact: all current rows for this CVE/package key are bash 2.05b or bash 2.05b-builder derivations in the build closure; runtime bash 5.x is scanned separately.
 CVE-2019-9924,True,bash,2.05b-builder,,,,Build-time bootstrap artifact: all current rows for this CVE/package key are bash 2.05b or bash 2.05b-builder derivations in the build closure; runtime bash 5.x is scanned separately.
-OSV-2024-112,True,boost,1.89.0,,1.91.0,1.91.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-914,True,boost,1.89.0,,1.91.0,1.91.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2024-58251,True,busybox,1.37.0,,1.37.0,1.36.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-298,True,cairo,1.18.4,,1.109,1.109,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-14363,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-14363,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-39837,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
@@ -64,10 +61,7 @@ CVE-2022-42011,True,dbus,1,,0.97,0.97,False positive: scanner triage classified 
 CVE-2022-42012,True,dbus,0.9.10,,0.97,0.97,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-42012,True,dbus,1,,0.97,0.97,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2024-13278,True,Diff,1.0.2,,1.0.2,1.0.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-1398,True,file,5.45,,5.48,5.48,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-505,True,file,5.45,,5.48,5.48,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2007-1397,True,fish,4.7.1,,4.8.1,4.8.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-678,True,flac,1.5.0,,1.5.0,1.5.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2020-26304,True,foundation,0.0.30,,0.0.30,0.0.30,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-40469,True,gawk,5.3.2,,5.4.0,5.4.1,Not applicable to this target: CVE is limited to 32-bit gawk builds; target host platform is x86_64-linux.
 CVE-2026-40469,True,gawk,5.4.0,,5.4.0,5.4.1,Not applicable to this target: CVE is limited to 32-bit gawk builds; target host platform is x86_64-linux.
@@ -115,7 +109,6 @@ CVE-2017-5436,True,graphite2,1.3.14,,1.3.15,1.3.15,NVD data issue: CPE entry doe
 CVE-2013-4577,True,grub,2.12,,2.12,2.14,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-12891,True,gstreamer,1.26.11,,1.28.4,1.28.5,"Incorrect package for this target: CVE affects gst-plugins-bad, but the scanned closure contains gstreamer/gst-plugins-base and no gst-plugins-bad derivation."
 CVE-2026-12892,True,gstreamer,1.26.11,,1.28.4,1.28.5,"Incorrect package for this target: CVE affects gst-plugins-bad, but the scanned closure contains gstreamer/gst-plugins-base and no gst-plugins-bad derivation."
-OSV-2023-137,True,harfbuzz,12.3.0,,13.2.1,14.2.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2021-4276,True,hedgehog,1.5,,1.7,1.7,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2021-4276,True,hedgehog,1.5-r2.cabal,,1.7,1.7,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2020-35669,True,http,0.2.12,,,,"Incorrect package: scanned component is the Rust crate http 0.2.12 in the build closure; CVE affects the Dart http package, not the Rust crate."
@@ -133,35 +126,14 @@ CVE-2026-39979,True,jq,1.8.1,,1.8.2,1.8.2,Patched in the scanned derivation: fla
 CVE-2026-39979,True,jq,1.8.1-binlore,,1.8.2,1.8.2,Patched in the scanned derivation: flakevuln run 29970797071 reported a CVE-specific Nix patch for this package.
 CVE-2026-54679,True,jq,1.8.1,,1.8.2,1.8.2,Not applicable to this target: CVE is documented as 32-bit-only; target host platform is x86_64-linux.
 CVE-2026-54679,True,jq,1.8.1-binlore,,1.8.2,1.8.2,Not applicable to this target: CVE is documented as 32-bit-only; target host platform is x86_64-linux.
-OSV-2024-396,True,jq,1.8.1,,1.8.2,1.8.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-440,True,jq,1.8.1,,1.8.2,1.8.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-5121,True,libarchive,3.8.6,,3.8.8,3.8.8,Not applicable to this target: CVE describes a 32-bit-only libarchive issue; target host platform is x86_64-linux.
-OSV-2023-1307,True,libbpf,1.6.3,,1.7.0,1.7.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-1307,True,libbpf,1.7.0,,1.7.0,1.7.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-877,True,libbpf,1.6.3,,1.7.0,1.7.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-877,True,libbpf,1.7.0,,1.7.0,1.7.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2020-2308,True,libheif,1.23.0,,1.23.1,1.23.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-1129,True,libheif,1.23.0,,1.23.1,1.23.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2022-608,True,libjxl,0.11.2,,0.11.2,0.12.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2022-725,True,libjxl,0.11.2,,0.11.2,0.12.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-395,True,libpcap,1.10.6,,1.10.6,1.10.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2025-202,True,librsvg,2.62.1,,2.62.3,2.62.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2020-1420,True,libsass,3.6.6,,3.6.6,3.6.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2020-862,True,libsass,3.6.6,,3.6.6,3.6.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2021-508,True,libsass,3.6.6,,3.6.6,3.6.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2022-896,True,libsass,3.6.6,,3.6.6,3.6.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-52356,True,libtiff,4.7.1,,4.7.1,4.7.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-6228,True,libtiff,4.7.1,,4.7.1,4.7.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-6277,True,libtiff,4.7.1,,4.7.1,4.7.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-1164,True,libultrahdr,1.4.0,,1.4.0,1.4.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-6021,True,libxml2,2.15.1,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-6021,True,libxml2,2.15.3,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-6170,True,libxml2,2.15.1,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-6170,True,libxml2,2.15.3,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2021-777,True,libxml2,2.15.1,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2021-777,True,libxml2,2.15.3,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-698,True,libxml2,2.15.1,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2024-698,True,libxml2,2.15.3,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-10911,True,libxslt,1.1.45,,1.1.45,1.1.45,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-7425,True,libxslt,1.1.45,,1.1.45,1.1.45,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2013-6393,True,libyaml,0.1.4,,0.1.4,0.1.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -193,10 +165,6 @@ CVE-2019-17365,True,nix,0.31.1,,,,"Incorrect package: scanned components are Rus
 CVE-2023-39327,True,openjpeg,2.5.4,,2.5.4,2.5.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-39328,True,openjpeg,2.5.4,,2.5.4,2.5.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-39329,True,openjpeg,2.5.4,,2.5.4,2.5.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2025-219,True,openjpeg,2.5.4,,2.5.4,2.5.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2022-1188,True,opensc,0.27.1,,0.27.1,0.27.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2022-1201,True,opensc,0.27.1,,0.27.1,0.27.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2023-395,True,opensc,0.27.1,,0.27.1,0.27.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2007-2768,True,openssh,10.3p1,,10.4p1,10.4p1,False positive: legacy OpenSSH CVE metadata does not apply to the current OpenSSH package version.
 CVE-2008-3844,True,openssh,10.3p1,,10.4p1,10.4p1,False positive: legacy OpenSSH CVE metadata does not apply to the current OpenSSH package version.
 CVE-2014-9278,True,openssh,10.3p1,,10.4p1,10.4p1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -206,7 +174,6 @@ CVE-2026-55654,True,openssh,10.3p1,,10.4p1,10.4p1,"Not applicable to this target
 CVE-2026-55655,True,openssh,10.3p1,,10.4p1,10.4p1,"Not applicable to this target: CVE is for Red Hat Enterprise Linux OpenSSH patch behavior, not upstream Nixpkgs OpenSSH."
 CVE-2025-47436,True,orc,0.4.41,,1.2.1.4,1.2.1.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-2100,True,p11-kit,0.26.2,,0.26.2,0.26.4,Not affected: CVE affected range is p11-kit <0.26.2; scanned version is 0.26.2.
-OSV-2023-197,True,p11-kit,0.26.2,,0.26.2,0.26.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2015-4155,True,parallel,3.2.2.0,,3.3.0.0,3.3.0.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2015-4156,True,parallel,3.2.2.0,,3.3.0.0,3.3.0.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-37769,True,pixman,0.46.4,,0.46.4,0.46.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -571,9 +538,6 @@ CVE-2026-6844,True,binutils,2.46,,2.46,2.47,False positive: scanner triage class
 CVE-2026-6844,True,binutils,2.46.0,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-6845,True,binutils,2.46,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-6845,True,binutils,2.46.0,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-350,True,binutils,2.46,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-973,True,binutils,2.46,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-987,True,binutils,2.46,,2.46,2.47,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-5222,True,cargo,1.94.1,,0.4.9,0.4.9,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-5223,True,cargo,1.94.1,,0.4.9,0.4.9,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2025-15276,True,fontforge,20251009,,20251009,,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -599,7 +563,6 @@ CVE-2026-42009,True,gnutls,3.8.12,,3.8.13,3.8.13,False positive: scanner triage 
 CVE-2026-42009,True,gnutls,3.8.13,,3.8.13,3.8.13,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-42010,True,gnutls,3.8.12,,3.8.13,3.8.13,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-42010,True,gnutls,3.8.13,,3.8.13,3.8.13,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-53,True,harfbuzz,12.3.0,,13.2.1,14.2.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-40612,True,jq,1.8.1,,1.8.2,1.8.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-41256,True,jq,1.8.1,,1.8.2,1.8.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-41257,True,jq,1.8.1,,1.8.2,1.8.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -618,15 +581,9 @@ CVE-2026-5745,True,libarchive,3.8.6,,3.8.8,3.8.8,False positive: scanner triage 
 CVE-2026-5745,True,libarchive,3.8.7,,3.8.8,3.8.8,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-4878,True,libcap,2.77,,2.78,2.78,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-4775,True,libtiff,4.7.1,,4.7.1,4.7.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-568,True,libultrahdr,1.4.0,,1.4.0,1.4.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-23679,True,libusb,1.0.29,,1.0.30,1.0.30,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-47104,True,libusb,1.0.29,,1.0.30,1.0.30,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-55,True,libvpx,1.16.0,,1.16.0,1.16.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-97,True,libvpx,1.16.0,,1.16.0,1.16.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-565,True,libxml2,2.15.3,,2.15.3,2.15.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-40170,True,ngtcp2,1.22.0,,1.24.0,1.25.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-653,True,openexr,3.4.11,,3.4.11,3.4.13,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
-OSV-2026-664,True,openexr,3.4.11,,3.4.11,3.4.13,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-13757,True,p11-kit,0.26.2,,0.26.2,0.26.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-0672,True,python,2.7.18.12,,3.14.6,3.14.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-0672,True,python,3.14.2,,3.14.6,3.14.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.

--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -35,7 +35,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run flakevuln
-              uses: tiiuae/flakevuln@3f2d9747337d8aae97e50fc1f2a49f460ea9c641
+              uses: tiiuae/flakevuln@4cad247c0575c1407214f9f62e5aa2784bdb8e53
               with:
                   targets: |
                       nixosConfigurations.hetzci-prod.config.system.build.toplevel

--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
     scan:
         name: Scan hetzci-prod vulnerabilities
+        if: ${{ github.repository == 'tiiuae/ghaf-infra' }}
         runs-on: ubuntu-latest
         timeout-minutes: 180
         steps:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ result-*
 ca.key
 **/__pycache__/*
 .codex
+/.flakevuln/


### PR DESCRIPTION
- Stop whitelisting OSV findings based on Repology-only triage
- Skip the flakevuln scan job outside `tiiuae/ghaf-infra`
- Update the flakevuln action pin to include the comparison-report fix

Example run at: https://github.com/tiiuae/ghaf-infra/actions/runs/30541223230