### PR TITLE
ci: update flakevuln

### DIFF
--- a/.github/flakevuln/manual_analysis.csv
+++ b/.github/flakevuln/manual_analysis.csv
@@ -1,4 +1,47 @@
 vuln_id,whitelist,package,version_local,version_local_regex,version_nixpkgs,version_upstream,comment
+(CVE-2026-3441|CVE-2026-3442|CVE-2026-4647|CVE-2026-6844|CVE-2026-6845),False,binutils,,2\.46(\.0)?,,,Valid: NVD describes GNU Binutils issues and local 2.46 source predates the 2.46.1 fixes.
+CVE-2024-58251,False,busybox,1.37.0,,,,Valid: NVD affected range is BusyBox <=1.37.0 and local patches do not address this CVE.
+CVE-2023-7216,False,cpio,2.15,,,,Valid: NVD describes GNU cpio path traversal and the local 2.15 derivation has no relevant patch.
+(CVE-2025-15276|CVE-2025-15277|CVE-2025-15278),False,fontforge,20251009,,,,Valid: NVD affected commits are ancestors of tag 20251009 and Nixpkgs only patches adjacent CVEs 15269 15275 and 15279.
+(CVE-2026-40467|CVE-2026-40468|CVE-2026-40553),False,gawk,5.3.2,,,,Valid: NVD affected range is GNU gawk <=5.4.0 and local 5.3.2 has no relevant patch.
+CVE-2022-3219,True,gnupg,2.4.9,,,,Fixed in this derivation: the freepg patch set includes Disallow compressed signatures and certificates which is the mitigation referenced by T5993/D556.
+(CVE-2013-6393|CVE-2014-2525),False,libyaml,0.1.4,,,,Valid: Haskell libyaml 0.1.4 wraps libyaml-clib and the local derivation has no patch for these LibYAML issues.
+CVE-2026-13757,False,p11-kit,0.26.2,,,,Valid: p11-kit fixed this in 0.26.3 or later and local 0.26.2 has no recursion-depth patch.
+(CVE-2025-15366|CVE-2025-15367|CVE-2026-0864|CVE-2026-11940|CVE-2026-11972|CVE-2026-1502|CVE-2026-3276|CVE-2026-4360|CVE-2026-4786|CVE-2026-5713|CVE-2026-6100|CVE-2026-7774|CVE-2026-8328|CVE-2026-9669),False,python,3.14.4,,,,Valid: NVD CPython affected range includes 3.14.4 and this derivation has no security backports.
+CVE-2024-13278,True,Diff,1.0.2,,,,Incorrect package: NVD record affects the Drupal Diff module; scanned component is the Haskell Diff package.
+CVE-2021-28794,True,ShellCheck,0.11.0,,,,Incorrect package: NVD record affects an unofficial Visual Studio Code ShellCheck extension; scanned component is the ShellCheck CLI.
+CVE-2024-9410,True,ada,3.4.4,,,,Incorrect package: NVD record affects the Ada.cx Sentry service component; scanned component is the ada library.
+CVE-2018-13162,True,alex,3.5.4.2,,,,Incorrect package: NVD record affects an Ethereum token contract named ALEX; scanned component is the Haskell Alex lexer generator.
+CVE-2021-43138,True,async,2.2.6,,,,Incorrect package: NVD record affects the npm async package; scanned component is the Haskell async package.
+CVE-2019-10010,True,commonmark,0.2.6.1,,,,Incorrect package: NVD record affects PHP League CommonMark; scanned component is the Haskell commonmark package.
+CVE-2017-18589,True,cookie,0.5.1,,,,Incorrect package: NVD record affects the Rust cookie crate; scanned component is the Haskell cookie package.
+CVE-2018-6553,True,cups,2.4.19,,,,Target mismatch: NVD record is for Ubuntu CUPS AppArmor profile packaging and fixed there before 2.2.7-1ubuntu2.1.
+(CVE-2022-42010|CVE-2022-42011|CVE-2022-42012),True,dbus,0.9.10,,,,Incorrect package: scanned component is the Rust dbus crate source and not the D-Bus daemon or libdbus implementation.
+(CVE-2022-42010|CVE-2022-42011|CVE-2022-42012),True,dbus,1,,,,Generated config false positive: underlying D-Bus is 1.16.2 which is newer than the NVD fixed ranges for these issues.
+CVE-2020-26304,True,foundation,0.0.30,,,,Incorrect package: NVD record affects foundation-sites JavaScript framework; scanned component is the Haskell foundation package.
+(CVE-2025-32989|CVE-2025-32990|CVE-2026-1584|CVE-2026-33845|CVE-2026-3832|CVE-2026-3833|CVE-2026-42009|CVE-2026-42010),True,gnutls,3.8.13,,,,Fixed in current source: GnuTLS 3.8.13 includes the relevant security fixes and local version is 3.8.13.
+CVE-2023-49292,True,go,,,,,Incorrect package: NVD CPE is ecies:go for the ECIES Go library; scanned component is the Go toolchain or bootstrap toolchain.
+CVE-2013-4577,True,grub,2.12,,,,Target mismatch: CVE affects a Debian-specific GRUB patch creating world-readable grub.cfg and not upstream Nixpkgs GRUB.
+CVE-2021-4276,True,hedgehog,,1\.5(-r2\.cabal)?,,,Incorrect package: NVD record affects dns-stats hedgehog and not the Haskell Hedgehog testing library.
+(CVE-2026-33948|CVE-2026-39979|CVE-2026-44777),True,jq,,1\.8\.2(-binlore)?,,,Fixed in current source: upstream fix commits 6374ae0 and 2f09060 are ancestors of jq-1.8.2 and the module-loader issue only affects through 1.8.2rc1.
+(CVE-2025-6021|CVE-2025-6170),True,libxml2,2.15.3,,,,Fixed before this build: NVD affected ranges end before libxml2 2.14.4 or 2.14.5 and local version is 2.15.3.
+CVE-2025-10911,True,libxslt,1.1.45,,,,Fixed before this build: NVD affected range ends at libxslt 1.1.43 and local version is 1.1.45.
+CVE-2025-7425,True,libxslt,1.1.45,,,,Fixed in current source: Nixpkgs applies the upstream result-value-tree memory-management patch for this libxslt issue.
+(CVE-2021-35047|CVE-2021-35048|CVE-2021-35049|CVE-2021-35050|CVE-2022-0486|CVE-2022-0997|CVE-2022-24388|CVE-2022-24389|CVE-2022-24390|CVE-2022-24391|CVE-2022-24392|CVE-2022-24393|CVE-2022-24394),True,network,3.2.8.0,,,,Incorrect package: NVD records affect Fidelis Network appliances and not the Haskell network package.
+CVE-2021-4336,True,ninja,1.13.2,,,,Incorrect package: NVD record affects ITRS monitor-ninja and not the Ninja build tool.
+(CVE-2015-4155|CVE-2015-4156),True,parallel,3.2.2.0,,,,Incorrect package: NVD records affect GNU Parallel and not the Haskell parallel package.
+CVE-2023-37769,True,pixman,0.46.4,,,,Not shipped in this output: NVD record affects the pixman stress-test program and the Nix output only contains the library and headers.
+CVE-.*,True,python,,2\.7\..*,,,Build-time bootstrap artifact: Python 2.7 derivations are build-closure-only artifacts and absent from the runtime closure scan.
+(CVE-2020-1171|CVE-2020-1192|CVE-2020-17163|CVE-2024-49050|CVE-2025-49714),True,python,3.14.4,,,,Incorrect package: NVD records affect the Visual Studio Code Python extension and not CPython.
+(CVE-2021-33594|CVE-2021-33595|CVE-2021-33596|CVE-2021-40834|CVE-2021-40835|CVE-2021-44751|CVE-2022-28868|CVE-2022-28869|CVE-2022-28870|CVE-2022-28872|CVE-2022-28873|CVE-2022-38163|CVE-2022-38164|CVE-2022-47524),True,safe,,0\.3\.21(-r1\.cabal)?,,,Incorrect package: NVD records affect F-Secure SAFE browser or mobile products and not the Haskell safe package.
+CVE-2000-0006,True,strace,7.1,,,,Legacy NVD record with no current affected range; strace 7.1 is decades newer than the vulnerable implementation.
+CVE-2024-21524,True,stringbuilder,0.5.1,,,,Incorrect package: NVD record affects node-stringbuilder and not the Haskell stringbuilder package.
+(CVE-2021-27400|CVE-2021-3024|CVE-2021-38554|CVE-2021-41802|CVE-2022-41316|CVE-2023-0620|CVE-2023-0665|CVE-2023-2121|CVE-2023-24999|CVE-2023-25000|CVE-2023-6337|CVE-2024-2048|CVE-2024-8365|CVE-2025-4166|CVE-2025-6011|CVE-2025-6014|CVE-2025-6037),True,vault,0.3.1.6,,,,Incorrect package: NVD records affect the Vault secrets-management server and not the Haskell vault package.
+CVE-2015-7777,True,void,0.7.4,,,,Incorrect package: NVD record affects the Void web app and not the Haskell void package.
+(CVE-2022-2145|CVE-2022-2225|CVE-2022-3320|CVE-2022-3512|CVE-2022-4428|CVE-2022-4457|CVE-2023-0238|CVE-2023-0652|CVE-2023-0654|CVE-2023-1412|CVE-2023-1862|CVE-2023-2754|CVE-2025-0651),True,warp,3.4.9,,,,Incorrect package: NVD records affect Cloudflare WARP client and not the Haskell warp web framework.
+(CVE-2021-4235|CVE-2022-3064),True,yaml,,0\.11\.11\.2(-r2\.cabal)?,,,Incorrect package: NVD records affect the Go yaml.v2 package and not the Haskell yaml package.
+(CVE-2002-0059|CVE-2022-37434|CVE-2023-45853|CVE-2023-6992),True,zlib,0.7.1.1,,,,Incorrect package: scanned component is the Haskell zlib package and NVD records affect C zlib or the Cloudflare zlib fork.
+CVE-2023-6992,True,zlib,1.3.2,,,,Incorrect package: NVD record affects the Cloudflare zlib fork and not upstream zlib 1.3.2.
 CVE-2024-9410,True,ada,3.4.4,,3.4.4,3.4.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2018-13162,True,alex,3.5.4.2,,3.5.4.2,3.5.4.2,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2021-43138,True,async,2.2.6,,2.2.6,2.2.6,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -24,18 +67,25 @@ CVE-2019-9924,True,bash,2.05b-builder,,,,Build-time bootstrap artifact: all curr
 CVE-2024-58251,True,busybox,1.37.0,,1.37.0,1.36.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-14363,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-14363,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-14363,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-39837,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-39837,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-39837,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-39839,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-39839,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-39839,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-39840,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-39840,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-39840,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-39841,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-39841,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-39841,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-58519,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-58519,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-58519,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2026-58521,True,cargo,1.94.1,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
 CVE-2026-58521,True,cargo,1.95.0,,0.4.9,0.4.9,"Incorrect package: CVE affects the MediaWiki Cargo extension, not Rust Cargo."
