### PR TITLE
Fix network interface name on nethsm-gateway-dev

### DIFF
--- a/hosts/nethsm-gateway/dev/configuration.nix
+++ b/hosts/nethsm-gateway/dev/configuration.nix
@@ -14,7 +14,7 @@
   networking.hostName = "nethsm-gateway-dev";
 
   # NetHSM connected directly to the ethernet port
-  networking.interfaces.enp89s0 = {
+  networking.interfaces.enp0s20f0u2 = {
     ipv4.addresses = [
       {
         address = "10.255.255.3";


### PR DESCRIPTION
The /29 network was already defined, but the interface names differ between prod and dev gateways, so the configuration never took any effect.