### PR TITLE
cachix: filter MicroVM store disk images

### DIFF
--- a/hosts/builders/cachix-push.nix
+++ b/hosts/builders/cachix-push.nix
@@ -24,11 +24,12 @@ in
         "nss-lookup.target"
       ];
       wantedBy = [ "multi-user.target" ];
-      path = with pkgs; [
-        cachix
-        coreutils
-        findutils
-        gnugrep
+      path = [
+        pkgs.cachix
+        pkgs.coreutils
+        pkgs.findutils
+        pkgs.gnugrep
+        config.nix.package
       ];
       serviceConfig = {
         Type = "simple";

--- a/hosts/builders/cachix-push.sh
+++ b/hosts/builders/cachix-push.sh
@@ -41,20 +41,51 @@ list_nix_store_paths() {
   mv -f "$tmp" "$out"
 }
 
-# Filter known image-related artifacts both by the normalized top-level store
-# path name (with the Nix hash prefix stripped) and by file basenames found
-# recursively inside store path directories.
-FILTER_GLOBS=(
+# Store paths matching these image artifact names are unsafe to upload directly.
+# Before pushing a batch, we also skip all current referrers of these paths
+# because cachix push uploads every missing reference of an unfiltered root.
+# The regex derivation below supports only literal characters, '*', and '.'.
+IMAGE_FILTER_GLOBS=(
   '*-disko-images*'
   'nixos-image-sd-card-*.img*'
   'nixos-disk-image'
-  'set-environment'
-  'etc-pam-environment'
   '*.raw.zst'
   '*.img.zst*'
+  'microvm-store-disk.*'
   'ghaf.iso'
   'nixos.img'
 )
+
+IMAGE_FILTER_REGEX=""
+for image_filter_glob in "${IMAGE_FILTER_GLOBS[@]}"; do
+  image_filter_regex_part="${image_filter_glob//./\\.}"
+  image_filter_regex_part="${image_filter_regex_part//\*/.*}"
+
+  if [ -n "$IMAGE_FILTER_REGEX" ]; then
+    IMAGE_FILTER_REGEX+="|"
+  fi
+  IMAGE_FILTER_REGEX+="$image_filter_regex_part"
+done
+IMAGE_FILTER_REGEX="^/nix/store/[0-9a-z]{32}-(${IMAGE_FILTER_REGEX})$"
+
+# Additional direct filters for files found near the top of store path
+# directories. These are intentionally not closure-wide; applying them through
+# NixOS system closures would skip too many ordinary paths.
+FILTER_GLOBS=(
+  "${IMAGE_FILTER_GLOBS[@]}"
+  'set-environment'
+  'etc-pam-environment'
+)
+
+FILTER_MATCH=""
+
+# Set to 1 by the poll helpers when they cannot finish the current iteration.
+# They report through this global and always return 0 so their callers can
+# invoke them bare. Wrapping a function call in `if`, `!` or `||` disables
+# errexit for the duration of that call, including inside everything the
+# function itself calls, so an unguarded failure would be silently ignored
+# instead of aborting the service and letting systemd restart it clean.
+SKIP_POLL=0
 
 # Return success when NAME matches any of the provided shell globs.
 matches_any_glob() {
@@ -74,20 +105,19 @@ matches_any_glob() {
   return 1
 }
 
-# Normalize a store path basename to the artifact name by dropping the Nix
-# hash prefix when present.
-canonical_filter_name() {
-  local basename
-  basename="$(basename "$1")"
-  echo "${basename#*-}"
-}
-
 # Find the first path inside STOREPATH whose basename matches any filter glob.
+# The search is depth bounded because the artifacts we filter sit at or near the
+# top of their output directory, as in iso/ghaf.iso or sd-image/*.img.zst. An
+# unbounded search matches unrelated payload deeper in ordinary packages:
+# linux-firmware ships lib/firmware/**/*.img.zst, which made the whole package,
+# and nothing else in its closure, silently unpushable. Depth 3 leaves headroom
+# for grouped image layouts such as images/<arch>/main.raw.zst while staying
+# well clear of that firmware payload, which sits five levels down.
 find_first_matching_path() {
   local storepath=$1
   shift
 
-  local find_args=("$storepath" "(")
+  local find_args=("$storepath" -maxdepth 3 "(")
   local first=1
   local pattern
   for pattern in "$@"; do
@@ -107,30 +137,104 @@ find_first_matching_path() {
 
 # Return success for store paths that should never be uploaded. Match both the
 # top-level store path names we actually publish via Jenkins artifacts and the
-# image files contained inside those store paths by comparing against the
-# canonical name without the Nix hash prefix.
+# image files contained inside those store paths.
 should_filter_store_path() {
   local storepath=$1
   local name
-  name="$(canonical_filter_name "$storepath")"
+  local matched
+
+  FILTER_MATCH=""
+  name="${storepath##*/}"
+  name="${name#*-}"
 
   if matches_any_glob "$name" "${FILTER_GLOBS[@]}"; then
+    FILTER_MATCH="$storepath"
     return 0
   fi
 
-  if [ ! -d "$storepath" ]; then
-    return 1
-  fi
-
-  if [ -n "$(
-    find_first_matching_path \
-      "$storepath" \
-      "${FILTER_GLOBS[@]}"
-  )" ]; then
-    return 0
+  if [ -d "$storepath" ]; then
+    matched="$(
+      find_first_matching_path \
+        "$storepath" \
+        "${FILTER_GLOBS[@]}"
+    )"
+    if [ -n "$matched" ]; then
+      FILTER_MATCH="$matched"
+      return 0
+    fi
   fi
 
   return 1
+}
+
+# Build the set of current roots that would upload a filtered image as a closure
+# member. This deliberately skips useful roots too, such as ghaf-host toplevels,
+# because cachix has no non-recursive push mode.
+build_closure_filter_matches() {
+  local snapshot=$1
+  local matches=$2
+  local image_paths="$TMPDIR/image-filter-paths"
+  local referrers="$TMPDIR/image-referrers"
+  local query_log="$TMPDIR/nix-store-query.err"
+  local message
+  local grep_status=0
+  local query_status=0
+
+  : >"$matches" || {
+    SKIP_POLL=1
+    return 0
+  }
+  : >"$image_paths" || {
+    SKIP_POLL=1
+    return 0
+  }
+
+  LC_ALL=C grep -E "$IMAGE_FILTER_REGEX" "$snapshot" >"$image_paths" 2>"$query_log" || grep_status=$?
+  if [ "$grep_status" -eq 1 ]; then
+    return 0
+  fi
+  if [ "$grep_status" -ne 0 ]; then
+    message="$(head -n 1 "$query_log" || true)"
+    if [ -z "$message" ]; then
+      message="grep exited with status $grep_status"
+    fi
+    echo "[!] Failed to scan image filter paths from snapshot: $message" >&2
+    SKIP_POLL=1
+    return 0
+  fi
+
+  [ -s "$image_paths" ] || return 0
+  LC_ALL=C sort -u "$image_paths" -o "$image_paths" || {
+    SKIP_POLL=1
+    return 0
+  }
+
+  # Query in chunks rather than passing every image path as a single argv.
+  # Images accumulate between store garbage collections, and once the argument
+  # list exceeds ARG_MAX the exec fails on every subsequent poll, which would
+  # stop the service from ever advancing REF_FILE again. Store paths cannot
+  # contain newlines, so -d skips xargs quote and backslash processing.
+  xargs -r -a "$image_paths" -d '\n' -n 256 \
+    nix-store -q --referrers-closure >"$referrers" 2>"$query_log" </dev/null ||
+    query_status=$?
+  if [ "$query_status" -ne 0 ]; then
+    message="$(head -n 1 "$query_log" || true)"
+    if [ -z "$message" ]; then
+      # xargs reports 123 when a chunk failed and 125..127 when it could not run
+      # nix-store at all. A signalled or OOM-killed child writes no stderr.
+      message="referrer query exited with status $query_status"
+    fi
+    echo "[!] Failed to query image referrers: $message" >&2
+    SKIP_POLL=1
+    return 0
+  fi
+
+  LC_ALL=C sort -u "$referrers" -o "$matches" || {
+    SKIP_POLL=1
+    return 0
+  }
+
+  return 0
 }
 
 # Combine the persisted retry queue with newly discovered store paths while
@@ -164,11 +268,55 @@ merge_candidates() {
 process_candidates() {
   local candidates=$1
   local retry_next=$2
-
-  : >"$retry_next"
-
+  local snapshot=$3
   local storepath
-  while read -r storepath; do
+  local closure_filter_file="$TMPDIR/closure-filter-matches"
+  local closure_filter_fd
+  local candidates_fd
+  declare -A closure_filter_matches=()
+
+  # Keep stderr redirection before the target redirection so Bash's own
+  # open/truncate error is suppressed and the journal gets one structured line.
+  if ! : 2>/dev/null >"$retry_next"; then
+    echo "[!] Failed to initialize retry queue: $retry_next" >&2
+    SKIP_POLL=1
+    return 0
+  fi
+
+  if ! { exec {candidates_fd}<"$candidates"; } 2>/dev/null; then
+    echo "[!] Failed to read candidate store paths: $candidates" >&2
+    SKIP_POLL=1
+    return 0
+  fi
+
+  if [ ! -s "$candidates" ]; then
+    exec {candidates_fd}<&-
+    return 0
+  fi
+
+  build_closure_filter_matches "$snapshot" "$closure_filter_file"
+  if [ "$SKIP_POLL" -ne 0 ]; then
+    exec {candidates_fd}<&-
+    echo "[!] Failed to inspect image referrers; skipping poll without advancing reference" >&2
+    return 0
+  fi
+
+  if ! { exec {closure_filter_fd}<"$closure_filter_file"; } 2>/dev/null; then
+    exec {candidates_fd}<&-
+    echo "[!] Failed to read closure filter matches: $closure_filter_file" >&2
+    SKIP_POLL=1
+    return 0
+  fi
+
+  while read -r -u "$closure_filter_fd" storepath; do
+    [ -n "$storepath" ] || continue
+    if [ -z "${closure_filter_matches["$storepath"]+x}" ]; then
+      closure_filter_matches["$storepath"]=1
+    fi
+  done
+  exec {closure_filter_fd}<&-
+
+  while read -r -u "$candidates_fd" storepath; do
     [ -n "$storepath" ] || continue
 
     if [ ! -e "$storepath" ]; then
@@ -177,15 +325,31 @@ process_candidates() {
     fi
 
     if should_filter_store_path "$storepath"; then
-      echo "[+] Skip filtered store path: $storepath"
+      if [ "$FILTER_MATCH" != "$storepath" ]; then
+        echo "[+] Skip filtered store path: $storepath (matched: $FILTER_MATCH)"
+      else
+        echo "[+] Skip filtered store path: $storepath"
+      fi
+      continue
+    fi
+
+    if [ -n "${closure_filter_matches["$storepath"]+x}" ]; then
+      echo "[+] Skip filtered store path: $storepath (matched: filtered image closure)"
       continue
     fi
 
     local push_log="$TMPDIR/cachix-push.log"
-    if ! cachix push -j4 -l16 "$CACHIX_CACHE_NAME" "$storepath" >"$push_log" 2>&1; then
+    if ! cachix push -j4 -l16 "$CACHIX_CACHE_NAME" "$storepath" >"$push_log" 2>&1 </dev/null; then
       cat "$push_log" >&2
       echo "[!] Failed to push store path, will retry: $storepath" >&2
-      echo "$storepath" >>"$retry_next"
+      # Keep stderr redirection before the append for the same reason as the
+      # retry queue initialization above.
+      if ! echo "$storepath" 2>/dev/null >>"$retry_next"; then
+        exec {candidates_fd}<&-
+        echo "[!] Failed to update retry queue: $retry_next" >&2
+        SKIP_POLL=1
+        return 0
+      fi
       continue
     fi
 
@@ -194,7 +358,8 @@ process_candidates() {
     if ! grep -qxF 'Nothing to push - all store paths are already on Cachix.' "$push_log"; then
       cat "$push_log"
     fi
-  done <"$candidates"
+  done
+  exec {candidates_fd}<&-
 }
 
 # Reconfigure cachix when the token file changes. Startup failures are fatal,
@@ -253,6 +418,8 @@ fi
 
 # Poll new store paths every 30 seconds
 while sleep 30; do
+  SKIP_POLL=0
+
   refresh_cachix_auth_token best-effort || true
 
   # Snapshot nix store paths for the current poll iteration
@@ -265,8 +432,13 @@ while sleep 30; do
   # paths.
   merge_candidates "$RETRY_FILE" "$TMPDIR/new" "$TMPDIR/candidates"
 
-  # Rebuild the retry queue from the paths that still fail.
-  process_candidates "$TMPDIR/candidates" "$TMPDIR/retry-next"
+  # Rebuild the retry queue from the paths that still fail. Call bare so errexit
+  # stays active inside the helper and everything it runs; an iteration that
+  # could not finish is reported through SKIP_POLL instead of an exit status.
+  process_candidates "$TMPDIR/candidates" "$TMPDIR/retry-next" "$TMPDIR/snapshot"
+  if [ "$SKIP_POLL" -ne 0 ]; then
+    continue
+  fi
 
   # Persist the next retry queue before checking limits or advancing REF_FILE.
   mv -f "$TMPDIR/retry-next" "$RETRY_FILE"


### PR DESCRIPTION
MicroVM store-on-disk builds produce microvm-store-disk.erofs filesystem images that contain a VM /nix/store closure. They are large image artifacts rather than shared build or runtime dependencies.

The derivation is produced with runCommandLocal, so direct realization is marked preferLocalBuild=true and allowSubstitutes=false. Uploading these paths as direct candidates therefore does not make the usual build path cheaper, while each image consumes several GiB in the cachix caches (ghaf-dev, ghaf-release).

This PR updates the builder Cachix push service to skip image artifacts and also skip candidate roots whose closure would upload one of those images. Direct filtering alone is not enough because cachix push uploads the closure for every accepted root.

I estimate currently on ghaf-dev cachix cache, roughly ~500GiB (out of 1200GiB total) is taken by the microvm-store-disk.erofs files. That's around 40% of the total current ghaf-dev usage. I'll do manual one-off cleanup from our cachix caches as soon as this PR is merged and deployed.

Some examples from ghaf-dev:
```
STORE PATH	                                                          SIZE	    UNCOMPRESSED
/nix/store/cjq1fh129gyx2jxl43ddhfa340ml9b90-microvm-store-disk.erofs	3.79 GiB	5.15 GiB
/nix/store/ikrgry772wh04b9j2vb4xlmpknplzn22-microvm-store-disk.erofs	3.79 GiB	5.15 GiB
/nix/store/r52vl2wz5pxzz1gr0dcwdd79brh6ffl9-microvm-store-disk.erofs	3.79 GiB	5.15 GiB
/nix/store/690ljlwlg1l3navsf1a343n48lz7zc23-microvm-store-disk.erofs	3.73 GiB	5.1  GiB
/nix/store/q5xxy8j7yngrabd417wdqvbvvjvv9w2h-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/lywlpkpdggaxl7axl5pvqfh7prcxj9dj-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/06ihm0nsc1k2a1i05ngilm10ksg75bn5-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/52qa8zvsd476qfwjafzldpznjczsj8sy-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/6gw7w9rs66q2xrhps1qsgd1a97cwk78d-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/s5iyqlv8vbzkgz6yygrxb7is5fjp81yk-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
/nix/store/4cx2q5g33r39p2ax30ik006znrr1ph7m-microvm-store-disk.erofs	3.52 GiB	4.91 GiB
...
(around 260-300 objects in total)
```
#### Implementation Notes

The Cachix push service now builds an image-root index from each poll snapshot, queries current image referrers in chunks, and skips candidate roots that would push filtered image artifacts through their closure.

The nested direct-path scan is depth-bounded so packages such as linux-firmware, which contain image-like payload files deeper in their output tree, are still cacheable.

Poll failure handling remains conservative: if closure inspection or retry-queue preparation fails, the service logs the issue and skips advancing the reference snapshot for that poll.

#### Testing

Tested in ci-release and [ci-dbg](https://ci-dbg.vedenemo.dev/job/ghaf-release-candidate/69/). In ci-dbg, cleared the cachix cache before the build, then inspected the ci-dbg cachix cache contents after the build to double-check the image artifacts are no longer pushed. Also inspected the builder load during the build to ensue the cachix-push service cpu usage on the dbg builders remains tolerable. 
