### PR TITLE
Rebuild testagent prod in UAE

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -43,7 +43,7 @@ keys:
   - &uae-azureci-az86-1 age1rcwsekkzc2x35kv3qcg6dvgjsl28nxhes4e9g8l5gue54tx2qp7s53wclg
   - &uae-testagent-prod age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
   - &uae-azureci-hetzarm-1 age1khvgc59e6mty0408cs523jzwldgjl389dywfrfmas08kzfdyj40qcuh2vf
-  - &uae-testagent2-prod age10x82kaw0zam7h4mfv88gx75gq7ex4gpfupslzgvh4cvp5sdc09vsmgwsdk
+  - &uae-testagent2-prod age1gqc3zuzve3988wx6qasqazfxt0tkq6mtjg2932d8mv6plage6yes0xscud
   - &uae-azureci-registry age1p07c3w942hfu5ye3t4cuvz29n8erl9nqdezre6u5gxvxwg270veqvl0vm7
   - &uae-azureci-dev age1hxxxvlrwcrvjw7ux7g8seuw2yt7zw09gler9z70070aycknqy3sq9aq5rg
 

--- a/hosts/machines.nix
+++ b/hosts/machines.nix
@@ -324,8 +324,8 @@
     module = ./uae/testagent/prod2/configuration.nix;
     system = "x86_64-linux";
     machine = {
-      ip = "172.20.16.25";
-      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBxyeOZsaqhiDREmVU+H8sUIiCmg6JgjDdbAvFpDx+KI";
+      ip = "172.20.16.26";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBlJBTvSjf/5wQwvMXGtAVxuSu3zF1dKnXccWpqw8CXu";
     };
   };
 
@@ -349,4 +349,5 @@
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJiajaY3bfjPdPtp8psMMRv42s6aFUN3Vba+iJlP954U";
     };
   };
+
 }

