### PR TITLE
jenkins: harden ghaf pre-merge trigger

### DIFF
--- a/hosts/hetzci/casc/githubToken.yaml
+++ b/hosts/hetzci/casc/githubToken.yaml
@@ -6,9 +6,12 @@ credentials:
               scope: GLOBAL
               id: "jenkins-github-commit-status-token"
               secret: "${file:/run/secrets/jenkins_github_commit_status_token}"
-              description: "Github token used to set the commit statuses"
+              description: "GitHub token used by Jenkins for API access and commit statuses"
 
 unclassified:
   gitHubPluginConfig:
     configs:
     - credentialsId: "jenkins-github-commit-status-token"
+      name: "GitHub"
+      apiUrl: "https://api.github.com"
+      manageHooks: true

--- a/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
+++ b/hosts/hetzci/pipeline-library/vars/pipelineExecution.groovy
@@ -692,23 +692,43 @@ def set_github_commit_status(
   String commit,
   String project = "tiiuae/ghaf",
   String context = "jenkins-pre-merge") {
+  context = context?.trim() ?: "jenkins-pre-merge"
   if (!commit) {
     println "Skip setting GitHub commit status"
-    return
+    return false
   }
   println "Setting GitHub commit status"
-  withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
-    env.TOKEN = "$TOKEN"
-    String status_url = "https://api.github.com/repos/$project/statuses/$commit"
-    sh """
-      # set -x
-      curl -H \"Authorization: token \$TOKEN\" \
-        -X POST \
-        -d '{\"description\": \"$message\", \
-             \"state\": \"$state\", \
-             \"context\": "$context", \
-             \"target_url\" : \"$BUILD_URL\" }' \
-        ${status_url}
-    """
+  String status_url = "https://api.github.com/repos/$project/statuses/$commit"
+  String payload = JsonOutput.toJson([
+    description: message,
+    state: state,
+    context: context,
+    target_url: env.BUILD_URL,
+  ])
+  try {
+    withCredentials([string(credentialsId: 'jenkins-github-commit-status-token', variable: 'TOKEN')]) {
+      withEnv([
+        "GITHUB_STATUS_PAYLOAD=${payload}",
+        "GITHUB_STATUS_URL=${status_url}",
+      ]) {
+        sh """
+          # set -x
+          curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            -H \"Authorization: token \$TOKEN\" \
+            -H \"Accept: application/vnd.github+json\" \
+            -H \"Content-Type: application/json\" \
+            -X POST \
+            --data-binary \"\$GITHUB_STATUS_PAYLOAD\" \
+            \"\$GITHUB_STATUS_URL\"
+        """
+      }
+    }
+    return true
+  } catch (InterruptedException e) {
+    throw e
+  } catch (Exception e) {
+    println "Failed to set GitHub commit status '${context}' on ${commit}: ${e.message}"
+    return false
   }
 }

--- a/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
+++ b/hosts/hetzci/pipelines/ghaf-pre-merge.groovy
@@ -37,34 +37,46 @@ def TARGETS = [
   ],
 ]
 
-properties([
-  githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
-  // https://www.jenkins.io/doc/pipeline/steps/params/pipelinetriggers/
-  pipelineTriggers([
-    githubPullRequests(
-      spec: '',
-      triggerMode: 'HEAVY_HOOKS',
-      events: [Open(), commitChanged(), close(), nonMergeable(skip: true)],
-      abortRunning: true,
-      cancelQueued: true,
-      preStatus: false,
-      skipFirstRun: false,
-      userRestriction: [users: '', orgs: 'tiiuae'],
-      repoProviders: [
-        githubPlugin(
-          repoPermission: 'PULL'
-        )
-      ]
-    )
-  ])
-])
-
 pipeline {
   agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {
+    stage('Set properties') {
+      agent { label 'built-in' }
+      steps {
+        script {
+          properties([
+            githubProjectProperty(displayName: '', projectUrlStr: REPO_URL),
+            // https://www.jenkins.io/doc/pipeline/steps/params/pipelinetriggers/
+            pipelineTriggers([
+              githubPullRequests(
+                // Keep webhook triggering, but poll in prod as a fallback for missed
+                // webhooks or GitHub API failures before the plugin updates local state.
+                // The plugin can still miss a build if it skips a bad-state PR and then
+                // persists the new head SHA; that needs an upstream plugin fix.
+                spec: env.CI_ENV == 'prod' ? 'H/15 * * * *' : '',
+                triggerMode: 'HEAVY_HOOKS_CRON',
+                events: [Open(), commitChanged(), close(), nonMergeable(skip: true)],
+                abortRunning: true,
+                cancelQueued: true,
+                preStatus: false,
+                skipFirstRun: false,
+                userRestriction: [users: '', orgs: 'tiiuae'],
+                repoProviders: [
+                  githubPlugin(
+                    // Avoid retaining the provider-local repository after API errors.
+                    cacheConnection: false,
+                    repoPermission: 'PULL'
+                  )
+                ]
+              )
+            ])
+          ])
+        }
+      }
+    }
     stage('Reload only') {
       agent { label 'built-in' }
       when { expression { params && params.RELOAD_ONLY } }
@@ -81,6 +93,10 @@ pipeline {
       steps {
         dir(artifactSupport.controller_workdir()) {
           script {
+            if (!env.GITHUB_PR_NUMBER || !env.GITHUB_PR_TARGET_BRANCH) {
+              currentBuild.result = 'ABORTED'
+              error('ghaf-pre-merge must be triggered by a GitHub PR event. Use ghaf-pre-merge-manual for manual runs.')
+            }
             checkoutUtils.checkout_github_pr_merge(
               REPO_URL,
               env.GITHUB_PR_NUMBER,


### PR DESCRIPTION
Set ghaf-pre-merge job properties from a built-in executor so the prod-only HEAVY_HOOKS_CRON poll fallback sees CI_ENV. Keep webhook triggering and add a 15-minute production poll for missed webhooks or early GitHub API failures.

Disable the github-pullrequest provider-local repository cache for this job. A bad-state PR can still be skipped if the plugin persists the new head SHA afterward; that needs an upstream plugin fix.

Abort direct ghaf-pre-merge builds with a clear message; operators should use ghaf-pre-merge-manual when starting pre-merge checks manually.

Make the Jenkins GitHub server settings explicit in CasC and harden commit status publication with retries, quoted curl input, and non-fatal failure logging.