+CVE-2026-58521,True,cargo,1.97.1,,0.4.9,0.4.9,Incorrect package: NVD CPE is mediawiki:cargo for the MediaWiki Cargo extension; scanned component is Rust Cargo 1.97.1.
 CVE-2019-10010,True,commonmark,0.2.6.1,,0.2.6.1,0.3,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-30838,True,commonmark,0.2.6.1,,0.2.6.1,0.3,Incorrect package: CVE affects PHP league/commonmark; scanned derivation is Haskell commonmark 0.2.6.1.
 CVE-2017-18589,True,cookie,0.5.1,,0.5.1,0.5.1,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -67,16 +117,22 @@ CVE-2026-40469,True,gawk,5.3.2,,5.4.0,5.4.1,Not applicable to this target: CVE i
 CVE-2026-40469,True,gawk,5.4.0,,5.4.0,5.4.1,Not applicable to this target: CVE is limited to 32-bit gawk builds; target host platform is x86_64-linux.
 CVE-2021-21684,True,git,2.53.0,,2.54.0,2.55.0,"Incorrect package: Impacts Jenkins git plugin, not git. Issue gets included to the report due to vulnix's design decision to avoid false negatives with the cost of false positives: https://github.com/nix-community/vulnix/blob/f56f3ac857626171b95e51d98cb6874278f789d3/src/vulnix/vulnerability.py#L90-L96."
 CVE-2021-21684,True,git,2.54.0,,2.54.0,2.55.0,"Incorrect package: Impacts Jenkins git plugin, not git. Issue gets included to the report due to vulnix's design decision to avoid false negatives with the cost of false positives: https://github.com/nix-community/vulnix/blob/f56f3ac857626171b95e51d98cb6874278f789d3/src/vulnix/vulnerability.py#L90-L96."
