### PR TITLE
Increase stream limit for loki

### DIFF
--- a/hosts/ghaf-log/loki.nix
+++ b/hosts/ghaf-log/loki.nix
@@ -47,7 +47,7 @@ in
       query_range.cache_results = true;
 
       limits_config = {
-        max_global_streams_per_user = 20000; # default is 5000
+        max_global_streams_per_user = 40000; # default is 5000
       };
     };
   };


### PR DESCRIPTION
Grafana on ghaf-log is hitting rate limit for fake user. Additionally logs from UAE adds up.
This increases limit from existing to 40k as temp fix.