### PR TITLE
ci: use latest flakevuln patch evidence

### DIFF
--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -35,7 +35,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run flakevuln
-              uses: tiiuae/flakevuln@b5497e75a5ce34d2d1d46bcf678d689b5bbf5e9b
+              uses: tiiuae/flakevuln@7ab7ddf46afed422ea1e498c89c201ec451a92e6
               with:
                   targets: |
                       nixosConfigurations.hetzci-prod.config.system.build.toplevel


### PR DESCRIPTION
Update flakevuln to the latest upstream revision with vulnxscan evidence, PRs:
- https://github.com/tiiuae/flakevuln/pull/2
- https://github.com/tiiuae/flakevuln/pull/3

Testrun with these changes is available here: https://github.com/tiiuae/ghaf-infra/actions/runs/31674303015