+CVE-2021-21684,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2022-30947,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-30947,True,git,2.54.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2022-30947,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2022-36882,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-36882,True,git,2.54.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2022-36882,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2022-36883,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-36883,True,git,2.54.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2022-36883,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2022-36884,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-36884,True,git,2.54.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2022-36884,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2022-38663,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2022-38663,True,git,2.54.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2022-38663,True,git,2.55.0,,2.55.0,2.55.0,Incorrect package: NVD CPE is jenkins:git for Jenkins Git Plugin; scanned component is upstream Git CLI 2.55.0.
 CVE-2025-66413,True,git,2.53.0,,2.54.0,2.55.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2012-2055,True,github,1.47.0,,,,False positive: generic package-name match for github; scanner could not confirm a matching Repology version for the actual Nix package.
 CVE-2020-10517,True,github,1.47.0,,,,False positive: generic package-name match for github; scanner could not confirm a matching Repology version for the actual Nix package.
@@ -105,6 +161,8 @@ CVE-2023-49292,True,go,1.24.13-linux-amd64-bootstrap,,1.27rc2,1.26.5,False posit
 CVE-2023-49292,True,go,1.25.12,,1.27rc2,1.26.5,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-49292,True,go,1.26.2,,1.27rc2,1.26.5,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2023-49292,True,go,1.26.4,,1.27rc2,1.26.5,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2023-49292,True,go,1.25.13,,1.27.0,1.27.0,Incorrect package: NVD CPE is ecies:go for the ECIES Go library; scanned component is the Go toolchain.
