### PR TITLE
Fix nix.settings.experimental-features format

### DIFF
--- a/hosts/uae/azureci/azure-common.nix
+++ b/hosts/uae/azureci/azure-common.nix
@@ -21,7 +21,10 @@ in
     nix = {
       settings = {
         # Enable flakes and 'nix' command
-        experimental-features = "nix-command flakes";
+        experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
         # https://github.com/NixOS/nix/issues/11728
         download-buffer-size = 524288000;
         # When free disk space in /nix/store drops below min-free during build,

--- a/modules/common/nix.nix
+++ b/modules/common/nix.nix
@@ -35,7 +35,10 @@ in
         "@wheel"
       ];
       # Enable flakes and new 'nix' command
-      experimental-features = "nix-command flakes";
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
       # Avoid copying unnecessary stuff over SSH
       builders-use-substitutes = true;
       # Auto-free the /nix/store:


### PR DESCRIPTION
Fixes
error: A definition for option `nix.settings.experimental-features'
       is not of type `list of string'.