### PR TITLE
Disable scrub on registry and make gc more stable

### DIFF
--- a/modules/zot-registry.nix
+++ b/modules/zot-registry.nix
@@ -21,7 +21,8 @@ let
       rootDirectory = zotDataDir;
       dedupe = true;
       gc = true;
-      gcInterval = "24h";
+      gcInterval = "1h";
+      gcDelay = "24h";
       retention = {
         policies = [
           {
@@ -130,7 +131,6 @@ let
       ui.enable = true;
       search.enable = true;
       metrics.enable = cfg.metrics.enable;
-      scrub.enable = true;
     };
   } cfg.extraConfig;
   zotConfigFile = pkgs.writeText "zot_config.json" (builtins.toJSON zotConfig);


### PR DESCRIPTION
Scrub was using massive amounts of IO so disable that. Small GC every hour instead of large GC once a day should make it more stable.