### PR TITLE
Group GitHub Actions updates and extend Dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 4
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -16,4 +16,4 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 4
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 4
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: gomod
     directory: /pkgs/policy-checker


### PR DESCRIPTION
Group weekly GitHub Actions updates into one PR and increase the GitHub Actions and Go module cooldowns to seven days to satisfy zizmor’s cooldown rule.