--- a/hosts/uae/testagent/credentials.yaml
+++ b/hosts/uae/testagent/credentials.yaml
@@ -9,51 +9,51 @@ pi-login: ENC[AES256_GCM,data:H69GRA==,iv:c7SBQR3RWY4d7XScmgO/bKQbTB7COLOyrmuO4P
 pi-pass: ENC[AES256_GCM,data:pIUeLqZl8H+vVVk0kw==,iv:sKSBmiVssQe+kgr3L89JgQrofZkGfdcYi02fnFxbOrE=,tag:gDEiXxFKn2FhO7y7X9LpaQ==,type:str]
 sops:
     age:
-        - recipient: age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMNDNMQlZMbmxhNkJFcnF4
-            a0t0T2JxZlU1RENjQTNzMHJYK0NUZmp4d0RVCkQ4cmdUU3pkZWdxQ1d2UUdVK3B4
-            ZUpHMTljSStnejZNcnkrV1BoQXJMSG8KLS0tIHRkeldGaUFHNnIrNnBrMHNmamlx
-            N0k4WGlETjRDdm9RTTNaR0V1cVBtbmMKpKr95za66vy3PqU355MBg9OE2mO5jBE4
-            v0bKBxSvD/r2noWXHNAC1c7azOAq46m7bDLyQ+2GxexteILSLuKdXA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsNWl0dzQvamN5U2lDVjBs
+            bzc3N0t5VnBXbFBlcDF2c0Z1SUxsYkdUT1MwClpxZzZEUDZhNnYwZlRyaU1iVzRa
+            Mk82bjNEdmI5TkJFTXpvUEU3KzRJSGsKLS0tIHh5b0FmNTJNaTdkaFVOMkFwUnpj
+            TmRPNEtQZnJWak15YS84SjBRYnBjQ0kKL25iRamgaZzyU6HWHmmCDovJJa/RKnyw
+            +YBcuH+8fGVX4i2e0sV1/6XWfJvk2p2HCllq7SG29T3mFnA0nLu9aQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age10x82kaw0zam7h4mfv88gx75gq7ex4gpfupslzgvh4cvp5sdc09vsmgwsdk
-          enc: |
+          recipient: age157plehwp0vk08g3tkvvzur7gq4pqg0xkkzth6ljw65zfcmlw8gnsc70uvr
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQMDlIbmM2dTMzZG9jeEVM
-            R0FiV00vazBzUlZydWVmKzF0Rlo2QWdIVFFjCm9UTHVFK243eEszaTZ5UEFycGE4
-            c3grUEFnL0ptMEI3Q3BVUGp0ZnkzYjgKLS0tIFBkczhHc0V3V2R2OG0wd3M1ZVNO
-            M0JZZjZ6YW85ZEpuaHI3QXJOTUp2dW8KyQGz9OzgK3BUljcaJFx/I56kYzcL9Jj+
-            acOMaQT73RzXQfcp6pho7sKqOykfeqv9cKDQDb0/9DNTZmuzVbE5bQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXVWJzNW1SazJJRm5aOTNO
+            QzZzWjlWR1hObkxxamZIeXNJMnVsaHpJOFVVCjhCMGdiVERRYk1GQnd6cm1DUTRM
+            R3g1T3BWbGhuUkh3VGJDR0NGVWVIVzAKLS0tIGZ2bVBvcHJVVTZrRzNhd1JidWdx
+            NnpiRURWRjk1UjFWdGxZbGdMdW53ZFEKe+IfPuDiJp54DdgkvwrFM34s4VxIo/Uo
+            oBgkeUDARE/Vc4DYwqsnumdWJIlNqWKcoCSJay39FBbz6YybuzYT1A==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
-          enc: |
+          recipient: age1gqc3zuzve3988wx6qasqazfxt0tkq6mtjg2932d8mv6plage6yes0xscud
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMS1FlQ2V6ZmlHVkFsNmY1
-            SjlyaSt6VFpYeE5rYUVodmtvZ3I5ZXRERmxjCjMxK05OQXBNSHRkazVid0cvK2Q2
-            R05kVVNWa210UGh0VGV1VVZkS0laTjAKLS0tIEw5VTRXRTBVR3hWMUgzazBHSzVI
-            dzhHYVZKbjZoNmU1MmZQbktuVE41bm8KAVThysrDkdBj1K0/XSRVz94AaPja/hoJ
-            KWMidXdnE7Vwv0zYugFVO0fzz8YbCsl9axfqwvVbgyrvzCK5QSxhOA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNG5VUlROdkUvWGVENDIy
+            dW8yaGJpUE1PMjI2NVVQTnFZSjUzWkxEdkZ3Cnl2WFFTL25tN2JCeFpWWjhyaGhy
+            RUljRGJ4Z1NXTkxDK0FRbm0zblBSS3MKLS0tIFR1TTc4eUZCZms3R3ZNQ3d4czl4
+            ZVVUL0Z6dE9oTTZhWE43bUd2RTZnNncKDefPjrscMYvjUlrzT2TmyJtB4p9PZoLm
+            KuZHsfiaK6v9IgXM83t0WaXjriy4Q4r9XNDCia5KYq91zzxMRW7MPA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
-          enc: |
+          recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2alpyVEp5N3NHdmZKUHBr
-            Ykg3SHZFcUdQcW1GUC9tUjBvd2pWOVFQbFc4CnRMSkZBWmdDWnllazltMUF6cm1j
-            VGlXbUxabW9PellicFhYTURGMVVhQzgKLS0tIGZCbHZMd2hSNGNFMmhLK2NVM1hX
-            WmZmRFBQbTFLU1oxc1l5NGNVa1c4azAKvq//cCi83VDjVR0A5jiZBlYIFMPiM97a
-            gpNtujU9YjrzaX9veO9oAQ1obeTjMi+THF9HJLNJdDwoXazluJD3qQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1VHR2Y1FEbHB5L2phTEl1
+            RFluNFdEUjdiTTBHNFEwSjhrVllxeDRuY1hZCm5qTEo0Rk1panQzQTZ1L3dJeElX
+            bWJlc3p6Sjl2bXI0V0JWNzdhUUZnZkkKLS0tIE5ZUHYxQWE1N2MzZWZibTlXVlVE
+            REdpV1ZEOExmWVVvUkZNTnczSnhUUHcKQCp/4pQk6WU2uIaBOpvVKdmrsZuVBWZj
+            WK8DSJSuOKfQvLIVXVkKm3jZJF9KqdQbZUhiCFP8QCuA45fxxnl7XQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
-          enc: |
+          recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSb3ZNemx3QTNmb3dUTi9p
-            U1JFdEFPZjBORGl6QVNycXFZS0duRThpV1Z3CjROVjlUZXRoY1lNem1Zb0pWWnBk
-            YXRhMkxhbUp1VW5lMmZGY0JoVWx2NlUKLS0tIGVscXA3blVtNklqSmtCM2tlRnNs
-            ZDVPTjFzOGFGaUU0eHVsZHZmU0N4VWsKgP/ayANnfHfsOvS0tj8E/2pzP2+7jRJi
-            KHFxh8fUtwN5sjSkFtm3mcZEP1R/p/fhJeyKow+sWH7zP9DtVpQPEw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvMGtkbUNsMzZ0WnAyTE5k
+            TkdpeFBlRUJvQ29MM0JOUy9FdzJvd2gyQjA0Ci9zU2Z4VERtbFRaTzFFUU5EdCtJ
+            aXk1YkgvT1lCaE1sU3ZlaDduOWtZcDQKLS0tIC9idjZaSFYrazhrU0pralBZb3la
+            SmczUTQyTTlRN2JYZ1E3UjIvdDNtaU0KzwWxgM5mh+lsrM+yhQ2mwbxJYQJoqSD5
+            gQ5MEM4M1zGewfmMUiRvTNDHeNo0DJlcKehDKmoRwjN0pDdFywHrKQ==
             -----END AGE ENCRYPTED FILE-----
+          recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
     lastmodified: "2026-02-02T08:31:33Z"
     mac: ENC[AES256_GCM,data:5HDxGzT4bxNmbnEaoQLwDUmJ5J0JNItN15WZJ7fo5HtKp5dGa0qVQae5/mLGVGYcZIkbT9toF2uaQGoIsCE3o1O8HAbx1PJReS3BN1EYnd5LNthRR5Zm4HoeODLvj9KI2eJCOGgU0iwLVEXttF7op8AJS5FKr1u6FWadNSDl71k=,iv:5FmQUb1oFsqR4DaDMRutrMF3gxd4b6w42ShXIfsBONU=,tag:q7d1i9I8Jvs0Ra9UC5kosA==,type:str]
     unencrypted_suffix: _unencrypted

--- a/hosts/uae/testagent/prod2/configuration.nix
+++ b/hosts/uae/testagent/prod2/configuration.nix
@@ -51,8 +51,8 @@
     ];
   };
 
