### PR TITLE
Fix dev AGX hostname

### DIFF
--- a/hosts/testagent/dev/configuration.nix
+++ b/hosts/testagent/dev/configuration.nix
@@ -87,7 +87,7 @@
         OrinAGX1 = {
           inherit location;
           device_id = "00-8c-e2-75-77";
-          netvm_hostname = "ghaf-236365144";
+          netvm_hostname = "ghaf-2363651447";
           serial_port = "NONE";
           relay_number = 4;
           device_ip_address = "172.18.16.54";


### PR DESCRIPTION
I accidentally dropped the last digit when updating the hostname in https://github.com/tiiuae/ghaf-infra/commit/02e7183d5af22ee1d182ef23870e30fc56b1b36b.

Correct hostname was confirmed from [this run](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7431/artifact/Robot-Framework/test-suites/orin-agxANDpre-merge/log.html#s1-s1-s3-t2-k3).
```
Actual NetVM hostname != Expected: ghaf-2363651447 != ghaf-236365144
```