+CVE-2023-49292,True,go,1.26.5,,1.27.0,1.27.0,Incorrect package: NVD CPE is ecies:go for the ECIES Go library; scanned component is the Go toolchain.
 CVE-2017-5436,True,graphite2,1.3.14,,1.3.15,1.3.15,NVD data issue: CPE entry does not correctly state the version numbers.
 CVE-2013-4577,True,grub,2.12,,2.12,2.14,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2026-12891,True,gstreamer,1.26.11,,1.28.4,1.28.5,"Incorrect package for this target: CVE affects gst-plugins-bad, but the scanned closure contains gstreamer/gst-plugins-base and no gst-plugins-bad derivation."
@@ -175,6 +233,7 @@ CVE-2026-55653,True,openssh,10.3p1,,10.4p1,10.4p1,"Not applicable to this target
 CVE-2026-55654,True,openssh,10.3p1,,10.4p1,10.4p1,"Not applicable to this target: CVE is for Red Hat Enterprise Linux OpenSSH patch behavior, not upstream Nixpkgs OpenSSH."
 CVE-2026-55655,True,openssh,10.3p1,,10.4p1,10.4p1,"Not applicable to this target: CVE is for Red Hat Enterprise Linux OpenSSH patch behavior, not upstream Nixpkgs OpenSSH."
 CVE-2025-47436,True,orc,0.4.41,,1.2.1.4,1.2.1.4,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
+CVE-2025-47436,True,orc,0.4.42,,1.2.1.4,1.2.1.4,Incorrect package: NVD CPE is apache:orc for the Apache ORC C++ library; scanned component is Oil Runtime Compiler 0.4.42.
 CVE-2026-2100,True,p11-kit,0.26.2,,0.26.2,0.26.4,Not affected: CVE affected range is p11-kit <0.26.2; scanned version is 0.26.2.
 CVE-2015-4155,True,parallel,3.2.2.0,,3.3.0.0,3.3.0.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
 CVE-2015-4156,True,parallel,3.2.2.0,,3.3.0.0,3.3.0.0,False positive: scanner triage classified the Nixpkgs package/version as not affected based on Repology/upstream package data.
