### PR TITLE
ci: update flakevuln action

### DIFF
--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -35,7 +35,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run flakevuln
-              uses: tiiuae/flakevuln@008c63137f1e35315668b1559fcaee265c1a2a3c
+              uses: tiiuae/flakevuln@a3fd1c84ab53e731e8a81f171c847a849bdb4f0c
               with:
                   targets: |
                       nixosConfigurations.hetzci-prod.config.system.build.toplevel


### PR DESCRIPTION
Update the flakevuln workflow to use the latest upstream main commit.
Most importantly, this brings in the vulnxscan ability to scan kernel vulnerabilities from: https://github.com/tiiuae/sbomnix/pull/309.

Test run: https://github.com/tiiuae/ghaf-infra/actions/runs/32225781450
