### PR TITLE
Move to nixpkgs unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1785318670,
-        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1785386831,
-        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "lastModified": 1785858998,
+        "narHash": "sha256-fKCq5jphd6l/Ms6gc3dptkw/TcKLYub9lQE5g6rbbkc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "rev": "04607e1165ac22c5fde6dcc54c9e0b3c0487c555",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,27 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
         "type": "github"
       },
       "original": {
@@ -347,7 +363,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1776877367,
         "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
@@ -368,9 +384,7 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1785849815,
@@ -415,7 +429,7 @@
           "flake-root"
         ],
         "git-hooks-nix": "git-hooks-nix_2",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "vulnix": "vulnix"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # Allows us to structure the flake with the NixOS module system
     flake-parts.url = "github:hercules-ci/flake-parts";
@@ -71,7 +71,6 @@
     robot-framework = {
       url = "github:tiiuae/ci-test-automation";
       inputs = {
-        nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
       };
     };
@@ -114,8 +113,6 @@
         systems = [
           "x86_64-linux"
           "aarch64-linux"
-          "x86_64-darwin"
-          "aarch64-darwin"
         ];
 
         imports = [

--- a/hosts/builders/hetz86-rel-2/configuration.nix
+++ b/hosts/builders/hetz86-rel-2/configuration.nix
@@ -22,7 +22,7 @@
     team-devenv
   ]);
 
-  system.stateVersion = "26.05";
+  system.stateVersion = "26.11";
 
   sops = {
     defaultSopsFile = ./secrets.yaml;

--- a/hosts/builders/hetzarm-rel-1/configuration.nix
+++ b/hosts/builders/hetzarm-rel-1/configuration.nix
@@ -22,7 +22,7 @@
     team-devenv
   ]);
 