-  # this server has been installed with 25.11
-  system.stateVersion = lib.mkForce "25.11";
+  # this server has been installed with 26.05
+  system.stateVersion = lib.mkForce "26.05";
 
   # udev rules for test devices serial connections
   services.udev.extraRules = ''

--- a/hosts/uae/testagent/prod2/disk-config.nix
+++ b/hosts/uae/testagent/prod2/disk-config.nix
@@ -1,35 +1,31 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 {
-  disko.devices = {
-    disk = {
-      vda = {
-        device = "/dev/disk/by-id/nvme-Samsung_SSD_970_EVO_Plus_2TB_S4J4NX0W800242X";
-        type = "disk";
-        content = {
-          type = "gpt";
-          partitions = {
-            boot = {
-              type = "EF02";
-              size = "1M";
-            };
-            ESP = {
-              type = "EF00";
-              size = "512M";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot";
-              };
-            };
-            root = {
-              size = "100%";
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                mountpoint = "/";
-              };
-            };
+  disko.devices.disk.os = {
+    device = "/dev/disk/by-id/nvme-Lexar_SSD_NM620_256GB_RB1758H000866P1104";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          type = "EF02";
+          size = "1M";
+        };
+        ESP = {
+          type = "EF00";
+          size = "1024M";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
           };
         };
       };

--- a/hosts/uae/testagent/prod2/secrets.yaml
+++ b/hosts/uae/testagent/prod2/secrets.yaml
@@ -1,44 +1,44 @@
-ssh_host_ed25519_key: ENC[AES256_GCM,data:vhpvLmoWrwhdvsQ9LQHB8Oodku1ln8g6jnsaUwVyMiTbGhPgx8IilEXavRyg4SciwTrwfU+VfPGgO2GnvMrroT7vElGWvsA/IoEp8nz79StZspA5eliopxK6fkEHwOcqiNSNQ7McCg3FWOaf5rDkJL67ndHkwl+EN/Z6nCULWTBYW8Gd+IVFoqOe0PvUpYYzQKjgjRWqg1sZku3ZOzjYUUMqMPay6y72tD5YYG2u1cdRN0t4wURP27v+GKAiLlAGBucQqZ6iPRaEt6NpvdoXRRjaXDN9UgCRwO2VvOEx6zb7zC8xcFDv0pr9rCWUiOelo/0jhEO9Skz0WTPamMdYI4lM92LPigj4bhw6AjOu88dB8SP16Nr8wjHBMUiuwU8FgIc5UWmhGCFLojRznYnfHoNjYN8eKloG6uObu8684Z0YyFdry4p5MGcnRYMUAxYlA+BsqwluOay03NSHqsYGwHXc40dSC98GH+C0T2XH9hU69DKf9KVuvk32IZq4xyH3MjG7HtG4tm7UyabZPcfG6qbhS98RvSmJU/gs9KIDTPjTLEs=,iv:7/DmUr5AksQTE5wsQ71CEyeJyE4rjb9C6JDjVjF4t64=,tag:R7o+7wOov6gvzxSiy6JLPw==,type:str]
+ssh_host_ed25519_key: ENC[AES256_GCM,data:VRnEMANkf4fnhf0wZS+qjxiwQb+5OSr0ucaQSZUItnlFAYy8raWp+Q257WV/8XwoBwVwnkzRiOMDlEfn+vGs2IjsRjdnu1Xo1X8dT5U8xCa29REdrWd0NzgukHWLurTpLZUd/z8CWpm8cZSwzpTntYyibyBIld1km8hgKsMauA9j33pgn2ohJSZgZNdGiaVJjeHCEoEjDM15qdTcPSMeuScuaQ+4pzUwH/nWl8W5UOV4pfxUJZ4RT3z3VYajdIDVVbUJeD1T3qgDJ4lUX8lTuGYAynqJv1s6MfXjBc0NupMts1ypBhMir8f860WpOYdMxSW+yrhz4+LSJ5+QgpGIdq11ZIWYrD0qyRH9dp+/xMx3UGsL2hvO3VvyP8o85t8dol0aHG/mGVgxd+rGLtAA8QEzvHm5DMWQKJ22/oM4AXsJbN7ltYDQuZIf7hqrdOXFtfoFocnDFHElfNyAKnYX4ITlxO8TF/1YAQ8ENlZLpG15KmUMN3vNSX8od0PPsJBNHDM+kB/x1VTwMbk91TL4MeAuiGWtBBRN01XsRQXnamGuD/I=,iv:4t1cqiNtd/p1ATm5lrsBkFcT3ZLqAr6Q36HEA4RGENU=,tag:8QEcba5G/CCatg2/bNSrPA==,type:str]
 metrics_password: ENC[AES256_GCM,data:DLXu6ugWD15xzcjSx3UT3YLJRw==,iv:IRzD5tuhN3Wmt2s/DVh7+yoTe1Wb5oerw4tQOo663gI=,tag:ngTIEvEE10x6pa3jehe/Cw==,type:str]
 sops:
     age:
-        - recipient: age10x82kaw0zam7h4mfv88gx75gq7ex4gpfupslzgvh4cvp5sdc09vsmgwsdk
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMaXkrN3kwUlh4QzlkQkpX
-            SUNJL09hME5ZU0ZnVWV3MnNrN3dxa2NNeEd3Cnl5VW5vTEIrYmtDKzV5d0R0ci84
-            cnE3NDNtcUJEMnpoQlBhakRUWjNBQ2MKLS0tIGNMaXA2WTlCRlVoVnVIUHM4dGpD
-            VTdvTnVPUlVLNy9PNEVac2c3aHF5MEkKbMRfehvNzzMciJ8P5JvFIrcR6q4RKNNs
-            5XAVS1nrroXD/t8lZNWE1Syt6LnQiGPETnkboi+NAbSbRY2HcJPSrA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoR1VQUUpYdGI2UWxoZmFK
+            d1ZvcFRkakNOZnpucnRpSDArQ05VWUM5aGhZCjc2QU5xclhxRnY2S05mSUN2RXF6
+            TFNoaHM5R2NxYVVrbzdqYXdnZnUvckEKLS0tIHdZQ2prRTdhSDlQbStXUko2NWw1
+            VkpJNC9uc013dmFySVFQbFM3TVpSOWMKU7bEw/TUERSsp5mte45mzmCSLU6FjReS
+            VQtdl0T9AzxcpFUVZQ4K1RVLL14rLSR5LG0cFaWUot+uRD7s935vTQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
-          enc: |
+          recipient: age1gqc3zuzve3988wx6qasqazfxt0tkq6mtjg2932d8mv6plage6yes0xscud
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCSjdZZzNwbFRDeDF5WHN2
-            T1ZsQmlDSkRhNGU5eTd5eElVYUZIWlJJaEcwClBhNEVmVzFPMi9BQ1lyQ1A2VElW
-            MXZJKzBmWDV3QUxnd2hSOEx2MFNYa0EKLS0tIGFaRTlpL2dMT00vOG45cXRGYmhs
-            Z0s5cmJ6SFVYaklRNEs4RzR2bTdqR0kKhXE5/pl0yWdKtQd3k9bICVJvdEauVwaz
-            7aLdy1LijRQnjB/Zu2mYwnRwwXrvqNVtu2EKB5F9Z4DM2+UIckmf8w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5aDF3UGtiZitrMzFEcTls
+            MFFMQUMxbVVBY0JMYVdQQU9hREtidE1Wem1vCk9scEdPY01kY2dzWWdjemJkd1pw
+            K0s0Y0Eydis0YTFJZTFEalpuS052MDQKLS0tIHdsU2kxSVJnSFNINGVyUnVYblhs
+            T3Y2UEFMSVQ3blNZTU5QK2RZeExEVW8Kj1F+3htsM4dwEVH2XIvA9gMGrsXnQ4MZ
+            cExUXKy9Slmuh5QQM8zf3yJamvYS7G/2d/CkWkmGesFfOZd559Zjbg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
-          enc: |
+          recipient: age1hszrldafdz09hzze4lgq58r0r66p4sjftn6q8z6h0leer77jhf4qd9vu9v
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGMjE4V0E0djZqM1RFZVE1
-            bm9wbGJDbHFwcjEzNGMzUVNWeXlZdUg2VW5NCjdTWEVqSStSSS9zcTFhVU14NUxi
-            K0JGVWhsbDdubGNWWTkrdGpmdGtWMVEKLS0tIE5DVUlEQkdnVjRFSm9DajZuajB1
-            WjljQVNSOWtyZk1vSXoyRDN0TitteG8K/Gl2ZZcD0+zXebCtfCq7ZGBJ5mi0JWve
-            AYG56T1UXNulZiBriz4zu80S+AecR+EjxGiANOW+N+LSqWIOKsa/rA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpbTEzSjh5RFNEUnh4K3R1
+            TEtBdGV6bkdrS3UxRE5jZFg5RVZkM2dTeEU0ClA4N3Z1SjlmWVZrUTNpc053QWdl
+            SEZNYUdpQW11YlozTkFzcG1yemEyZ3cKLS0tIHVQb2swc202UnV0K2NZcmFIazZ5
+            THVNTXBBRUVPd2ExVHhtTVE1aXFTL0kK8T2sD+YOingu/pEdLicKXs+CYQD7Ok9P
+            ae0IvlyC9IXbW8Nhs4AyPv9hYTiJ1NuTXxADMD7KzvQ+4IDOnwWLWA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
-          enc: |
+          recipient: age18t3gss4l6l629rd8s93eh3ctycu9vjnsftehy38c8tstu2gqycxs64t4sw
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDYjlXOG9YQ29OQlRXUDNO
-            bHhPSzVMYjVTN1V3QjZaYkJidFozZVp6dWpvClhZVXdKb29TQ2dOWE5yWXJ3VDAy
-            d0ZUVGtSSEZFQ2V3dkRTQTZTbU5ySk0KLS0tIHVhNVFMYS9DREh4YjVQa2tqbWF5
-            ZGFZRk9YYW5leFFncWptdThlR2FFcU0KgbeYC3nLQO/+wBdhTdlDjsq1j8dd8dBr
-            AyOD2f652u9zJixRdf2MJHtdfm02bHlrtN7tie2iCdGvPUxNVVCb8Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDeDdtYm9EUnk5cjQzZ0Vs
+            cU9FRWY0M3RLK1J4RVZXYnpUaXhRYkhFZ3drCitlMUF0UW05SGROUWRvWTJ0V0o1
+            QWp4U2lpcXBlaENOUHczY1crSGdGMkUKLS0tIEtIQVlMWkJ5SEhoZWdzdENCOGZT
+            Tnp4WW9SdlB4L3dEU3FseCtlWjdRYjAKAAxVuQ63dJCFwBUFE4sW90x9ywhyf9an
+            3tF07cKhX111f5RUNvLJI4rVYE+aeqgNY7J3c4H50Yk8uHDJ7Wx/RQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-20T07:29:10Z"
-    mac: ENC[AES256_GCM,data:K5A+kMMvOO1Ps0wU9yrzHls/duhRayyPz4+BmxdxtSOyYJF7JkT4y1mc1X2V4fpzMvxKT/ynZOYYdZcKvJPlxOnJZnDUYibT/fgJ0ARXVrhi3A6XaElZqqvwcWxGHP5gul+j0ZvRqjgVw0OwTo4J5+Lci8RKQVfnZUVt4iS2ccA=,iv:J5aFm43mEdqm9YHCO7cpWwZ7WfmdjlHBmlb4wGscc1c=,tag:4Pn+3wGz91HnZjhT/8oSOw==,type:str]
+          recipient: age1hc6hszepd5xezxkgd3yx74pn3scxjm5w6px48m4rq9yj7w6rke7q72zhgn
+    lastmodified: "2026-08-25T12:49:10Z"
+    mac: ENC[AES256_GCM,data:szovT0WDdLwAkYVEHC6gBGqkdu4qcIa08RE09rBMkeQYF/9+fKnUCyR/ugxSIi/+CivJLUvassXop/QZ2w/PdTlaIzcSf6ok6WYmV0CeWli0u4/LNTBnCvKY3dMBsJWSkd7OHZ3w7eKBtR/nuUagbBUp4QwiEbbAwowB0pQlcm0=,iv:2/s8uFniOVE72cGoQzMBxM2Rcs10ACSTiOmS7xp8eYM=,tag:pU0fhqUzBAr8Zsfra8o5tA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.13.2


### PR DESCRIPTION
Rebuild testagent prod2 on a node with more ports. 
Fixes flash issues in UAE by reducing load on the usb hub. 
Bumped state version to 26.05. Swapped ssds, updated IP address.
Credentials and secrets updated against new keys.