### PR TITLE
flake: make sbomnix follow root nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -340,22 +340,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1786862985,
-        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "robot-framework": {
       "inputs": {
         "flake-utils": [
@@ -406,7 +390,9 @@
           "flake-root"
         ],
         "git-hooks-nix": "git-hooks-nix_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "vulnix": "vulnix"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
         flake-parts.follows = "flake-parts";
         flake-compat.follows = "flake-compat";
         flake-root.follows = "flake-root";
+        nixpkgs.follows = "nixpkgs";
       };
     };
 


### PR DESCRIPTION
Point sbomnix at the flake's top-level nixpkgs input so it no longer carries a separate nixpkgs lock entry.
This way, when we bump nipxkgs pins in ghaf-infra, also the version of sbomnix used in ghaf-infra gets updated dependencies.

Tested locally by running full sbomnix test suite with the new pinned version, and also tested with the sbomnix+nixpkgs combination from https://github.com/tiiuae/ghaf-infra/pull/1248.