-  system.stateVersion = "26.05";
+  system.stateVersion = "26.11";
 
   sops = {
     defaultSopsFile = ./secrets.yaml;

--- a/hosts/hetzci/plugins.json
+++ b/hosts/hetzci/plugins.json
@@ -91,9 +91,9 @@
   },
   {
     "name": "cloudbees-folder",
-    "version": "6.1100.ve9eed61d16c4",
-    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1100.ve9eed61d16c4/cloudbees-folder.hpi",
-    "sha256": "187kda6wqlxkqh7190vbinc537wyflb6c19zfi1wj2cz2vjjqvvr"
+    "version": "6.1106.v3a_d9a_6d2465e",
+    "url": "https://updates.jenkins.io/download/plugins/cloudbees-folder/6.1106.v3a_d9a_6d2465e/cloudbees-folder.hpi",
+    "sha256": "02m7r09sl2ayhv7bzjdrzn83rsvlmbl8g4gic7pnmcx18phwzksc"
   },
   {
     "name": "command-launcher",
@@ -103,9 +103,9 @@
   },
   {
     "name": "commons-compress-api",
-    "version": "1.28.0-82.v4df6c060eb_66",
-    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.28.0-82.v4df6c060eb_66/commons-compress-api.hpi",
-    "sha256": "028n2hw3iy7sllihv0ka2pf62lp54x241qnzx4id51583jij544g"
+    "version": "1.28.0-86.v905b_77d84797",
+    "url": "https://updates.jenkins.io/download/plugins/commons-compress-api/1.28.0-86.v905b_77d84797/commons-compress-api.hpi",
+    "sha256": "113jsl2aws89ljfy95j09gwz5rf8n1s18kcxc8hc0mbcfqzy031f"
   },
   {
     "name": "commons-lang3-api",
@@ -133,9 +133,9 @@
   },
   {
     "name": "configuration-as-code",
-    "version": "2100.vb_fd699d2a_09c",
-    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/2100.vb_fd699d2a_09c/configuration-as-code.hpi",
-    "sha256": "1giq1bnq3i1697ipp4977ilgj3is23sp8hla12m0h1ypmc6dq16z"
+    "version": "2114.v67a_a_18696b_8f",
+    "url": "https://updates.jenkins.io/download/plugins/configuration-as-code/2114.v67a_a_18696b_8f/configuration-as-code.hpi",
+    "sha256": "1ifp3477ckpz28d75yaz5ymkjn5f0vng1xzc0h1716bci8xcnpkc"
   },
   {
     "name": "configuration-as-code-groovy",
@@ -181,9 +181,9 @@
   },
   {
     "name": "echarts-api",
-    "version": "6.0.0-1287.vfd24c22a_3d00",
-    "url": "https://updates.jenkins.io/download/plugins/echarts-api/6.0.0-1287.vfd24c22a_3d00/echarts-api.hpi",
-    "sha256": "0v6hsbwl6cbrvbc590rv58q6vlambmrmfdrm1dk63n6vj7lplykz"
+    "version": "6.1.0-1306.vcee1648c16a_4",
+    "url": "https://updates.jenkins.io/download/plugins/echarts-api/6.1.0-1306.vcee1648c16a_4/echarts-api.hpi",
+    "sha256": "15y9ymnmmpbv1vy0x3ch1qdjmbh9yha8m290srrih0a9wdhl156g"
   },
   {
     "name": "eddsa-api",
@@ -199,15 +199,15 @@
   },
   {
     "name": "favorite",
-    "version": "2.263.v941d21defef7",
-    "url": "https://updates.jenkins.io/download/plugins/favorite/2.263.v941d21defef7/favorite.hpi",
-    "sha256": "1cxkfvhqmnxbr9nnw656sq9d1y5wg2jwgx5991d2qyjwh85pbm1z"
+    "version": "2.267.vb_90d08408081",
+    "url": "https://updates.jenkins.io/download/plugins/favorite/2.267.vb_90d08408081/favorite.hpi",
+    "sha256": "05gk1rnrq894rk51lpnzx13yax2zjdjn8w5bdzan4i2n0m2ckj38"
   },
   {
     "name": "font-awesome-api",
-    "version": "7.2.0-990.vf220b_2a_496f9",
-    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/7.2.0-990.vf220b_2a_496f9/font-awesome-api.hpi",
-    "sha256": "1aa5dziyv9snh1sj4fvxv37f314yy9jj9ggzcdhmv1r2wcb6cngf"
+    "version": "7.3.1-1013.v0835a_879ec6d",
+    "url": "https://updates.jenkins.io/download/plugins/font-awesome-api/7.3.1-1013.v0835a_879ec6d/font-awesome-api.hpi",
+    "sha256": "0nmzvggypp3yy51gp0015gdrg6hjbnvxpr92n3amypslg3385qvy"
   },
   {
     "name": "git",
@@ -277,9 +277,9 @@
   },
   {
     "name": "jackson2-api",
-    "version": "2.22.0-439.vb_b_43658d6176",
-    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.22.0-439.vb_b_43658d6176/jackson2-api.hpi",
-    "sha256": "0xvl0qdv7nr0jpwpfzadd9hjx6y151sh26vgnjy8hz2a77g8s6c6"
+    "version": "2.22.1-443.vc91f592333c4",
+    "url": "https://updates.jenkins.io/download/plugins/jackson2-api/2.22.1-443.vc91f592333c4/jackson2-api.hpi",
+    "sha256": "06d4yx3dya6i57rzn35vzzq7z6sgf540nnk524fmhbyfi614h8l7"
   },
   {
     "name": "jackson3-api",
@@ -343,9 +343,9 @@
   },
   {
     "name": "joda-time-api",
-    "version": "2.14.2-193.v422b_efce56e0",
-    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.2-193.v422b_efce56e0/joda-time-api.hpi",
-    "sha256": "1i64xm3x7ds987h66x445xf2qg6f0aaf5jwmr2gq556rmfhmy04s"
+    "version": "2.14.3-200.v65623733c99f",
+    "url": "https://updates.jenkins.io/download/plugins/joda-time-api/2.14.3-200.v65623733c99f/joda-time-api.hpi",
+    "sha256": "1gn9wdsqrkl28l902vpi0nb4s7hwrq6436vv7ahnkf55v2zbsl59"
   },
   {
     "name": "jquery3-api",
@@ -361,9 +361,9 @@
   },
   {
     "name": "json-api",
-    "version": "20260522-217.v0b_18b_8cd4672",
-    "url": "https://updates.jenkins.io/download/plugins/json-api/20260522-217.v0b_18b_8cd4672/json-api.hpi",
-    "sha256": "0lvsy500ya5knaxni9jgxjf3wc3pzvkhafyg402qrxr13dqhmdv5"
+    "version": "20260719-223.va_81f828cdb_58",
+    "url": "https://updates.jenkins.io/download/plugins/json-api/20260719-223.va_81f828cdb_58/json-api.hpi",
+    "sha256": "1i4ny226ffv19bsdkwhvg0m7hvhdanl7a1l4a9lx9i8aybir75pp"
   },
   {
     "name": "json-path-api",
@@ -373,9 +373,9 @@
   },
   {
     "name": "jsoup",
-    "version": "1.22.2-95.vc5d00f1eb_42d",
-    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.22.2-95.vc5d00f1eb_42d/jsoup.hpi",
-    "sha256": "0b1v9gj7zdvdkng6svrblp2ily98rbn953qil7qfbxk0rpl2w3an"
+    "version": "1.23.1-103.v4fde9422cc6f",
+    "url": "https://updates.jenkins.io/download/plugins/jsoup/1.23.1-103.v4fde9422cc6f/jsoup.hpi",
+    "sha256": "1zg09b25p7l6fslqmjvzpnfblad66my334br3d1bbbjqizqvnclc"
   },
   {
     "name": "jucies",
@@ -385,15 +385,15 @@
   },
   {
     "name": "junit",
-    "version": "1413.v736fa_5b_61d80",
-    "url": "https://updates.jenkins.io/download/plugins/junit/1413.v736fa_5b_61d80/junit.hpi",
-    "sha256": "0k96l34sg6ygh7rqi3vn3dr53qgm0k7i72m0nl2jmhcnxd230fiv"
+    "version": "1418.v67a_81935603c",
+    "url": "https://updates.jenkins.io/download/plugins/junit/1418.v67a_81935603c/junit.hpi",
+    "sha256": "0zfssdv4xfywx9nx52wzq7k8vfb2yw7hxajcjqa2xnn0rl2njr6g"
   },
   {
     "name": "lockable-resources",
-    "version": "1537.v68d014129e68",
-    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1537.v68d014129e68/lockable-resources.hpi",
-    "sha256": "0rw3dygwlwi8ybh96f7c8pkmbihrxh8aw9j6w3d89ng7nfwjl9l2"
+    "version": "1539.v4db_b_fc1cc115",
+    "url": "https://updates.jenkins.io/download/plugins/lockable-resources/1539.v4db_b_fc1cc115/lockable-resources.hpi",
+    "sha256": "0vkmg0r7v89j2w2bhlzrainn5y1cfgks3jsng2ns1aa5mj8pprxm"
   },
   {
     "name": "mailer",
@@ -409,15 +409,15 @@
   },
   {
     "name": "matrix-auth",
-    "version": "3.2.10",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.2.10/matrix-auth.hpi",
-    "sha256": "05ik18iyqvlfx1ccz5dh05q21kazkbrkw5r7pxb2a353k0v00g92"
+    "version": "3.3",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-auth/3.3/matrix-auth.hpi",
+    "sha256": "0j1rc5gsris6b5s68xw2l4nmpnsgc3wvqr32q7a7426yy4bakxxq"
   },
   {
     "name": "matrix-project",
-    "version": "870.v9db_fcfc2f45b_",
-    "url": "https://updates.jenkins.io/download/plugins/matrix-project/870.v9db_fcfc2f45b_/matrix-project.hpi",
-    "sha256": "0qz2x5a7jz78j5gd0y011h2p95z2xb0j4bgfsc7rlzay349zrw01"
+    "version": "905.vcc6831e8760a_",
+    "url": "https://updates.jenkins.io/download/plugins/matrix-project/905.vcc6831e8760a_/matrix-project.hpi",
+    "sha256": "0p3a238bawpdsm8pj0zk0070pix9lzpm9gnz2jcsk32gj7b670jq"
   },
   {
     "name": "maven-plugin",
@@ -433,15 +433,15 @@
   },
   {
     "name": "mina-sshd-api-common",
-    "version": "2.17.1-187.v0341274c2905",
-    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-common/2.17.1-187.v0341274c2905/mina-sshd-api-common.hpi",
-    "sha256": "1s0kxhkc18qy3a9ri4zx3xddv47wbqdnpfxykqjbydclmmkx5y2b"
+    "version": "2.19.0-192.v2b_a_7b_2c1dc71",
+    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-common/2.19.0-192.v2b_a_7b_2c1dc71/mina-sshd-api-common.hpi",
+    "sha256": "1g45kgj8kh50mmfjlf3myciwj3wr3f15f4i02dhrp4a3brjbszl8"
   },
   {
     "name": "mina-sshd-api-core",
-    "version": "2.17.1-187.v0341274c2905",
-    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-core/2.17.1-187.v0341274c2905/mina-sshd-api-core.hpi",
-    "sha256": "1d01xhrp6kszn6z0sj0ddvah4d2mam6wxkqnz1shs6i0d45dfycl"
+    "version": "2.19.0-192.v2b_a_7b_2c1dc71",
+    "url": "https://updates.jenkins.io/download/plugins/mina-sshd-api-core/2.19.0-192.v2b_a_7b_2c1dc71/mina-sshd-api-core.hpi",
+    "sha256": "1594ydli6x9c1higrbr2ywh9zsiqdh1ixk1cf54y7a8sx8bylfah"
   },
   {
     "name": "node-iterator-api",
@@ -469,9 +469,9 @@
   },
   {
     "name": "pipeline-build-step",
-    "version": "584.vdb_a_2cc3a_d07a_",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-build-step/584.vdb_a_2cc3a_d07a_/pipeline-build-step.hpi",
-    "sha256": "07vl25jilacjasi8arh763qihmrdg1mznsrvk7hss64hmj91gpw8"
+    "version": "599.v4b_67ea_11b_152",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-build-step/599.v4b_67ea_11b_152/pipeline-build-step.hpi",
+    "sha256": "0dp378l2jg65wbhigfbbbxgxbnjg8p74kin2wlsg1f90mwkgbbks"
   },
   {
     "name": "pipeline-graph-analysis",
@@ -481,9 +481,9 @@
   },
   {
     "name": "pipeline-graph-view",
-    "version": "963.v2a_b_019810b_e1",
-    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/963.v2a_b_019810b_e1/pipeline-graph-view.hpi",
-    "sha256": "1hd2lsrjrfd859v0n8mklqwsxxk1lx0dzhlcj2v5j7f3vypl9njw"
+    "version": "980.vb_db_0b_e5f683c",
+    "url": "https://updates.jenkins.io/download/plugins/pipeline-graph-view/980.vb_db_0b_e5f683c/pipeline-graph-view.hpi",
+    "sha256": "1nlvgp4iximg9plf6xkw8wrab9xhr6jcxfa14sjnr7iv9wlhjvk8"
   },
   {
     "name": "pipeline-groovy-lib",
@@ -571,9 +571,9 @@
   },
   {
     "name": "promoted-builds",
-    "version": "992.va_00888f21b_74",
-    "url": "https://updates.jenkins.io/download/plugins/promoted-builds/992.va_00888f21b_74/promoted-builds.hpi",
-    "sha256": "11icp071dasjdlhwa6xpafbfv48qcxmz580l9zlffakdhzmzk7f0"
+    "version": "1029.v979cc7835e39",
+    "url": "https://updates.jenkins.io/download/plugins/promoted-builds/1029.v979cc7835e39/promoted-builds.hpi",
+    "sha256": "052fr25b73lcxgsmmyi7a4klg9qzba29rpmp8sqfpby56iylni13"
   },
   {
     "name": "rebuild",
@@ -709,9 +709,9 @@
   },
   {
     "name": "vsphere-cloud",
-    "version": "4.530.v1b_68fb_22777c",
-    "url": "https://updates.jenkins.io/download/plugins/vsphere-cloud/4.530.v1b_68fb_22777c/vsphere-cloud.hpi",
-    "sha256": "1l7zkcp27ff47yynibza5zjskpay25xz2808qrl1ylp7mcx3hs0l"
+    "version": "4.554.va_e21a_3cd25ea_",
+    "url": "https://updates.jenkins.io/download/plugins/vsphere-cloud/4.554.va_e21a_3cd25ea_/vsphere-cloud.hpi",
+    "sha256": "05cdsjbxy46xnb7sybflckdkc22g57ry6pfm9l0kxsd87n7jcj39"
   },
   {
     "name": "woodstox-core-api",
@@ -739,9 +739,9 @@
   },
   {
     "name": "workflow-cps",
-    "version": "4350.vcc65d4958821",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4350.vcc65d4958821/workflow-cps.hpi",
-    "sha256": "1h907ar0gqgba6gm6dr9z5dcz23dpr377gdifqc53df85yn8flw5"
+    "version": "4360.v2020e8819a_d6",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-cps/4360.v2020e8819a_d6/workflow-cps.hpi",
+    "sha256": "0mqb5b7a8zlfskh2ij5mbawnq15jyslfx99671ca3rfg6xbxbjaa"
   },
   {
     "name": "workflow-durable-task-step",
@@ -751,15 +751,15 @@
   },
   {
     "name": "workflow-job",
-    "version": "1571.1580.v18e46842c125",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-job/1571.1580.v18e46842c125/workflow-job.hpi",
-    "sha256": "1wn85wl1hfjdqln2fkwpchq1lkwaipz8mx1njq86ra0cb21acm7g"
+    "version": "1590.v49101d088542",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-job/1590.v49101d088542/workflow-job.hpi",
+    "sha256": "0qdlqwx33b076zkvz9f9zxjbqpvjn0jff0nqgmbjnk312fvgi4r9"
   },
   {
     "name": "workflow-multibranch",
-    "version": "821.vc3b_4ea_780798",
-    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/821.vc3b_4ea_780798/workflow-multibranch.hpi",
-    "sha256": "1z8cy21nmmy3wg91d55b3h8jwqbllbf6wys29v2jri871dz8bagh"
+    "version": "841.vec5b_9e1806ec",
+    "url": "https://updates.jenkins.io/download/plugins/workflow-multibranch/841.vec5b_9e1806ec/workflow-multibranch.hpi",
+    "sha256": "1dx17ybanvydzhn4hlkmg5kcvwqxabjqv0pm90pcvl386d2srkrq"
   },
   {
     "name": "workflow-scm-step",

--- a/hosts/hetzci/release/configuration.nix
+++ b/hosts/hetzci/release/configuration.nix
@@ -37,7 +37,7 @@ in
     ../signing.nix
   ];
 