@@ -359,6 +418,7 @@ CVE-2019-5443,True,curl,0.4.49,,,,"Incorrect package: scanned component is the R
 CVE-2020-8284,True,curl,0.4.49,,,,"Incorrect package: scanned component is the Rust crate curl 0.4.49 in the build closure, not curl/libcurl; actual curl/libcurl derivations are scanned separately as curl 8.x."
 CVE-2024-21485,True,dash,0.5.13.2,,,,Incorrect package: CVE is for Plotly/Python dash and dash-core/html components; scanned component is the dash POSIX shell for x86_64-linux.
 CVE-2024-21485,True,dash,0.5.13.3,,,,Incorrect package: CVE is for Plotly/Python dash and dash-core/html components; scanned component is the dash POSIX shell for x86_64-linux.
+CVE-2024-21485,True,dash,0.5.13.5,,,,Incorrect package: NVD CPE is plotly:dash; scanned component is the dash POSIX shell for x86_64-linux.
 CVE-2021-37322,True,gcc,4.6.4,,15.2.0,16.1.0,Build-time bootstrap artifact: all current rows for this CVE/package key are gcc 4.6.4 bootstrap compiler derivations in the build closure; current gcc 15.x rows are scanned separately.
 CVE-2023-4039,True,gcc,10.4.0,,15.2.0,16.1.0,Target-specific false positive: CVE is limited to GCC/Arm GNU Toolchain targeting AArch64; scanned component is an x86_64-linux build.
 CVE-2023-4039,True,gcc,15.2.0,,15.2.0,16.1.0,Target-specific false positive: CVE is limited to GCC/Arm GNU Toolchain targeting AArch64; scanned component is an x86_64-linux build.
@@ -431,9 +491,13 @@ CVE-2009-2624,True,gzip,1.2.4,,1.14,1.14,Build-time bootstrap artifact: all curr
 CVE-2010-0001,True,gzip,1.2.4,,1.14,1.14,Build-time bootstrap artifact: all current rows for this CVE/package key are gzip 1.2.4 bootstrap derivations in the build closure; current gzip 1.14 rows remain active for their own CVEs.
 CVE-2016-2563,True,kitty,0.47.0,,,,Incorrect package: CVE affects the PuTTY-derived KiTTY SCP utility; scanned component is the Kovid Goyal kitty terminal emulator for x86_64-linux.
 CVE-2023-48795,True,kitty,0.47.0,,,,"Incorrect package/implementation: CVE affects SSH transport implementations; scanned component is the Kovid Goyal kitty terminal emulator, not an SSH transport library."
+CVE-2023-48795,True,kitty,0.48.2,,,,Incorrect package: NVD affected products are SSH implementations including 9bis:kitty KiTTY; scanned component is the Kovid Goyal kitty terminal emulator.
 CVE-2024-23749,True,kitty,0.47.0,,,,Incorrect package: CVE is for KiTTY Windows PuTTY fork; scanned component is the kitty terminal emulator for x86_64-linux.
+CVE-2024-23749,True,kitty,0.48.2,,,,Incorrect package: NVD CPE is 9bis:kitty for the Windows PuTTY fork KiTTY; scanned component is the Kovid Goyal kitty terminal emulator.
 CVE-2024-25003,True,kitty,0.47.0,,,,Incorrect package: CVE is for KiTTY Windows PuTTY fork; scanned component is the kitty terminal emulator for x86_64-linux.
+CVE-2024-25003,True,kitty,0.48.2,,,,Incorrect package: NVD CPE is 9bis:kitty for the Windows PuTTY fork KiTTY; scanned component is the Kovid Goyal kitty terminal emulator.
 CVE-2024-25004,True,kitty,0.47.0,,,,Incorrect package: CVE is for KiTTY Windows PuTTY fork; scanned component is the kitty terminal emulator for x86_64-linux.
