### PR TITLE
Update ghaf-auth for jenkins auth group

### DIFF
--- a/hosts/ghaf-auth/configuration.nix
+++ b/hosts/ghaf-auth/configuration.nix
@@ -79,6 +79,7 @@ in
                 teams = [
                   "devenv-fi"
                   "phone"
+                  "ci-dev-admins"
                 ];
               }
             ];


### PR DESCRIPTION
Allow newly created auth group for jenkins admin tasks.
Enabled rbac for jenkins configured through casc auth configured with jenkins admin operations.
Ghaf auth will enable auth from the newly created group alongside devenv-fi.