### PR TITLE
Update NX target in UAE prod

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -69,14 +69,14 @@ Current ghaf-infra targets:
 │ testagent-release     │ testagent-release     │ 172.18.16.32    │
 │ testagent2-prod       │ testagent2-prod       │ 172.18.16.25    │
 │ uae-azureci-az86-1    │ uae-azureci-az86-1    │ 20.46.48.30     │
-│ uae-azureci-dev       │ uae-azureci-dev       │ 20.174.185.164  │
 │ uae-azureci-hetzarm-1 │ uae-azureci-hetzarm-1 │ 91.98.90.243    │
 │ uae-azureci-prod      │ uae-azureci-prod      │ 74.162.68.205   │
+│ uae-azureci-dev       │ uae-azureci-dev       │ 20.174.185.164  │
 │ uae-azureci-registry  │ uae-azureci-registry  │ 40.120.125.69   │
 │ uae-lab-node1         │ uae-lab-node1         │ 172.31.107.42   │
 │ uae-nethsm-gateway    │ uae-nethsm-gateway    │ 172.31.141.51   │
 │ uae-testagent-prod    │ uae-testagent-prod    │ 172.20.16.24    │
-│ uae-testagent2-prod   │ uae-testagent2-prod   │ 172.20.16.25    │
+│ uae-testagent2-prod   │ uae-testagent2-prod   │ 172.20.16.26    │
 ╘═══════════════════════╧═══════════════════════╧═════════════════╛
 
 ```

--- a/hosts/uae/testagent/prod2/configuration.nix
+++ b/hosts/uae/testagent/prod2/configuration.nix
@@ -62,7 +62,7 @@
     SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="50026B7283C099A7", SYMLINK+="ssdORINAGX1", MODE="0666", GROUP="dialout"
 
     # Orin nx
-    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="AU008K01", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
     # SSD-drive
     SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S3R4NF0K618289", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
 
@@ -96,8 +96,8 @@
         };
         OrinNX1 = {
           inherit location;
-          device_id = "00-dd-4d-d9-3d";
-          netvm_hostname = "ghaf-3712866621";
+          device_id = "00-ca-96-a7-e4";
+          netvm_hostname = "ghaf-3398871012";
           serial_port = "/dev/ttyORINNX1";
           relay_number = 3;
           device_ip_address = "172.20.16.75";

--- a/hosts/uae/testagent/prod2/configuration.nix
+++ b/hosts/uae/testagent/prod2/configuration.nix
@@ -64,7 +64,7 @@
     # Orin nx
     SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="FTD0W9KS", SYMLINK+="ttyORINNX1", MODE="0666", GROUP="dialout"
     # SSD-drive
-    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="50026B7283C099B0", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
+    SUBSYSTEM=="block", KERNEL=="sd[a-z]", ENV{ID_SERIAL_SHORT}=="S3R4NF0K618289", SYMLINK+="ssdORINNX1", MODE="0666", GROUP="dialout"
 
     # Orin AGX64
     SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{serial}=="TOPO7394FE13", ENV{ID_USB_INTERFACE_NUM}=="01", SYMLINK+="ttyAGX64", MODE="0666", GROUP="dialout"
@@ -96,8 +96,8 @@
         };
         OrinNX1 = {
           inherit location;
-          device_id = "00-b2-e1-cb-48";
-          netvm_hostname = "ghaf-3001142088";
+          device_id = "00-dd-4d-d9-3d";
+          netvm_hostname = "ghaf-3712866621";
           serial_port = "/dev/ttyORINNX1";
           relay_number = 3;
           device_ip_address = "172.20.16.75";


### PR DESCRIPTION
Swap the carrier board in NX with a compatible board.
Flash qspi, and configure NX with new IP, ssd.
Reconfigure with updated netvm and device-id.