+CVE-2024-25004,True,kitty,0.48.2,,,,Incorrect package: NVD CPE is 9bis:kitty for the Windows PuTTY fork KiTTY; scanned component is the Kovid Goyal kitty terminal emulator.
 CVE-2021-4048,True,lapack,3,,3.12.1,3.12.1,Incorrect local version: Nixpkgs lapack-3 is an ABI shim over OpenBLAS 0.3.32/0.3.33 and liblapack headers 3.12.1; CVE affects LAPACK through 3.10.0 or OpenBLAS before 0.3.18.
 CVE-2026-58050,True,libssh2,1.11.1,,1.11.1,1.11.1,Target-specific false positive: CVE is limited to 32-bit platforms; scanned libssh2 component is built for x86_64-linux.
 CVE-2019-17178,True,lodepng,3.12.1,,,,Incorrect implementation: CVE names HuffmanTree_makeFromFrequencies in C lodepng.c through 2019-09-28; scanned crate is the pure-Rust lodepng 3.12.1 rewrite and does not contain that C function.
@@ -669,6 +733,16 @@ CVE-2025-69652,True,binutils,,2\.46(\.0)?,,,All referenced upstream fix commits 
 CVE-2007-1397,True,fish,4.8.1,,,,"Product-name collision: the CVE affects the FiSH IRC encryption add-on, not the fish shell."
 CVE-2023-4039,True,gcc,15.3.0,,,,Target mismatch: the CVE applies only when GCC targets AArch64; this derivation targets x86_64-linux.
 CVE-2026-5201,True,gdk-pixbuf,2.44.7,,,,Fixed before this build: Debian records 2.44.6 as fixed and 2.44.7 is the scanned upstream version.
+CVE-2010-4756,True,glibc,2.42,,2.42,2.44,Sourceware bug 18012 for CVE-2010-4756 is RESOLVED INVALID and carries a negative security flag.
+CVE-2010-4756,True,glibc,2.42-67,,2.42,2.44,Sourceware bug 18012 for CVE-2010-4756 is RESOLVED INVALID and carries a negative security flag.
+CVE-2019-1010022,True,glibc,2.42,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010022,True,glibc,2.42-67,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010023,True,glibc,2.42,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010023,True,glibc,2.42-67,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010024,True,glibc,2.42,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010024,True,glibc,2.42-67,,2.42,2.44,NVD description records upstream/vendor position that this is a non-security bug with no real threat.
+CVE-2019-1010025,True,glibc,2.42,,2.42,2.44,NVD description records vendor position that ASLR bypass itself is not a vulnerability.
+CVE-2019-1010025,True,glibc,2.42-67,,2.42,2.44,NVD description records vendor position that ASLR bypass itself is not a vulnerability.
 CVE-2025-15281,True,glibc,2.42-67,,,,The Nixpkgs glibc 2.42-67 derivation contains this fix in 2.42-master.patch or an explicit CVE backport.
 CVE-2025-5702,True,glibc,2.42-67,,,,The Nixpkgs glibc 2.42-67 derivation contains this fix in 2.42-master.patch or an explicit CVE backport.
 CVE-2025-5745,True,glibc,2.42-67,,,,The Nixpkgs glibc 2.42-67 derivation contains this fix in 2.42-master.patch or an explicit CVE backport.

--- a/.github/workflows/flakevuln.yml
+++ b/.github/workflows/flakevuln.yml
@@ -35,7 +35,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run flakevuln
-              uses: tiiuae/flakevuln@31ecdf356f3951cf01c9128ab7e6a781032eaa36
+              uses: tiiuae/flakevuln@bcee94a5eaa101f6bd65c349696ad4e40894b2fa
               with:
                   targets: |
                       nixosConfigurations.hetzci-prod.config.system.build.toplevel


### PR DESCRIPTION
- Update flakevuln to fix the missing TRACKER links: https://github.com/tiiuae/flakevuln/commit/bcee94a5eaa101f6bd65c349696ad4e40894b2fa
- Triage more flakevuln findings
