### PR TITLE
cachix: tolerate store snapshot races

### DIFF
--- a/hosts/builders/cachix-push.sh
+++ b/hosts/builders/cachix-push.sh
@@ -316,9 +316,7 @@ process_candidates() {
 
   while read -r -u "$closure_filter_fd" storepath; do
     [ -n "$storepath" ] || continue
-    if [ -z "${closure_filter_matches["$storepath"]+x}" ]; then
-      closure_filter_matches["$storepath"]=1
-    fi
+    closure_filter_matches["$storepath"]=1
   done
   exec {closure_filter_fd}<&-
 

--- a/hosts/builders/cachix-push.sh
+++ b/hosts/builders/cachix-push.sh
@@ -42,6 +42,7 @@ list_nix_store_paths() {
     ! -name '*.check' \
     ! -name '*.lock' \
     ! -name '*.links' \
+    ! -name '.tmp-link-*' \
     -print | LC_ALL=C sort >"$tmp"
   mv -f "$tmp" "$out"
 }

--- a/hosts/builders/cachix-push.sh
+++ b/hosts/builders/cachix-push.sh
@@ -28,10 +28,15 @@ CURRENT_CACHIX_TOKEN_DIGEST=""
 
 # Lists all nix store paths potentially pushed to cachix
 list_nix_store_paths() {
-  out=$1
+  local out=$1
+  local tmp
+
   tmp="$(mktemp --tmpdir="$(dirname "$out")" ".$(basename "$out").XXXXXX")"
   # https://github.com/cachix/cachix-action/blob/ee79d/dist/list-nix-store.sh
-  find /nix/store -mindepth 1 -maxdepth 1 \
+  # Builders and nix-daemon auto-GC can remove store entries while this snapshot
+  # runs. find stats entries before applying the exclusions below, so even
+  # ignored names such as *.drv.chroot can otherwise fail the whole poll.
+  find /nix/store -ignore_readdir_race -mindepth 1 -maxdepth 1 \
     ! -name '*.drv' \
     ! -name '*.drv.chroot' \
     ! -name '*.check' \
@@ -320,7 +325,7 @@ process_candidates() {
     [ -n "$storepath" ] || continue
 
     if [ ! -e "$storepath" ]; then
-      echo "[!] Skip vanished store path: $storepath"
+      echo "[!] Skip vanished store path: $storepath" >&2
       continue
     fi
 


### PR DESCRIPTION
This is a continuation to: https://github.com/tiiuae/ghaf-infra/pull/1231

Make `cachix-push` tolerate transient `/nix/store` entries disappearing while taking its poll snapshot. Busy builders can remove build or GC-related paths between `find` reading a directory entry and evaluating the exclusion filters, which previously could exit the service under `set -e`. That was not fatal because systemd restarted the service, but it caused avoidable noise and delayed polling.

Also excludes Nix store optimiser `.tmp-link-*` paths from snapshots, logs vanished candidate paths as warnings, and simplifies closure filter set insertion.

Tested in ci-dbg and its builders: https://ci-dbg.vedenemo.dev/job/ghaf-release-candidate/70/