### PR TITLE
Fix loki logging on uae hosts

### DIFF
--- a/hosts/uae/common.nix
+++ b/hosts/uae/common.nix
@@ -4,11 +4,10 @@
   config,
   lib,
   self,
-  machines,
   ...
 }:
 let
-  defaultLoki = "http://${machines.ghaf-monitoring.nebula_ip}:3100";
+  defaultLoki = "https://monitoring.vedenemo.dev";
 in
 {
   imports = [

--- a/modules/nebula/default.nix
+++ b/modules/nebula/default.nix
@@ -76,23 +76,35 @@ in
         "${lighthouseAddress}" = [ "${machines.ghaf-lighthouse.ip}:${toString listenPort}" ];
       };
 
-      # https://nebula.defined.net/docs/config/punchy
-      settings.punchy = {
-        punch = true;
-        respond = true;
-      };
+      settings = {
+        # https://nebula.defined.net/docs/config/punchy
+        punchy = {
+          punch = true;
+          respond = true;
+        };
 
-      # force a client to be disconnected if the certificate is expired or invalid
-      settings.pki.disconnect_invalid = true;
+        # force a client to be disconnected if the certificate is expired or invalid
+        pki.disconnect_invalid = true;
 
-      settings.stats = {
-        type = "prometheus";
-        interval = "60s";
-        message_metrics = true;
-        lighthouse_metrics = cfg.isLighthouse;
-        listen = "0.0.0.0:9101";
-        path = "/metrics";
-        namespace = "nebula";
+        stats = {
+          type = "prometheus";
+          interval = "60s";
+          message_metrics = true;
+          lighthouse_metrics = cfg.isLighthouse;
+          listen = "0.0.0.0:9101";
+          path = "/metrics";
+          namespace = "nebula";
+        };
+
+        firewall = {
+          outbound_action = "reject";
+          inbound_action = "reject";
+        };
+
+        logging = {
+          level = "info";
+          format = "json";
+        };
       };
 
       firewall = {


### PR DESCRIPTION
I traced the incoming dropped packages on ghaf-monitoring to uae azureci, which was trying to send logs into nebula address of ghaf-monitoring on port 3100. This port is not open on the nebula firewall and as such the packets were being dropped. 

Fixed by using the public monitoring.vedenemo.dev endpoint with basic auth as we do on other hosts. As a bonus, the logs from uae are now actually present. They were never received on monitoring end before now.

Also changed nebula behaviour to instantly reject packets that hit the firewall, instead of dropping them and timing out. This will make things easier to debug in the future.