### PR TITLE
Use filesystem storage backend for zot

### DIFF
--- a/hosts/ghaf-registry/configuration.nix
+++ b/hosts/ghaf-registry/configuration.nix
@@ -20,21 +20,13 @@
   ]);
 
   sops.defaultSopsFile = ./secrets.yaml;
-  system.stateVersion = lib.mkForce "25.11";
+  system.stateVersion = lib.mkForce "26.05";
   networking.hostName = "ghaf-registry";
 
   services.zot-registry = {
     clientId = "zot-registry";
     domain = "registry.vedenemo.dev";
     metrics.enable = true;
-    extraConfig.storage.storageDriver = {
-      name = "s3";
-      bucket = "oci-artifacts";
-      region = "hel1";
-      forcepathstyle = true;
-      regionendpoint = "https://hel1.your-objectstorage.com";
-      chunksize = toString (32 * 1024 * 1024);
-    };
   };
 
   services.monitoring = {

--- a/hosts/ghaf-registry/disk-config.nix
+++ b/hosts/ghaf-registry/disk-config.nix
@@ -1,33 +1,44 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  disko.devices.disk.os = {
-    device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_112112540";
-    type = "disk";
-    content = {
-      type = "gpt";
-      partitions = {
-        boot = {
-          type = "EF02";
-          size = "1M";
-        };
-        ESP = {
-          type = "EF00";
-          size = "512M";
-          content = {
-            type = "filesystem";
-            format = "vfat";
-            mountpoint = "/boot";
+  disko.devices.disk = {
+    os = {
+      device = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_112112540";
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          boot = {
+            type = "EF02";
+            size = "1M";
+          };
+          ESP = {
+            type = "EF00";
+            size = "512M";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+            };
+          };
+          root = {
+            size = "100%";
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/";
+            };
           };
         };
-        root = {
-          size = "100%";
-          content = {
-            type = "filesystem";
-            format = "ext4";
-            mountpoint = "/";
-          };
-        };
+      };
+    };
+    data = {
+      device = "/dev/disk/by-id/scsi-0HC_Volume_106501150";
+      type = "disk";
+      content = {
+        type = "filesystem";
+        format = "xfs";
+        mountpoint = "/var/lib/zot";
       };
     };
   };

--- a/hosts/ghaf-registry/secrets.yaml
+++ b/hosts/ghaf-registry/secrets.yaml
@@ -1,11 +1,10 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:I8dItWRRqyn3Vqib+JimxV6T3oTcCn6PAk6RGYdm2C0Hhf0wIxu0TU7DEnIryUeyFc1eLVkrIaNNRLryQaQPIVuZebjeRJwbupvtCgXrvcGai3sHFHrfg/MZ2AvHFexphrwq6kLP2bbakTAKgnqNp7rDOrHckayIHv8dSiH9hK1vpgeFCd5kNGv72EpkOXOcahB8VodV8eJnD1PHWvE0lbfWE2QtWbkTaUZDNhIDFUuHch+wH7BUqWTRY1ez6wFZr8Q3uSk6YvWM/fB68NUupa4t6uQFBuLtyoJz3sL4u3w7seTVFTol290E4aFKFPAkUsTFTC70LhHEDIUb/xnQJmZxsrBJdpTl1S3pU7UCwTU3oXI3Y8ivwmEiXMBC0oXdJkhBfT6TtkGss/9iff5rrGhQjWkh2qBDv+jHUtEBdeRMH8wKH1XBSXuKf4nIJNKxbMroHEza5kN4i9xauO/mJ/JtIwSdjhGaUipixrXZFygmRbKhvA8/CFdhFK5h+H/Kr4ibNzSg42Gau79qMVYu12jVW1MJSZXvQ8p8,iv:CrXCP9BnYTPqkyi8+UGKBR8RsarMQK4wFBsUjqVpmL0=,tag:OI2L5o096ZbBziOndt9LMQ==,type:str]
 auth-client-secret: ENC[AES256_GCM,data:+ksZToYSEZCVlSg+d+TmXcG3wc0ZR+RQ8LodEcH/t7NHS4BiOzz6b7QVy4w=,iv:Fq5FD5lITbBZC6FdfquexoxEskmdZ3KE3yQkYPC0QY0=,tag:3MIBmfTJGwO6fTpG0aH0Sg==,type:str]
 zot-htpasswd: ENC[AES256_GCM,data:9F6ti1uCZIwyz5GzlMNJ244AIMeGMQ+auBXSWOj5y4mwEe2XFG7D7XLki2/3R4317mXpTJzZU54gwXtd3NKCP+gPUe6xIIH3eCIgCywx7iA1skvojZtz/5Ob/5ErtPl3tZq1S1ZQ77jDGNUZ5+pRgWcWlW8I1WjwGDHSV2w3piq0Jpo2pRPT8m44GAUA,iv:z1nX4oJKa2GaMgeuZDgoQX0JVUGYznJhk2YS6HsZVaA=,tag:9TT4ovshYreJdFQnl7VhbQ==,type:str]
-zot-s3-credentials: ENC[AES256_GCM,data:ggITQskb4wjxL7hsc9vg8LKtVKxvh+i8tPPsNlxN0I4aG7/MnirdTRyuumrjGkUOQHhbD5kaKx33O7Ey4IDGb7shwMdUaHgte2t3vyi15OAOBh/q0MxOQ5SET084eqQi0HR3TMPI,iv:A+Cet2Kr/HCrpYcisow8KplAosckGCN/uFpnLMvxDfI=,tag:nSH2h1PrE8DXDenPCTMnRA==,type:str]
+zot-hashkey: ENC[AES256_GCM,data:zBGyUL9HTbWL+9vli7UxEzqNtzR8Nmtzn/E2TCp2MivFtaLnqzqrjKkUlv8=,iv:gWbVR31XVh+I6zzVN9tAwliW3PH724gyRstJydXnCB8=,tag:7apaGaiqE57AR8f9/VGNEA==,type:str]
 sops:
     age:
-        - recipient: age1j6xlgk93a9nwwtaqdxfqfp52x0kt9jkwj3r2zmdg8eres72s0y7qvf5r90
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6cW5LZy9yS3R3bWJ0OUNJ
             YUhUTk1GQVA5SUlKYmNMcTlOY2NkcHBKRlZvCkJScGtSQ2dYUXlUemcyYVpHekZG
@@ -13,8 +12,8 @@ sops:
             TkFLd2NlUUtpWWR6VDdRU2I0MDlMQncKKsOtTYIkwKtdkbCH2wycmCy66kO4asAG
             NrFjiGbtrEmzJJjp/51JtHGGEs3LmBMGtzqP6gPe11eXu9jYs7gI9Q==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
-          enc: |
+          recipient: age1j6xlgk93a9nwwtaqdxfqfp52x0kt9jkwj3r2zmdg8eres72s0y7qvf5r90
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3d2ZNQWp4MUZjcmw0R0la
             WVI3bjFod3lWUFlTUlp2Um91eU5TQ2dXSmc4Ckt4dG9wdjVTc1ZQMGk4aWlncEZn
@@ -22,8 +21,8 @@ sops:
             ZXhhUjduUnpCN2ZpUGh6L1F6L25HRHMKzqJR5w7TmhzB8o6+l8vC7MMkDz0KOmci
             sDFH0ygjE33wwg9ZhKJsSSGFxnVm6HJ1GimfUdFLGpvU4u3/PVF7Yw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
-          enc: |
+          recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0WEhxT1NNSzVoN2xlMFdI
             T1V2QmRDMnZnN2szRnVOSGplSVJQV29UeDJVCks0L0lXTEVWVFlHREEzTFRrbUNE
@@ -31,8 +30,8 @@ sops:
             QWhZc1ljVHVjMWt4WGVWNzZlVGQ2eHcK9taCPoabIwAkFhdl2nuXXVOX/SKLevZ8
             nkBwni+V/8k+AcBlfK1v91aOK05+sIiIEJg/VClY9tz3MkNty5T/SQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
-          enc: |
+          recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCVW5HUUxlc3N6UDRBemo0
             azVRd3I1bTV3cFduUDdUQVlkbUVFbVFkMVI0CjR5T3lxb3p5bXQ5d25PQ2UranYw
@@ -40,8 +39,8 @@ sops:
             KzR6ZlZaWWlCb0VCY2RCV2xCb3JUVG8KpMG63rNjWnPJJEklhTR6AUtvvipMZnvh
             EjLUpuQIAGqQ4DMZa2N8e9nOLRynyI9YEdOcut0/O1a2wKJKG7/xTw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
-          enc: |
+          recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKUFZFczVYa0NnbjE5NERz
             U1lQeGRjUW9kZURhNTRHQ2hwc1V3eC83aVF3CldLSjdOYzJ6alVNNjNDeUl0bFRm
@@ -49,7 +48,8 @@ sops:
             ekVEaE1NL241MFVOclhLSWF2aEZJOGcKAGu2Hx5C0efVWYVvg8D2Q2uCcXBgxTca
             q52YWWYi6CVNbpbLU0H7JwD2E7/MCX0EVcErtNSUSDy4NGaGuTHR3w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T11:10:46Z"
-    mac: ENC[AES256_GCM,data:QKa29pVRs4eIjOshFOAntPcNHm8UQ3YcQImK++0jKTPTiN0xILwR05dNNrUJckCAkSbGjykDeFeWCuGmm30p8NXH487sj9CijjgeQuJQJogNM+yBeEiwKPPKZO+tSTDedKFMGcKj9fBmJ+IjEM6lyVyhgqihh9gAXomHWDXneuU=,iv:eH4YQloCaMZ9YYT5i1m+1DgSwZ4xQaMLdsx83gwDUos=,tag:ojOc1TMxnZwWh9QgI70tDw==,type:str]
+          recipient: age10a2kt6f07urjv6ahutda3jgr73wferkcqjhkvukwm07eaaqyrqtsh08syf
+    lastmodified: "2026-07-30T13:42:11Z"
+    mac: ENC[AES256_GCM,data:ddARay8nc/UW4dpb2L8EJupSVnoqeHW67ZZUmWSIcBJ2nM8CRDvIc3Ca4uIS4h8mWuifEDIDl3b11T73yxaz9Ka6CJWZmiv2y15z0CG3MO07Rzv5xoDkUIohsoDPo7EPlA5MKliWbNeV1Q90ycjYE0RDuBmnjdzW2TTNvrBJaU8=,iv:fs3W74E8ryjlQa+Qg2ZelynfI+pHTcgOnn+3du/Pfxo=,tag:BLjQaVmbb+/V+q9yfc4Lew==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.13.2

--- a/hosts/hetzci/jenkins.nix
+++ b/hosts/hetzci/jenkins.nix
@@ -239,7 +239,7 @@ in
 
       environment = {
         CI_ENV = cfg.envType;
-        OCI_REGISTRY = lib.mkDefault "registry.uaenorth.cloudapp.azure.com";
+        OCI_REGISTRY = lib.mkDefault "registry.vedenemo.dev";
       };
 
       extraJavaOptions = [

--- a/hosts/uae/azureci/registry/secrets.yaml
+++ b/hosts/uae/azureci/registry/secrets.yaml
@@ -1,7 +1,7 @@
 ssh_host_ed25519_key: ENC[AES256_GCM,data:A5bfbkJld3Q3F0MuzFPzo6NyWkD28MhhA+jJLi8MFXAmNJGPQAo8PCTkzLEPmibPIOcKMqXgau9LtCs7qFnM2NKxxvNvBjByHcG0ccA9FFJHApGhr46ldrCTuxPFrTZQJapK0g2tf/CbOZ46cKLv0AVpa4Gj8RzdqA+1JY5OyVxT7FbZBwyw1T1LtgkIdrpKmzAhbHgm5TjbI6idgZRKLeIVZBLJIyELMuSo1r2y5VQy14MVoJ1tswfJsfICl/Hq7YZPF+YHjSbSlHGk7wJdCO0xT/wDvLmB7VO6Ps32VMQerxGP2hHDGTLK6Frb8dm9f0GB1lk0Wtu4GFq5j09NFFoeIOkRGCDCmMmrs9qdEnR3nxPB8xM5wKVxcVmsTVZqkO7ObJDRrBEQR7UVVMouHBB7fRwnev6AihfuzLuTtqk1ivjvODWb8/BwzGCOFRVOGFcbeE14gHVh1E9uRVI1Ab6zZXFftp9qOiAEefc0Cy/8ay/RDdyl5zcZKJvy3llP2rQt+M1BNCc310K/USBgUULdMVLhUyL2nFwGvfTUJfP+PPim7V+T25nyGvfl6HHZVaKNzVtEliCc8UCg,iv:gTxyyGgAgsQcS6PHIkolZZNu6f41konLjgrM5xGupbw=,tag:5cSiRnf2RBwpS2CUh3NNEQ==,type:str]
 auth-client-secret: ENC[AES256_GCM,data:b3h6NdJxDW5OWbCucGzTn9Hu1gd9XPjGLqs1FEJpc1ByHauzJXXKTMmkmkw=,iv:FulP2MOV5DTuOHXjolKDqn3ZGt21VoYboChGcSuEghc=,tag:v9LDuZBQqFQwIa7YCxBSeg==,type:str]
 zot-htpasswd: ENC[AES256_GCM,data:udIe0CMshc9FXlNwE+mSUy2mEBKJXSQ6KCNqjba0Wx7+gofK7YPCTGhU4llVOecET51PXVn8KgoWt141udz2O8oM/Ytq+mwIWGVIPSyk0tmXzF6iKIJubfWeSSwcYcjDT1u6YHncSIZj+nZp3NNFce67lfhjF8L5/aacxHytmi41+YHv76ZAYm0COOAs,iv:rk6seWvOMGJ8dtuHlSjLK2yZ6dkEjbyF2Hajfxvm79k=,tag:PtmW2OvJb9Jpa894yC3v5w==,type:str]
-zot-s3-credentials: ENC[AES256_GCM,data:kwOHVNDkzfMRouhvNvth/uiJnk8O8DBvet+IWqzm3IRLV79ZByC/bx8ANz8b+HYr8TElCHTkAdvcWQdyondS8pQWC/43Z5iOOjhqnjZNMAo2D8xPTq5OnP+jhk4DKUWJDTPxnF04,iv:o3ic5OMlPX2C2TqK5bQPw7PydSVa7b7A3HJPeQgXMbk=,tag:Br4HyeBfBzwATzb5qzD5ig==,type:str]
+zot-hashkey: ENC[AES256_GCM,data:5MbTYrli+l7dReCQ1vRmL2ud8a0iY4XhmZrAxaDLMwTMNERgn7CfbmXiAuQ=,iv:7ZYvPR7XcfpoHNKks5nhxWdr+uVk9R64Rj9pFFyk/6o=,tag:4VgV7kJlp3AM/XYYWdtWIQ==,type:str]
 sops:
     age:
         - enc: |
@@ -40,7 +40,7 @@ sops:
             umgDcbtDpyVJtGuaCLD7vH2UgI9svTwA0GdEUNHVVUYQL00cwllAKQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
-    lastmodified: "2026-07-24T15:43:36Z"
-    mac: ENC[AES256_GCM,data:f31U323v4yjibybR1H1rNySKRZSDsfgBGa73ztA+OGni3Gcp9j+zySXv7g76GGJ7xQG4t3PJDAn5m0ZNBGdrtcKdHnLO/848mMH/2IwvGLwXKGJRdBOh3X/ohQAYVeSTv/fmBW32S6j8zj2czaKYOfHsHtZIKSeVD0JNKae6Y9o=,iv:759QOu9uKEzq9Z87PsrhMygqczakRx4r9nGMXT3wcEA=,tag:vk2i3NPxdqrG1j/DODd9FA==,type:str]
+    lastmodified: "2026-07-30T13:51:18Z"
+    mac: ENC[AES256_GCM,data:2b2lYurPTeP/WXYKsRtFH6LIKlKl4hxHUu8VdbdseFHQUgZOZRzylzBvWiQzvr1NT66bI8PET64qCeRkvs36KNNqkyh3kpCBNomraDRlxYvo9Rro0Fh5ZabbsZXMkGQYsfnq/fZ4DK63bQll1ip3Ofh4Yth7D53S6773i/tfY5I=,iv:nJXK03v935kc5Pl6XVae4KcVqQffagQ71tBDZilsNaQ=,tag:fMcXp9ujNF6ukDJnW3z1zQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2

--- a/modules/zot-registry.nix
+++ b/modules/zot-registry.nix
@@ -19,11 +19,10 @@ let
   zotConfig = lib.recursiveUpdate {
     storage = {
       rootDirectory = zotDataDir;
-      dedupe = false;
+      dedupe = true;
       gc = true;
-      gcInterval = "1h";
+      gcInterval = "24h";
       retention = {
-        delay = "24h";
         policies = [
           {
             repositories = [ "ghaf/**" ];
@@ -77,7 +76,9 @@ let
 
       auth = {
         htpasswd.path = config.sops.secrets.zot-htpasswd.path;
+        sessionKeysFile = config.sops.templates."zot-session-keys.json".path;
         apikey = true;
+
         openid.providers.oidc = {
           name = "Vedenemo Auth";
           issuer = "https://auth.vedenemo.dev";
@@ -129,6 +130,7 @@ let
       ui.enable = true;
       search.enable = true;
       metrics.enable = cfg.metrics.enable;
+      scrub.enable = true;
     };
   } cfg.extraConfig;
   zotConfigFile = pkgs.writeText "zot_config.json" (builtins.toJSON zotConfig);
@@ -155,8 +157,8 @@ in
     sops = {
       secrets = {
         auth-client-secret.owner = "zot";
-        zot-s3-credentials.owner = "zot";
         zot-htpasswd.owner = "zot";
+        zot-hashkey.owner = "zot";
       };
       templates."zot-oidc-credentials.json" = {
         owner = "zot";
@@ -165,6 +167,13 @@ in
           clientsecret = config.sops.placeholder.auth-client-secret;
         };
       };
+      templates."zot-session-keys.json" = {
+        owner = "zot";
+        content = builtins.toJSON {
+          hashKey = config.sops.placeholder.zot-hashkey;
+        };
+      };
+
     };
 
     networking.firewall.allowedTCPPorts = [
@@ -216,7 +225,6 @@ in
         Restart = "always";
         RestartSec = "5s";
         UMask = "0027";
-        EnvironmentFile = config.sops.secrets.zot-s3-credentials.path;
         WorkingDirectory = zotDataDir;
         ReadWritePaths = [ zotDataDir ];
       };


### PR DESCRIPTION
- Decommissioned S3 backend. Hetzner object storage cannot handle the high traffic volume.
- New 4TB disk volume for registry artifact storage.
- Added static `hashKey` for hashing authentication sessions so zot doesn't generate a new one on each restart (keeps sessions authenticated).
- Increased GC interval to 24h to prevent lock races with reads and writes.
- Enabled `scrub` extension which periodically checks the integrity of the digests.
- Enabled `dedupe` to save space. Duplicate blobs are stored as symlinks. This didn't work on S3.
- Bumped `stateVersion` and Reinstalled `ghaf-registry`
- Switch hetzci back to using `registry.vedenemo.dev`