### PR TITLE
Add break step to all installers

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test-manual.groovy
@@ -418,7 +418,7 @@ pipeline {
           when { expression { env.INSTALLER_FLOW == 'true'} }
           steps {
             script {
-              if (env.INSTALLER_FLOW == 'true' && env.DEVICE_TAG == "darter-pro") {
+              if (env.INSTALLER_FLOW == 'true') {
                 ghaf_robot_test('break')
               }
               ghaf_robot_test('relay-turnoff')

--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -423,7 +423,7 @@ pipeline {
           when { expression { env.INSTALLER_FLOW == 'true'} }
           steps {
             script {
-              if (env.INSTALLER_FLOW == 'true' && env.DEVICE_TAG == "darter-pro") {
+              if (env.INSTALLER_FLOW == 'true') {
                 ghaf_robot_test('break')
               }
               ghaf_robot_test('relay-turnoff')


### PR DESCRIPTION
~~To be merged after https://github.com/tiiuae/ci-test-automation/pull/959~~ Merged

Break is needed for all installers after https://github.com/tiiuae/ghaf/commit/561a9772a7566460099bb48273a707ac3ba608e3. It added a new boot option `Ghaf` whenever installer was used. `Ghaf` becomes the default boot option and booting from the SSD to wipe does not work on X1 anymore.

On Darter Pro we already have a workaround for this because it does not remember the boot order. This PR adds the same `break` workaround for X1 too.

**Testruns** (tested with https://github.com/tiiuae/ci-test-automation/pull/959)
- [Lenovo X1 installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7735/)
- [Darter Pro storeDisk Installer](https://ci-dev.vedenemo.dev/job/ghaf-hw-test-manual/7736/)