### PR TITLE
Enable multi-tenancy in ghaf-log loki config

### DIFF
--- a/hosts/ghaf-log/configuration.nix
+++ b/hosts/ghaf-log/configuration.nix
@@ -19,6 +19,7 @@
     openssh
     nginx
     team-devenv
+    team-testers
     user-bmg
   ]);
 

--- a/hosts/ghaf-log/loki.nix
+++ b/hosts/ghaf-log/loki.nix
@@ -11,7 +11,7 @@ in
     enable = true;
     dataDir = loki_data_dir;
     configuration = {
-      auth_enabled = false;
+      auth_enabled = true; # enables multi-tenancy
       server = {
         http_listen_port = 3100;
         http_listen_address = "127.0.0.1";


### PR DESCRIPTION
Enables the use of `tenant_id` in https://github.com/tiiuae/ghaf/pull/2172, to avoid hitting per-user limits.

something to note is that once we enable multi-tenancy on `ghaf-log` then sending any logs without tenant id present will fail

Also add testing team access to ghaf-log