-  system.stateVersion = "26.05";
+  system.stateVersion = "26.11";
   networking.hostName = "hetzci-release";
   nix.caches = [
     "nixos-org"

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -11,6 +11,13 @@
         in
         pkgs.writeShellScriptBin "pre-commit-run" ''
           set -eu
+          unset PYTHONPATH
+          export PATH="${
+            pkgs.lib.makeBinPath [
+              pkgs.coreutils
+              pkgs.git
+            ]
+          }"
 
           # Run all hooks except pylint first, then lint only changed Python files.
           SKIP=pylint ${pkgs.lib.getExe package} run --all-files --config ${configFile}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -27,6 +27,8 @@
           inherit (self'.packages) fleet;
         };
 
+      }
+      // pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") {
         # Vendored in, as brainstem isn't suitable for nixpkgs packaging upstream:
         # https://github.com/NixOS/nixpkgs/pull/313643
         brainstem = pkgs.callPackage ../pkgs/brainstem {

--- a/tasks.py
+++ b/tasks.py
@@ -192,8 +192,7 @@ class _ContextLoguruHandler(logging.Handler):
             raise
         # Logging handlers are expected to swallow formatting/write errors and
         # delegate them to handleError instead of crashing the caller.
-        # pylint: disable=broad-exception-caught
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             self.handleError(record)
 
 
@@ -672,8 +671,7 @@ def _install_release_hosts(c: Context, tmpdir: Path) -> None:
                 future.result()
             # Worker installs may raise SystemExit via helper guards; keep going so
             # all parallel host failures are surfaced before the task aborts.
-            # pylint: disable=broad-exception-caught
-            except (Exception, SystemExit) as err:
+            except (Exception, SystemExit) as err:  # pylint: disable=broad-exception-caught
                 failures.append(alias)
                 detail = _install_error_summary(err)
                 _log_error(f"Release install failed for '{alias}': {detail}")


### PR DESCRIPTION
Move the main `nixpkgs` input to `nixos-unstable` and update the Jenkins plugin manifest for the resulting Jenkins version.

This also keeps `robot-framework` on its own nixpkgs input, removes unsupported Darwin flake systems, scopes `brainstem` to `x86_64-linux`, and adjusts formatter/pylint handling for the newer toolchain.

Tested:
- `inv install-release` from main to this branch, back to main, and back to this branch again
- `inv install-release`: in a loop with changes from this branch
- Jenkins 2.568.1 starts cleanly: CasC loads, expected jobs appear, plugins load without dependency warnings, testagent connects
- deploy to dbg environment and dbg build with changes from this branch
- dummy release build with the changes from this branch: https://ci-release.vedenemo.dev/job/ghaf-release-candidate/3/
- dummy ghaf release publish: https://ci-release.vedenemo.dev/job/ghaf-release-publish/2/
- test/deploy on ghaf-auth