### PR TITLE
ci: update flakevuln action

### DIFF
--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -35,7 +35,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run flakevuln
-              uses: tiiuae/flakevuln@7ab7ddf46afed422ea1e498c89c201ec451a92e6
+              uses: tiiuae/flakevuln@008c63137f1e35315668b1559fcaee265c1a2a3c
               with:
                   targets: |
                       nixosConfigurations.hetzci-prod.config.system.build.toplevel


### PR DESCRIPTION
Update the flakevuln pin in github workflow to include the upstream changes: https://github.com/tiiuae/flakevuln/pull/4.

It walks flake.lock, finds reachable github:NixOS/nixpkgs inputs, evaluates each one’s package drv paths, then matches scanned components by drv_path or package/version: this brings in flake input annotations for vulnerable packages.

Example run: https://github.com/tiiuae/ghaf-infra/actions/runs/31783926373

There's a new Input column, that identifies which [flake input](https://github.com/tiiuae/ghaf-infra/blob/743f0a1fcadb4bb44b0471caf0352ee77c0c547a/flake.nix#L21-L101) brings in the vulnerable package.
- (candidate) means flakevuln found a plausible input only by pname + version, not by exact drv_path. So: “this input has a package with the same name/version; likely relevant, but not proven.”
- (unresolved) means flakevuln could not fully attribute the finding to a flake input. Either no component matched any candidate input, or only some components matched and at least one stayed unknown.
- multiple inputs on separate lines: if multiple plausible inputs exist. 
