### PR TITLE
docs: refresh runbooks and simplify wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 This repository is a Nix flake for Ghaf CI/CD infrastructure.
 
 - `hosts/`: host-specific NixOS configs (usually `configuration.nix`, `disk-config.nix`, `secrets.yaml`).
-- `services/`: reusable NixOS service modules (`*/default.nix`).
+- `modules/`: reusable NixOS modules, exported from `modules/default.nix`.
 - `users/`: user and team access definitions (`users/*.nix`, `users/teams/*.nix`).
 - `nix/`: flake modules for devshell, hooks, deployments, apps, and packages.
 - `scripts/`: operational helpers (for build, signing, plugin resolution, user onboarding).
+- `tests/`: Python tests for Invoke tasks and Groovy tests for Jenkins pipelines.
 - `docs/`: operational runbooks (`tasks.md`, `deploy-rs.md`, onboarding docs).
 - `pkgs/`, `keys/`, `slsa/`: custom packages, key material, and provenance definitions.
 
@@ -26,7 +27,7 @@ This repository is a Nix flake for Ghaf CI/CD infrastructure.
 - Nix: format with `nixfmt`; keep module entry files as `default.nix` where practical.
 - Python: format with `ruff format`; lint with `pylint`.
 - Shell: format with `shfmt --indent 2`; validate with `shellcheck`.
-- Keep host/service paths lowercase and hyphenated (for example `hosts/ghaf-monitoring`, `services/remote-build`).
+- Keep host/module paths lowercase and hyphenated (for example `hosts/ghaf-monitoring`, `modules/environment/hetzner-cloud.nix`).
 
 ## Code Style: Prefer Compact, Human-Maintainable Code
 This repository values straightforward, readable code over excessive abstraction.
@@ -80,7 +81,9 @@ Look specifically for:
 Prefer the smallest change that solves the problem cleanly.
 
 ## Testing Guidelines
-There is no standalone unit-test suite; validation is check-driven.
+Python tests live in `tests/test_tasks.py`; Jenkins pipeline tests live in
+`tests/jenkins/`. Both run through the hooks configured in `nix/git-hooks.nix`.
+
 - Run `nix fmt` to catch formatting/lint issues early.
 - Run `nix flake check --option allow-import-from-derivation false --no-build` for checks.
 - For host changes, build the target configuration explicitly with `nix build` and verify affected aliases.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository declaratively defines the NixOS configuration for the [Ghaf](htt
 ## Overview
 
 The infrastructure includes:
-- **Jenkins CI environments** (prod, dev, release) hosted at Hetzner
+
+- **Jenkins CI environments** (prod, dev, dbg, release) hosted at Hetzner
 - **Multi-architecture remote builders** for x86_64 and aarch64
 - **On-prem test agents** with connected hardware devices
 - **Supporting services**: monitoring, logging, authentication, [Nebula](./docs/nebula.md) overlay network, [NetHSM](./docs/nethsm.md) hardware signing, and an OCI container registry
@@ -27,7 +28,7 @@ Clone this repository:
 ❯ cd ghaf-infra
 ```
 
-Bootstrap nix shell with the required dependencies:
+Enter the development shell:
 
 ```bash
 ❯ nix develop
@@ -39,18 +40,20 @@ All commands referenced in the documentation are executed inside the nix-shell.
 
 The dev shell includes pre-commit hooks that run automatically on
 `git commit`. See [`nix/git-hooks.nix`](./nix/git-hooks.nix) for the
-full list. To run them manually against all files:
+full list. To run the hooks manually:
 
 ```bash
 nix fmt
 ```
 
-To evaluate all Nix expressions and validate NixOS configurations without
-building derivations (catches syntax errors, type mismatches, and missing
-attributes):
+This includes the Python tests in `tests/test_tasks.py` and the Jenkins
+pipeline tests in `tests/jenkins/`. Most hooks check all files; pylint checks
+only changed Python files.
+
+To evaluate the flake without building derivations, using the same command as CI:
 
 ```bash
-nix flake check --no-build
+nix flake check --option allow-import-from-derivation false --no-build
 ```
 
 To run the full check suite including builds:
@@ -67,43 +70,49 @@ ghaf-infra
 ├── hosts/              # NixOS host configurations
 │   ├── builders/       # Remote builder machines
 │   ├── hetzci/         # Jenkins CI environments (see hetzci/README.md)
+│   ├── nethsm-gateway/ # Tampere signing gateways and shared configuration
 │   ├── testagent/      # On-prem test agents
+│   ├── uae/            # UAE CI, test agents, and signing gateway
 │   ├── ghaf-*/         # Supporting services (monitoring, auth, registry, etc.)
 │   └── machines.nix    # Canonical host inventory (modules, systems, deploy metadata, IPs, keys)
+├── keys/               # Signing public keys and certificates
+├── modules/            # Shared NixOS modules
 ├── nix/                # Flake plumbing (deployments, apps, git-hooks)
+├── pkgs/               # Custom packages
 ├── scripts/            # Operational scripts
-├── services/           # Shared NixOS service modules
+├── slsa/               # Provenance definitions and attestation policies
+├── tests/              # Python and Jenkins pipeline tests
 ├── users/              # Admin user configurations
 └── tasks.py            # Invoke tasks (see docs/tasks.md)
 ```
 
 ## Documentation
 
-- [Architecture overview](./docs/architecture.md) — how all the pieces fit together
-- [Adding a new host](./docs/adding-a-host.md) — step-by-step runbook for onboarding a host
-- [Deployment tasks](./docs/tasks.md) — install, reboot, and other operational tasks
-- [Deploying with deploy-rs](./docs/deploy-rs.md) — how to deploy configuration changes
-- [Monitoring](./docs/monitoring.md) — Grafana and Prometheus setup
-- [Nebula overlay network](./docs/nebula.md) — network connectivity between hosts
-- [NetHSM hardware signing](./docs/nethsm.md) — hardware-backed signing
-- [Jenkins authentication](./docs/jenkins-authentication.md) — Jenkins auth setup
-- [Jenkins test agents](./docs/jenkins-testagents.md) — on-prem test agents
-- [Jenkins CI development](./hosts/hetzci/README.md) — developing the CI environment
+- [Architecture overview](./docs/architecture.md): how all the pieces fit together
+- [Adding a new host](./docs/adding-a-host.md): host configuration and first install
+- [Deployment tasks](./docs/tasks.md): install, reboot, and other operational tasks
+- [Deploying with deploy-rs](./docs/deploy-rs.md): how to deploy configuration changes
+- [Monitoring](./docs/monitoring.md): Grafana and Prometheus setup
+- [Nebula overlay network](./docs/nebula.md): network connectivity between hosts
+- [NetHSM hardware signing](./docs/nethsm.md): hardware-backed signing
+- [Jenkins authentication](./docs/jenkins-authentication.md): Jenkins auth setup
+- [Jenkins test agents](./docs/jenkins-testagents.md): on-prem test agents
+- [Jenkins CI development](./hosts/hetzci/README.md): developing the CI environment
 
 ## Common Tasks
 
-- **Deploy configuration changes** — [deploy-rs](./docs/deploy-rs.md)
-- **Add a new host** — [adding a host](./docs/adding-a-host.md)
-- **Add a remote builder user** — add their SSH key to
+- **Deploy configuration changes**: [deploy-rs](./docs/deploy-rs.md)
+- **Add a new host**: [adding a host](./docs/adding-a-host.md)
+- **Add a remote builder user**: add their SSH key to
   [developers.nix](./hosts/builders/developers.nix), then deploy
-- **Onboard a new admin** — add their user to [users/](./users/),
+- **Onboard a new admin**: add their user to [users/](./users/),
   optionally add their age key to [.sops.yaml](.sops.yaml) and run
   [`inv update-sops-files`](./docs/tasks.md#update-sops-files), then deploy
-- **Manage secrets** — [secrets management](./docs/architecture.md#secrets-management)
-- **Install, reboot, and other operational tasks** — [tasks](./docs/tasks.md)
+- **Manage secrets**: [secrets management](./docs/architecture.md#secrets-management)
+- **Install, reboot, and other operational tasks**: [tasks](./docs/tasks.md)
 
 **Note**: Hosts may be reinstalled at any time. Do not store important
-data outside the configurations in this repository — including in `/home`
+data outside the configurations in this repository, including in `/home`
 directories on the hosts.
 
 ## License

--- a/docs/adding-a-host.md
+++ b/docs/adding-a-host.md
@@ -5,8 +5,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Adding a New Host
 
-This runbook covers the end-to-end steps for adding a new NixOS host to
-ghaf-infra. For architectural context on where hosts fit, see
+To add a NixOS host to ghaf-infra, follow the steps below. See also
 [architecture.md](./architecture.md).
 
 ## Prerequisites
@@ -18,8 +17,9 @@ ghaf-infra. For architectural context on where hosts fit, see
 
 ## File checklist
 
-The following files need to be created or modified. The examples below use
-`ghaf-example` as the host name — replace it with the actual name. See
+The examples below target an x86_64 Hetzner Cloud VM using legacy BIOS and
+use `ghaf-example` as the host name. Replace it with the actual name. For
+other platforms, start from a host with the same hardware and boot mode. See
 [`hosts/ghaf-webserver/`](../hosts/ghaf-webserver/) for a minimal reference.
 
 ### 1. Create the host configuration
@@ -29,25 +29,49 @@ service modules the host needs, and user modules:
 
 ```nix
 # hosts/ghaf-example/configuration.nix
-{ self, lib, inputs, ... }:
+{ self, inputs, ... }:
 {
   imports = [
     ./disk-config.nix
-    inputs.sops-nix.nixosModules.sops
+    self.nixosModules.hetzner-cloud
     inputs.disko.nixosModules.disko
   ]
   ++ (with self.nixosModules; [
     common
     openssh
+    team-devenv
     # add other service modules as needed
   ]);
 
   sops.defaultSopsFile = ./secrets.yaml;
 
-  system.stateVersion = lib.mkForce "24.05";
+  system.stateVersion = "<nixpkgs-release>";
   networking.hostName = "ghaf-example";
+
+  services.monitoring = {
+    metrics.enable = true;
+    logs.enable = true;
+  };
 }
 ```
+
+The `hetzner-cloud` module selects GRUB for legacy BIOS and supplies the
+QEMU guest and network defaults. The disk layout below includes the `EF02`
+partition needed by GRUB. The `common` module imports sops-nix.
+
+The `team-devenv` import provides admin users with SSH keys and sudo access.
+Use the appropriate user or team module for the new host; `openssh` disables
+root login.
+
+For a new install, replace `<nixpkgs-release>` with the pinned release:
+
+```sh
+nix eval --raw .#nixosConfigurations.ghaf-webserver.config.system.nixos.release
+```
+
+`inv install` warns if `system.stateVersion` differs. Keep the chosen value on
+subsequent upgrades; it records the release used for the initial installation.
+Adapt the boot and network settings to the target hardware before installing.
 
 ### 2. Create the disk configuration
 
@@ -82,8 +106,7 @@ partitioning for the target disk. Identify the disk device ID on the server
 ### 3. Add the host to `hosts/machines.nix`
 
 Add a new inventory entry with the module path, target system, and machine
-metadata such as the host IP (and optionally `internal_ip`, `nebula_ip`,
-`publicKey`):
+metadata such as the public IP and the assigned Hetzner private network IP:
 
 ```nix
 ghaf-example = {
@@ -91,6 +114,7 @@ ghaf-example = {
   system = "x86_64-linux";
   machine = {
     ip = "1.2.3.4";
+    internal_ip = "<private-ip>";
   };
 };
 ```
@@ -102,7 +126,48 @@ non-deploy-rs hosts can omit the `machine` attrset; VM-style outliers should
 also set `kind = "vm"`. The `publicKey` field is populated after the first
 install (see [print-keys](./tasks.md#print-keys)).
 
+#### Configure monitoring
+
+The example enables node-exporter and sends journal logs to Loki. Attach
+the VM to the same Hetzner private network as `ghaf-monitoring` and replace
+`<private-ip>` with its assigned address. The `hetzner-cloud` module supplies
+the internal Loki URL and trusts the private interface, `eth1`.
+
+Add the host to `hetznerCloudHosts` in
+[`hosts/ghaf-monitoring/configuration.nix`](../hosts/ghaf-monitoring/configuration.nix)
+so Prometheus scrapes it. Deploy `ghaf-monitoring` after the new host is
+running to apply the target change. For other environments, configure the
+appropriate scrape job, network access, and Loki endpoint and credentials;
+see [Monitoring](./monitoring.md#hosts).
+
 ## Provisioning (first install)
+
+Create the encrypted file referenced by `sops.defaultSopsFile` before
+installing. Add a creation rule to `.sops.yaml` using your existing admin
+key anchor; the host's key will be added after its first boot:
+
+```yaml
+- path_regex: hosts/ghaf-example/secrets.yaml$
+  key_groups:
+  - age:
+    - *your-admin-anchor
+```
+
+Open the new secrets file with sops:
+
+```sh
+sops hosts/ghaf-example/secrets.yaml
+```
+
+Replace the editor's example contents with `bootstrap: pending-host-key`
+and save. Leave `ssh_host_ed25519_key` absent until the host generates it.
+
+Stage the new files so the Git flake includes them:
+
+```sh
+git add hosts/ghaf-example/configuration.nix hosts/ghaf-example/disk-config.nix hosts/machines.nix
+git add .sops.yaml hosts/ghaf-example/secrets.yaml
+```
 
 Install the host with [nixos-anywhere](https://github.com/nix-community/nixos-anywhere):
 
@@ -113,8 +178,8 @@ inv install --alias ghaf-example
 This repartitions the disk and deploys the NixOS configuration.
 **All existing data on the target will be destroyed.**
 
-The first install runs without host-specific secrets (`inv install` will
-warn that decryption failed — confirm with `y` to continue). NixOS
+The first install uses this placeholder (`inv install` will warn that
+reading `ssh_host_ed25519_key` failed; confirm with `y` to continue). NixOS
 generates an SSH host key on first boot. Those keys are captured in the
 next section.
 
@@ -138,10 +203,9 @@ Add the resulting age key to the `keys` section of `.sops.yaml`:
 - &ghaf-example age1...
 ```
 
-### 5. Add creation rule in `.sops.yaml`
+### 5. Update the creation rule in `.sops.yaml`
 
-Add a `creation_rules` entry so sops knows which keys can decrypt the
-host's secrets:
+Add the host's key to the existing `creation_rules` entry:
 
 ```yaml
 - path_regex: hosts/ghaf-example/secrets.yaml$
@@ -151,23 +215,45 @@ host's secrets:
     - *your-admin-anchor
 ```
 
-### 6. Create secrets file
+### 6. Store the host key in the secrets file
 
 Copy the host's private SSH key from the remote host and store it as
 a sops secret:
 
 ```sh
-# Copy the private key from the host (requires sudo — root login is disabled)
+# Copy the private key from the host (requires sudo; root login is disabled)
 (umask 077 && ssh <user>@<host-ip> sudo cat /etc/ssh/ssh_host_ed25519_key > /tmp/host-key)
 
-# Create the encrypted secrets file and add the key as ssh_host_ed25519_key
 sops hosts/ghaf-example/secrets.yaml
+```
 
+In the sops editor, remove `bootstrap` and paste the complete contents of
+`/tmp/host-key` under `ssh_host_ed25519_key: |`. Indent every key line by two
+spaces, including the BEGIN and END lines, to preserve the newlines:
+
+```yaml
+ssh_host_ed25519_key: |
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  <paste all key lines here>
+  -----END OPENSSH PRIVATE KEY-----
+```
+
+Save and close the editor, then remove the plaintext copy:
+
+```sh
 # Remove the temporary key file
 rm /tmp/host-key
 ```
 
 At minimum, the secrets file must contain the `ssh_host_ed25519_key`.
+Stage the encrypted file so Nix can read it:
+
+```sh
+git add hosts/ghaf-example/secrets.yaml
+```
+
+Use `inv print-keys --alias ghaf-example` to read the stored public key, and
+add it as `machine.publicKey` in `hosts/machines.nix`.
 
 ### 7. Run `inv update-sops-files`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,31 +19,31 @@ sections below group hosts by role and describe how they relate to one another.
 
 ### Jenkins Controllers
 
-Four Jenkins controller instances serve different stages of the development
+Four Hetzner Jenkins controllers serve different stages of the development
 lifecycle. Each runs behind an OAuth2 Proxy that authenticates users via
 ghaf-auth and exposes a public web UI over Caddy with ACME TLS.
 
 | Host | URL | Purpose |
 |---|---|---|
-| `hetzci-prod` | ci-prod.vedenemo.dev | Production CI — runs on every push and PR to Ghaf |
-| `hetzci-dev` | ci-dev.vedenemo.dev | Development CI — for CI and hardware-test development |
-| `hetzci-release` | ci-release.vedenemo.dev | Release CI — ephemeral, re-installed per release cycle |
-| `hetzci-dbg` | ci-dbg.vedenemo.dev | Debug CI — isolated controller/builder environment for troubleshooting |
+| `hetzci-prod` | ci-prod.vedenemo.dev | Production CI: runs on every push and PR to Ghaf |
+| `hetzci-dev` | ci-dev.vedenemo.dev | Development CI: for CI and hardware-test development |
+| `hetzci-release` | ci-release.vedenemo.dev | Release CI: ephemeral, re-installed per release cycle |
+| `hetzci-dbg` | ci-dbg.vedenemo.dev | Debug CI: isolated controller/builder environment for troubleshooting |
 
-A fifth configuration, `hetzci-vm`, is not deployed — it runs locally
-(`localhost:8080`) via `nix run .#run-hetzci-vm` as a QEMU VM for developing
-and testing CI changes before deploying to a real environment.
+The `hetzci-vm` configuration runs locally (`localhost:8080`) via
+`nix run .#run-hetzci-vm` as a QEMU VM for developing and testing CI changes
+before deploying to a real environment. It is not a deploy target.
 
 GitHub webhooks deliver push and PR events to `hetzci-prod`. The release
 controller has no webhooks; its pipelines are triggered manually. Each
-controller dispatches Nix builds to its own set of remote builders and
+controller dispatches Nix builds to its configured remote builders and
 connects to test agents over the Nebula overlay.
 
 ### Remote Builders
 
 Builders are high-resource Hetzner machines that compile Nix derivations on
-behalf of Jenkins controllers, GitHub Actions, and individual developers. Each
-Jenkins controller has a dedicated builder set to isolate workloads.
+behalf of Jenkins controllers, GitHub Actions, and individual developers.
+Prod and dev share builders; release and debug use separate builder sets.
 
 | Host | Arch | Used by |
 |---|---|---|
@@ -57,13 +57,16 @@ Jenkins controller has a dedicated builder set to isolate workloads.
 
 Build results are pushed to three Cachix binary caches:
 
-- **[`ghaf-dev`](https://app.cachix.org/organization/tiiuae/cache/ghaf-dev)** — populated by prod/dev CI on every PR authored by a `tiiuae`
-  organization member. This is the main cache used during day-to-day
-  development.
-- **[`ghaf-dbg`](https://app.cachix.org/organization/tiiuae/cache/ghaf-dbg)** — populated by the debug controller/builders and consumed by those
+- **[`ghaf-dev`](https://app.cachix.org/organization/tiiuae/cache/ghaf-dev)**:
+  the main development cache. The `cachix-push` service on `hetz86-1` and
+  `hetzarm` uploads new store paths, subject to the image and referrer filters
+  in `hosts/builders/cachix-push.sh`. Since `hetzarm` also serves GitHub
+  Actions and developer builds, the cache can contain their outputs too.
+  The push service does not check PR authorship.
+- **[`ghaf-dbg`](https://app.cachix.org/organization/tiiuae/cache/ghaf-dbg)**: populated by the debug controller/builders and consumed by those
   hosts, keeping dbg-published results isolated from the main development
   cache.
-- **[`ghaf-release`](https://app.cachix.org/organization/tiiuae/cache/ghaf-release)** — populated exclusively by the release environment. The
+- **[`ghaf-release`](https://app.cachix.org/organization/tiiuae/cache/ghaf-release)**: populated exclusively by the release environment. The
   ephemeral release controller and builders pull earlier build results from this
   cache so that only changed derivations need to be rebuilt.
 
@@ -84,10 +87,10 @@ device, effectively acting as a lock for each piece of hardware.
 
 Each agent also runs:
 
-- [BrainStem](https://acroname.com/software/brainstem-development-kit) — CLI
+- [BrainStem](https://acroname.com/software/brainstem-development-kit): CLI
   tools and udev rules for controlling Acroname programmable USB hubs (used for
   power-cycling and USB switching of test devices)
-- `policy-checker` — a Go wrapper around `verify-signature` that validates SLSA
+- `policy-checker`: a Go wrapper around `verify-signature` that validates SLSA
   provenance and image signatures before flashing
 
 Agents expose relay-board metrics (port 8000) and push logs to Loki via Alloy.
@@ -103,17 +106,17 @@ They are monitored by `ghaf-monitoring` through the Nebula overlay.
 | `ghaf-lighthouse` | Nebula lighthouse | Overlay network discovery and DNS for `sumu.vedenemo.dev` |
 | `ghaf-registry` | [Zot](https://zotregistry.dev/) OCI registry | Container image registry (registry.vedenemo.dev), OIDC-authenticated via ghaf-auth |
 | `ghaf-webserver` | Nginx | Static web content (vedenemo.dev) |
-| `ghaf-fleetdm` | [Fleet](https://fleetdm.com/) (fleetdm.vedenemo.dev) | Device management server for Ghaf end-devices — test agents carry enrollment credentials (via sops) so that Ghaf images flashed during CI testing can register with Fleet |
+| `ghaf-fleetdm` | [Fleet](https://fleetdm.com/) (fleetdm.vedenemo.dev) | Device management server for Ghaf end-devices. Test agents carry enrollment credentials (via sops) so that Ghaf images flashed during CI testing can register with Fleet |
 
 ### NetHSM Gateways
 
 CI builds use hardware security modules (HSMs) for two independent signing
 purposes:
 
-- **SLSA signing** — disk images and provenance files are signed for supply
+- **SLSA signing**: disk images and provenance files are signed for supply
   chain integrity. This uses `openssl` with ECDSA/EDDSA keys stored on the
   NetHSM.
-- **UEFI Secure Boot signing** — EFI binaries and boot images are signed so
+- **UEFI Secure Boot signing**: EFI binaries and boot images are signed so
   they pass Secure Boot verification on target hardware. This uses
   `uefisign`/`systemd-sbsign` with RSA keys stored on the HSM.
 
@@ -130,8 +133,9 @@ signing operations without direct access to the HSM.
 
 | Host | Location | NetHSM address |
 |---|---|---|
-| `nethsm-gateway` | Tampere office | 192.168.70.10 (isolated ethernet) |
-| `uae-nethsm-gateway` | UAE site | 172.31.141.51 (isolated sectech vlan in masdar) |
+| `nethsm-gateway` | Tampere office | 10.255.255.1 (isolated link per gateway) |
+| `nethsm-gateway-dev` | Tampere office | 10.255.255.1 (isolated link per gateway) |
+| `uae-nethsm-gateway` | UAE site | 192.168.70.20 (isolated ethernet) |
 
 Each gateway runs a `pkcs11-proxy` daemon on a TLS port reachable from the
 Nebula network. Requests are encrypted with a host-specific key from sops
@@ -160,16 +164,16 @@ Changes to the Ghaf repository trigger two parallel build paths:
 
 ### Jenkins Pipeline
 
-1. **Trigger** — a push or PR to the [Ghaf](https://github.com/tiiuae/ghaf)
+1. **Trigger**: a push or PR to the [Ghaf](https://github.com/tiiuae/ghaf)
    repo sends a GitHub webhook to the **prod** Jenkins controller.
-2. **Build** — Jenkins dispatches Nix builds to its dedicated remote builders
+2. **Build**: Jenkins dispatches Nix builds to the shared prod/dev builders
    (`hetz86-1`, `hetzarm`). [sbomnix](https://github.com/tiiuae/sbomnix)
    generates SBOMs and SLSA provenance on the controller, and build
    artifacts are signed via the [NetHSM](#nethsm-gateways).
-3. **Test** — built images are deployed to on-prem test agents over the Nebula
+3. **Test**: built images are deployed to on-prem test agents over the Nebula
    overlay. Each agent houses physical hardware devices and runs one Jenkins
    agent service per test device.
-4. **Results** — test results flow back to Jenkins and build status is
+4. **Results**: test results flow back to Jenkins and build status is
    reported on the GitHub PR.
 
 The **release** environment is ephemeral: it is fully re-provisioned with
@@ -193,11 +197,10 @@ Pushes and PRs to Ghaf `main` also trigger a
 [GitHub Actions workflow](https://github.com/tiiuae/ghaf/blob/main/.github/workflows/build.yml)
 that compiles a matrix of build targets across x86_64 and aarch64. The workflow
 uses `nix-fast-build --remote` over SSH to offload compilation to
-`hetz86-builder` and `hetzarm` — the same shared builders available for
-developer remote builds. This path verifies that targets build successfully but
-does not run hardware tests. This path exists primarily because it integrates
-naturally with the developer workflow — build status appears directly on PRs
-and commits in GitHub without requiring access to Jenkins.
+`hetz86-builder` and `hetzarm`, the shared builders available for developer
+remote builds. This workflow checks builds without running hardware tests.
+Build status appears directly on PRs and commits in GitHub without requiring
+access to Jenkins.
 
 ### Release artifact storage
 
@@ -229,34 +232,37 @@ The ghaf-infra repository has its own GitHub Actions workflows
 
 **PR and push checks:**
 
-- `check.yml` — runs `nix flake check` on PRs and pushes to main
-  (fast syntax and lint gate).
-- `test-ghaf-infra.yml` — builds all NixOS configurations for x86_64 and
-  aarch64 using remote builders.
-- `authorize.yml` — reusable authorization workflow. PRs from `tiiuae` org
+- `check.yml`: runs `nix flake check` on PRs and pushes to main
+  with `--option allow-import-from-derivation false --no-build` (evaluation only).
+- `test-ghaf-infra.yml`: builds all NixOS configurations for x86_64 and
+  aarch64 using remote builders, and runs the pre-commit checks on x86_64.
+- `authorize.yml`: reusable authorization workflow. PRs from `tiiuae` org
   members are auto-approved; external PRs require manual approval before
   CI runs.
-- `warn-on-workflow-changes.yml` — intentionally fails if `authorize.yml`
+- `warn-on-workflow-changes.yml`: intentionally fails if `authorize.yml`
   or `test-ghaf-infra.yml` are modified in a PR, since those changes only
   take effect after merge.
 
-**Security scanning:**
+**Security scanning and attestations:**
 
-- `actions-security-analysis.yml` — runs [zizmor](https://woodruffw.github.io/zizmor/)
+- `source-vsa.yml`: issues Source Verification Summary Attestations (VSAs)
+  on pushes to main using `slsa/source-vsa-policy.yaml`. It uses GitHub OIDC
+  (`id-token: write`) for signing and publishes the attestations to GHCR.
+- `actions-security-analysis.yml`: runs [zizmor](https://woodruffw.github.io/zizmor/)
   to audit workflow files for security issues.
-- `dependency-review.yml` — blocks PRs that introduce known-vulnerable
+- `dependency-review.yml`: blocks PRs that introduce known-vulnerable
   dependencies.
-- `flakevuln.yml` — scheduled and manual vulnerability scanning for the
+- `flakevuln.yml`: scheduled and manual vulnerability scanning for the
   ci-prod environment: the `hetzci-prod` controller, its `hetz86-1` (x86) and
   `hetzarm` (aarch64) remote builders, and `ghaf-auth`.
-- `scorecards.yml` — [OSSF Scorecard](https://securityscorecards.dev/)
+- `scorecards.yml`: [OSSF Scorecard](https://securityscorecards.dev/)
   supply chain security analysis.
 
 **Automation:**
 
-- `update-robot-framework.yml` — daily automated PR to bump the
+- `update-robot-framework.yml`: daily automated PR to bump the
   robot-framework flake input.
-- `update-flake-inputs.yml` — weekly automated PR to update all flake inputs
+- `update-flake-inputs.yml`: weekly automated PR to update all flake inputs
   and Jenkins plugin manifests.
 - Dependabot (`.github/dependabot.yml`) keeps GitHub Actions and Go module
   dependencies up to date.
@@ -271,32 +277,38 @@ The infrastructure spans three network tiers:
 | Hetzner internal | `10.0.0.0/24` | Cloud-to-cloud communication between Hetzner hosts |
 | Nebula overlay | `10.42.42.0/24` | Encrypted tunnel connecting Hetzner, Tampere office, and UAE site |
 
-**Nebula** is a peer-to-peer overlay — traffic flows directly between hosts,
-not through the lighthouse. The lighthouse (`ghaf-lighthouse`) is only a
-discovery node. It also serves as a DNS server for the `sumu.vedenemo.dev`
-subdomain, resolving Nebula addresses within the overlay.
+**Nebula** traffic flows directly between hosts, not through the lighthouse.
+The lighthouse (`ghaf-lighthouse`) is only a discovery node. It also serves
+as a DNS server for the `sumu.vedenemo.dev` subdomain, resolving Nebula
+addresses within the overlay.
 
-Not every host joins the Nebula network. Only hosts that need to communicate
-with on-prem or cross-site resources have Nebula IPs: the Jenkins controllers
-(`hetzci-prod`, `hetzci-dev`, `hetzci-release`), `ghaf-monitoring`,
-`ghaf-lighthouse`, all test agents, and the NetHSM gateways. Hosts that only
-operate within Hetzner — such as the remote builders (`hetz86-1`,
-`hetz86-builder`, `hetzarm`, etc.) — rely on public IPs or the Hetzner
-internal network and have no Nebula connectivity. This is why builders cannot
-directly reach on-prem hardware; only the Jenkins controllers bridge that gap.
+Hosts with Nebula addresses are listed under `nebula_ip` in
+`hosts/machines.nix`: the Hetzner Jenkins controllers (`hetzci-prod`,
+`hetzci-dev`, `hetzci-dbg`, `hetzci-release`), the UAE Azure controllers
+(`uae-azureci-prod`, `uae-azureci-dev`), the test agents (`testagent-dbg`,
+`testagent-dev`, `testagent-prod`, `testagent2-prod`, `testagent-release`),
+all three NetHSM gateways, `ghaf-monitoring`, and `ghaf-lighthouse`. The UAE
+test agents are not enrolled in Nebula.
+
+Remote builders (`hetz86-1`, `hetz86-builder`, `hetzarm`, etc.) rely on public
+IPs or the Hetzner internal network and have no Nebula connectivity. They
+cannot reach on-prem hardware through the overlay; Jenkins controllers
+provide that connection.
 
 See [Nebula overlay network](./nebula.md) for certificate management and
 configuration details.
 
 ## Authentication
 
-All user-facing services authenticate through a central OIDC provider:
+Jenkins and the OCI registries use a central OIDC provider; Grafana uses
+GitHub OAuth directly:
 
 - **ghaf-auth** runs [Dex](https://dexidp.io/) with a GitHub connector backed
-  by `tiiuae` organization membership.
+  by the `devenv-fi`, `phone`, and `ci-dev-admins` teams in `tiiuae`.
 - Jenkins controllers sit behind [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/),
   which validates tokens with ghaf-auth before forwarding requests to Jenkins.
-- Grafana and the OCI registry also authenticate via GitHub / OIDC.
+- The OCI registries authenticate through ghaf-auth. Grafana connects to
+  GitHub directly, with its own organization and team restrictions.
 
 See [Jenkins authentication](./jenkins-authentication.md) for the full
 auth flow and secret generation.
@@ -329,14 +341,23 @@ volume.
 
 **Metrics collection** (Prometheus scrape jobs):
 
+The target lists are defined in
+[`hosts/ghaf-monitoring/configuration.nix`](../hosts/ghaf-monitoring/configuration.nix).
+
 | Job | Transport | Hosts |
 |---|---|---|
-| `hetzner-cloud` | Hetzner internal network (direct) | Cloud VMs with `internal_ip` |
-| `hetzner-robot` | SSH proxy (`sshified`) | Dedicated servers without internal network access |
-| `office` / `relay-board` / `nethsm` | Nebula overlay | On-prem test agents, NetHSM gateway |
+| `hetzner-cloud` | Hetzner internal network (direct) | Configured Hetzner Cloud VMs, node-exporter on port 9100 |
+| `hetzner-robot` | SSH proxy (`sshified`) | Configured dedicated servers, node-exporter on port 9100 |
+| `office` | Nebula overlay | Tampere test agents and `nethsm-gateway`, node-exporter on port 9100 |
+| `relay-board` | Nebula overlay | `testagent-dev`, `testagent2-prod`, `testagent-release`, port 8000 |
+| `nethsm` | Nebula overlay | `nethsm-gateway`, `uae-nethsm-gateway`, port 8000 |
+| `zot` | HTTPS with basic auth over the Hetzner internal network | `ghaf-registry`, port 443 |
+| `nebula` | Hetzner internal network or Nebula overlay | All hosts with `nebula_ip`, Nebula metrics on port 9101 |
+| `uae` | Nebula overlay | `uae-azureci-prod`, `uae-nethsm-gateway`, node-exporter on port 9100 |
 
-**Logging** — hosts run Grafana Alloy agents that push systemd journal logs to
-Loki on `ghaf-monitoring`. Alerting is configured to notify a Slack channel.
+**Logging**: hosts with `services.monitoring.logs.enable` run Grafana Alloy
+agents that push systemd journal logs to Loki on `ghaf-monitoring`. Alerting
+is configured to notify a Slack channel.
 
 **`ghaf-log`** (ghaflogs.vedenemo.dev) is a separate Grafana + Loki instance
 for Ghaf device logs, independent from the infrastructure monitoring on
@@ -353,17 +374,17 @@ See [Monitoring](./monitoring.md) for development and debugging details.
 | Method | Use case |
 |---|---|
 | [`deploy-rs`](./deploy-rs.md) | Push configuration changes to running hosts (with automatic rollback) |
-| [`nixos-anywhere`](https://github.com/nix-community/nixos-anywhere) + [`disko`](https://github.com/nix-community/disko) | Initial provisioning — partitions disks and installs NixOS |
+| [`nixos-anywhere`](https://github.com/nix-community/nixos-anywhere) + [`disko`](https://github.com/nix-community/disko) | Initial provisioning: partitions disks and installs NixOS |
 | [`invoke` tasks](./tasks.md) | Operational workflows (`inv install`, `inv reboot`, `inv update-sops-files`, `inv install-release`, etc.) |
 
 ## Cross-References
 
-- [Deployment tasks](./tasks.md) — install, reboot, and other invoke tasks
-- [Deploying with deploy-rs](./deploy-rs.md) — deploying configuration changes
-- [Monitoring](./monitoring.md) — Grafana, Prometheus, and Loki setup
-- [Nebula overlay network](./nebula.md) — overlay network and certificate management
-- [NetHSM hardware signing](./nethsm.md) — PKCS#11 proxy and signing operations
-- [Jenkins authentication](./jenkins-authentication.md) — OIDC auth flow
-- [Jenkins test agents](./jenkins-testagents.md) — on-prem test agent setup
-- [Jenkins CI development](../hosts/hetzci/README.md) — CI environments and pipeline overview
-- [`hosts/machines.nix`](../hosts/machines.nix) — canonical host inventory (modules, systems, deploy metadata, IPs, keys, Nebula addresses)
+- [Deployment tasks](./tasks.md): install, reboot, and other invoke tasks
+- [Deploying with deploy-rs](./deploy-rs.md): deploying configuration changes
+- [Monitoring](./monitoring.md): Grafana, Prometheus, and Loki setup
+- [Nebula overlay network](./nebula.md): overlay network and certificate management
+- [NetHSM hardware signing](./nethsm.md): PKCS#11 proxy and signing operations
+- [Jenkins authentication](./jenkins-authentication.md): OIDC auth flow
+- [Jenkins test agents](./jenkins-testagents.md): on-prem test agent setup
+- [Jenkins CI development](../hosts/hetzci/README.md): CI environments and pipeline overview
+- [`hosts/machines.nix`](../hosts/machines.nix): canonical host inventory (modules, systems, deploy metadata, IPs, keys, Nebula addresses)

--- a/docs/deploy-rs.md
+++ b/docs/deploy-rs.md
@@ -4,8 +4,10 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 # Using deploy-rs
 
-As an alternative to using `tasks.py` and `invoke deploy` commands,
-the remote hosts are also defined in `nix/deployments.nix` as [deploy-rs](https://github.com/serokell/deploy-rs) nodes.
+Use [deploy-rs](https://github.com/serokell/deploy-rs) to deploy configuration
+changes to existing hosts. Nodes are generated from `hosts/machines.nix` by
+`nix/deployments.nix`. For initial installs and other operational tasks, see
+[tasks.md](./tasks.md).
 
 This makes deploying multiple hosts easier as it can be done with one command.
 `deploy-rs` also has automatic rollback functionality, so the system is rolled back if the configuration fails to activate.

--- a/docs/jenkins-testagents.md
+++ b/docs/jenkins-testagents.md
@@ -16,15 +16,15 @@ Each testagent has the following tools available to the Jenkins agent services
 (configured in `hosts/testagent/agent.nix` and `hosts/testagent/agents-common.nix`):
 
 - **[BrainStem](https://acroname.com/software/brainstem-development-kit)**
-  (`AcronameHubCLI`) — controls Acroname programmable USB hubs for
+  (`AcronameHubCLI`): controls Acroname programmable USB hubs for
   power-cycling and USB switching of test devices. Packaged in `pkgs/brainstem/`
   with udev rules for device access.
-- **`policy-checker`** — a Go tool (in `pkgs/policy-checker/`) that wraps
+- **`policy-checker`**: a Go tool (in `pkgs/policy-checker/`) that wraps
   `verify-signature` to validate SLSA provenance and image signatures against
   the certificates in `ghaf-infra-pki` before flashing.
-- **`ghaf-robot`** — [Robot Framework](https://robotframework.org/) test runner
+- **`ghaf-robot`**: [Robot Framework](https://robotframework.org/) test runner
   from the `robot-framework` flake input.
-- **[FleetDM](https://fleetdm.com/) credentials** — agents hold Fleet enrollment
+- **[FleetDM](https://fleetdm.com/) credentials**: agents hold Fleet enrollment
   secrets and API tokens (via sops) so that Ghaf images flashed during CI
   testing can register with the `ghaf-fleetdm` server. Fleet manages the
   Ghaf end-devices, not the test agents themselves.
@@ -57,18 +57,14 @@ To add a new test device to a testagent that is already running:
 
 ## Adding a new test agent
 
-To set up a brand new testagent machine from scratch:
+To set up a new testagent:
 
-1. **Provision the hardware** — rack the machine, connect test devices, and
-   ensure network access.
-2. **Add the host to ghaf-infra** — follow the
-   [adding a host](./adding-a-host.md) runbook to create the NixOS
-   configuration, secrets, and deployment entries.
-3. **Enroll in Nebula** — testagents need Nebula connectivity to reach the
-   Jenkins controllers. Follow the
-   [Nebula onboarding checklist](./nebula.md#onboarding-checklist), assigning
-   the `testagent` group (and `office` or `uae-lab` as appropriate).
-4. **Install** — provision the machine with `inv install --alias <name>`
-   (see [tasks](./tasks.md#install)).
-5. **Connect to controller** — SSH into the testagent and run `connect`
-   with the target controller URL.
+1. Rack the machine, connect test devices, and ensure network access.
+2. Follow the [adding a host](./adding-a-host.md) runbook to create the NixOS
+   configuration, install the host, and set up secrets. Use an existing testagent
+   as the configuration reference instead of the Hetzner Cloud example.
+3. For a Tampere agent, follow the
+   [Nebula onboarding checklist](./nebula.md#onboarding-checklist) with the
+   `testagent,office` groups. The existing UAE test agents do not use Nebula;
+   follow their site configuration under `hosts/uae/testagent/` instead.
+4. SSH into the testagent and run `connect` with the target controller URL.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -6,62 +6,83 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 # Monitoring
 
 Grafana instance is publicly accessible at <https://monitoring.vedenemo.dev>.
-The authentication happens through Github login. Login is accepted if you are
-part of the `tiiuae` or `devenv-fi` team.
+Log in with GitHub. Access requires membership in the `tiiuae` organization
+and its `devenv-fi` team.
 
 The hosts in ghaf-infra are monitored with Grafana running on `ghaf-monitoring`.
 
-Each host runs `node-exporter` to expose resource usage metrics, and optionally
-sends systemd logs to loki.
+Hosts opt in to resource metrics with `services.monitoring.metrics.enable`,
+which starts `node-exporter`. Enabling `services.monitoring.logs.enable`
+starts Grafana Alloy to send systemd journal logs to Loki. Both default to off.
 
 The monitoring server has an additional Hetzner volume attached which stores the
 state (metrics and logs) of Grafana, Prometheus & Loki.
 
 ## Hosts
 
+The eight Prometheus jobs below are configured in
+[`hosts/ghaf-monitoring/configuration.nix`](../hosts/ghaf-monitoring/configuration.nix).
+Enabling an exporter does not add a host to a scrape job; most target lists
+must be updated explicitly.
+
 ### Hetzner Cloud
 
-Hetzner cloud hosts are monitored through the Hetzner internal network. They
-don't need authentication and are configured to scrape the metrics from
-port 9100. They are configured in the `hetzner-cloud` prometheus scraping job.
+The `hetzner-cloud` job scrapes hosts listed in `hetznerCloudHosts` at their
+`internal_ip` on port 9100 over the Hetzner private network, without
+authentication.
+
+The `zot` job scrapes registry metrics from `ghaf-registry` at its
+`internal_ip` on port 443, using HTTPS and basic authentication.
 
 ### Hetzner Robot
 
 Hetzner robot side machines cannot join the internal network the same way cloud
 machines can. For this reason, they are monitored through an ssh proxy
 (`sshified`). The scrape job `hetzner-robot` sends its traffic through this
-proxy to the needed hosts.
+proxy to hosts listed in `hetznerRobotHosts`, on port 9100.
 
 ### On-prem
 
-Servers in the office are monitored through a nebula tunnel. These hosts must
-join the nebula network, and be accessible under the `sumu.vedenemo.dev`
-subdomain. Configured under the `office` scrape job.
+The `office` job scrapes the five Tampere test agents and `nethsm-gateway`
+at their `nebula_ip` addresses on port 9100. These hosts must join Nebula
+and allow access from the monitoring server.
 
 #### relay-board
 
-Test agents also expose the relay board statuses under port 8000, by running
-`relay_board_exporter.py`. this is then scraped by the `relay-board` job.
+The `relay-board` job scrapes `testagent-dev`, `testagent2-prod`, and
+`testagent-release` on port 8000 using their `sumu.vedenemo.dev` names.
+These agents run `relay_board_exporter.py` to expose relay board status.
 
 #### NetHSM
 
-`nethsm-gateway` is running `nethsm-exporter`, which exposes nethsm metrics
-scraped from the NetHSM rest API. These metrics are scraped into the `nethsm`
-job.
+The `nethsm` job scrapes `nethsm-gateway` and `uae-nethsm-gateway` on port
+8000 using their `sumu.vedenemo.dev` names. Each runs `nethsm-exporter`,
+which collects metrics from the NetHSM REST API. `nethsm-gateway-dev` also
+enables the exporters, but is absent from the `office` and `nethsm` jobs.
 
-The gateway also sends the NetHSM logs in addition to systemd logs to loki.
+The gateways also send NetHSM logs in addition to systemd logs to Loki.
+
+### UAE
+
+The `uae` job scrapes `uae-azureci-prod` and `uae-nethsm-gateway` at their
+`nebula_ip` addresses on port 9100.
+
+### Nebula metrics
+
+The `nebula` job includes every host with a `nebula_ip` in `hosts/machines.nix`.
+It scrapes Nebula metrics on port 9101, using `internal_ip` for hosts in
+`hetznerCloudHosts` and `nebula_ip` for the rest.
 
 ## ghaf-log (separate instance)
 
 A second, independent Grafana + Loki instance runs on `ghaf-log`
-(<https://ghaflogs.vedenemo.dev>). This is **not** the same as
-`ghaf-monitoring` — it is a dedicated log analysis platform for Ghaf device
-logs, separate from the infrastructure monitoring above.
+(<https://ghaflogs.vedenemo.dev>). It handles Ghaf device logs separately from the
+infrastructure monitoring on `ghaf-monitoring`.
 
 | URL | Purpose |
 |---|---|
-| <https://ghaflogs.vedenemo.dev> | Grafana UI — GitHub login (`tiiuae` org, `devenv-fi` and `phone` teams) |
-| <https://loki.ghaflogs.vedenemo.dev> | Loki push/query API — basic-auth protected |
+| <https://ghaflogs.vedenemo.dev> | Grafana UI with GitHub login (`tiiuae` org, `devenv-fi` and `phone` teams) |
+| <https://loki.ghaflogs.vedenemo.dev> | Loki push/query API with basic authentication |
 
 External log producers (e.g. Ghaf devices running Alloy or promtail) can push
 logs to the Loki endpoint. Credentials are stored in

--- a/docs/nebula.md
+++ b/docs/nebula.md
@@ -5,10 +5,8 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Nebula overlay network
 
-> [Nebula](https://github.com/slackhq/nebula) is a scalable overlay networking tool with a focus on performance,
-simplicity and security. It lets you seamlessly connect computers anywhere in the world.
-
-Nebula is used in ghaf-infra to create a network between servers in the Tampere office and hetzner.
+[Nebula](https://github.com/slackhq/nebula) connects the servers in Hetzner,
+the Tampere office, and the UAE over an encrypted overlay network.
 
 ![diagram](./nebula-monitoring.png)
 
@@ -29,7 +27,7 @@ sumu.vedenemo.dev. 0  A   65.109.141.136
 ```
 
 Query like `dig monitoring.sumu.vedenemo.dev` will return the nebula address of our monitoring server.
-The address if of course only reachable from within the network.
+The address is only reachable from within the network.
 
 From within the nebula network, and using the nebula address of the lighthouse, you can also query the cert of any host:
 
@@ -46,7 +44,7 @@ The CA key and cert are stored encrypted in
 These can be decrypted with SOPS, given you have the rights:
 
 ```sh
-sops decrypt ca.key
+sops decrypt modules/nebula/ca.key.crypt
 ```
 
 The current keys have been generated with this command:
@@ -76,9 +74,7 @@ The groups can be anything and are used to define firewall rules between hosts.
 ./scripts/nebula-sign.sh -name "testagent-dev.sumu.vedenemo.dev" -ip "10.42.42.11/24" -groups "testagent,office"
 ```
 
-Other groups we are using:
-    - hetzner
-    - scraper
+Other groups include `hetzner` and `scraper`. See [Firewall groups](#firewall-groups).
 
 The script will print the cert and key in a format that can be easily copy-pasted into `secrets.yaml`.
 
@@ -125,35 +121,34 @@ The new host should be able to decrypt `ca.crt.crypt` for nebula to run.
 
 ## Onboarding checklist
 
-End-to-end steps for adding a host to the Nebula network. This assumes the
-host already exists in the infrastructure (see
-[adding a host](./adding-a-host.md) for the full setup).
+These steps assume the host is already installed. For a new machine, start
+with [adding a host](./adding-a-host.md).
 
-1. **Pick an IP** — choose the next free `10.42.42.x` address by checking
+1. Choose the next free `10.42.42.x` address by checking
    existing `nebula_ip` values in `hosts/machines.nix`.
-2. **Choose groups** — select the appropriate groups for the host (see
+2. Select the appropriate groups for the host (see
    [firewall groups](#firewall-groups) below).
-3. **Sign a certificate** — run `./scripts/nebula-sign.sh` with the chosen
+3. Run `./scripts/nebula-sign.sh` with the chosen
    name, IP, and groups:
    ```sh
    ./scripts/nebula-sign.sh -name "<name>.sumu.vedenemo.dev" -ip "10.42.42.x/24" -groups "group1,group2"
    ```
-4. **Add cert and key to secrets** — copy the script output into the host's
+4. Copy the script output into the host's
    `secrets.yaml` (the `nebula-cert` and `nebula-key` fields).
-5. **Update `.sops.yaml`** — add the host's age key anchor to the
+5. In `.sops.yaml`, add the host's age key anchor to the
    `modules/nebula/ca.crt.crypt` creation rule so the host can decrypt it.
-6. **Re-encrypt** — run `sops updatekeys modules/nebula/ca.crt.crypt`.
-7. **Configure NixOS** — import the `nebula` module in the host's
+6. Run `sops updatekeys modules/nebula/ca.crt.crypt`.
+7. Import the `nebula` module in the host's
    `configuration.nix` and enable it (see [Nix configuration](#nix-configuration)
    above).
-8. **Add `nebula_ip`** — set the `nebula_ip` field in `hosts/machines.nix`
+8. Set the `nebula_ip` field in `hosts/machines.nix`
    under the host's `machine` attrset.
-9. **Deploy** — deploy the host with `deploy .#<name>`.
+9. Deploy the host with `deploy .#<name>`.
 
 ## Firewall groups
 
 Groups are assigned when signing a host certificate and are used in the
-Nebula firewall rules defined in `modules/nebula/default.nix`.
+shared firewall rules in `modules/nebula/default.nix` and host-specific rules.
 
 | Group | Purpose |
 |---|---|
@@ -165,7 +160,13 @@ Nebula firewall rules defined in `modules/nebula/default.nix`.
 | `uae-lab` | UAE lab nodes |
 | `masdar` | UAE masdar nodes |
 
-The `scraper` group is used in an inbound firewall rule that allows
-ghaf-monitoring to scrape Prometheus node-exporter metrics (port 9100/tcp)
-from any host in that group. Other groups are currently informational and
-can be used to add targeted firewall rules as needed.
+Only `scraper` and `hetzner` currently appear in firewall rules. The other
+groups are descriptive labels and do not grant additional access.
+
+The shared inbound rules allow connections from peers in the `scraper`
+group, including ghaf-monitoring, to node-exporter (9100/tcp) and Nebula
+metrics (9101/tcp). The hosts being scraped do not need the `scraper` group.
+
+Host-specific rules also use groups. For example, the NetHSM gateways allow
+outbound UDP on port 4242 only to peers in `hetzner`. Check the host
+configuration as well as the shared module when choosing groups.

--- a/docs/nethsm.md
+++ b/docs/nethsm.md
@@ -7,10 +7,13 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ![diagram](./nethsm-setup.png)
 
-`nethsm-gateway` runs a daemon provided by
-[pkcs11-proxy](https://github.com/tiiuae/pkcs11-proxy).
+Three gateways run a daemon provided by
+[pkcs11-proxy](https://github.com/tiiuae/pkcs11-proxy): `nethsm-gateway` and
+`nethsm-gateway-dev` in Tampere, and `uae-nethsm-gateway` in the UAE. Each
+connects to its own HSM on an isolated link. See the
+[gateway table](./architecture.md#nethsm-gateways) for addresses.
 
-This daemon is listening on tls port 2345, accessible through the nebula tunnel
+Each daemon listens on TLS port 2345, accessible through the Nebula tunnel
 from the hetzner CI. A library provided by the same project can be used as the
 pkcs11 module, which will proxy the requests to the correct place (configured
 through environment variables).
@@ -20,10 +23,9 @@ The requests are encrypted with a PKS key which comes from the host secrets.
 Signing operations can be done from Hetzner CI, with configured pkcs11-proxy.
 The keys used will be the ones stored on the NetHSM.
 
-The HSM infrastructure serves two independent signing purposes — **SLSA
-signing** (supply chain integrity for disk images and provenance) and **UEFI
-Secure Boot signing** (EFI binary authentication on target hardware). Both use
-the same PKCS#11 proxy but different keys and tools.
+The HSM handles **SLSA signing** (supply chain integrity for disk images and
+provenance) and **UEFI Secure Boot signing** (EFI binary authentication on
+target hardware). Both use the same PKCS#11 proxy but different keys and tools.
 
 ## SLSA Signing
 
@@ -90,14 +92,16 @@ openssl dgst -verify \
 
 UEFI Secure Boot signing ensures that EFI binaries and boot images are
 authenticated by the target hardware's firmware before execution. This is
-separate from SLSA signing — SLSA provides supply chain provenance, while
-Secure Boot provides runtime boot integrity enforced by the UEFI firmware.
+separate from SLSA signing, which records supply chain provenance.
+The UEFI firmware checks Secure Boot signatures during boot.
 
 ### Keys
 
 The Secure Boot key hierarchy (PK, KEK, DB) is stored on the HSM. The
-`get-secureboot-keys` command on `nethsm-gateway` fetches the certificates
-and generates the signed auth files needed for enrollment:
+`get-secureboot-keys` command is installed on all three gateways and fetches
+the certificates from the HSM that gateway is connected to, generating the
+signed auth files needed for enrollment. Run it on the gateway whose HSM
+holds the keys you need, `nethsm-gateway` for production:
 
 ```sh
 get-secureboot-keys /path/to/output
@@ -112,10 +116,10 @@ The public certificates used for build-time signing are distributed via the
 Jenkins controllers have the following UEFI signing tools available
 (from the `ci-yubi` flake input and `hosts/hetzci/signing.nix`):
 
-- `uefisign` — sign individual EFI binaries
-- `uefisigniso` — sign EFI binaries within ISO images
-- `uefisign-simple` — simplified wrapper for common signing operations
-- `systemd-sbsign` — systemd's built-in sbsign tool for PE binary signing
+- `uefisign`: sign individual EFI binaries
+- `uefisigniso`: sign EFI binaries within ISO images
+- `uefisign-simple`: simplified wrapper for common signing operations
+- `systemd-sbsign`: systemd's built-in sbsign tool for PE binary signing
 
 These tools use the same PKCS#11 proxy connection as SLSA signing to access
 the HSM keys.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -22,13 +22,15 @@ Available tasks:
   install             Install `alias` configuration using nixos-anywhere, deploying host private key.
   install-release     Initialize hetzner release environment
   print-keys          Decrypt host private key, print ssh and age public keys for `alias` config.
+  print-revision      Print the currently deployed git revision on the 'alias' host.
   reboot              Reboot host identified as `alias`, selected aliases, or hosts needing reboot.
   renew-nebula-certificates
                       Renew Nebula host certificates and keys stored in sops.
-  update-sops-files   Update all sops yaml and json files according to .sops.yaml rules.
+  update-sops-files   Update all sops files according to .sops.yaml rules.
 ```
 
-In the following sections, we will explain the intended usage of the most common of the above deployment tasks.
+Most tasks are described below. For `renew-nebula-certificates`, see
+[Renewing host certificates](./nebula.md#renewing-host-certificates).
 
 ## alias-list
 
@@ -63,16 +65,17 @@ Current ghaf-infra targets:
 │ hetzci-prod           │ hetzci-prod           │ 157.180.43.236  │
 │ hetzci-release        │ hetzci-release        │ 95.217.210.252  │
 │ nethsm-gateway        │ nethsm-gateway        │ 192.168.70.11   │
+│ nethsm-gateway-dev    │ nethsm-gateway-dev    │ 192.168.70.2    │
 │ testagent-dbg         │ testagent-dbg         │ 172.18.16.26    │
 │ testagent-dev         │ testagent-dev         │ 172.18.16.33    │
 │ testagent-prod        │ testagent-prod        │ 172.18.16.60    │
 │ testagent-release     │ testagent-release     │ 172.18.16.32    │
 │ testagent2-prod       │ testagent2-prod       │ 172.18.16.25    │
 │ uae-azureci-az86-1    │ uae-azureci-az86-1    │ 20.46.48.30     │
+│ uae-azureci-dev       │ uae-azureci-dev       │ 20.174.185.164  │
 │ uae-azureci-hetzarm-1 │ uae-azureci-hetzarm-1 │ 91.98.90.243    │
 │ uae-azureci-prod      │ uae-azureci-prod      │ 74.162.68.205   │
-│ uae-azureci-dev       │ uae-azureci-dev       │ 20.174.185.164  │
-│ uae-azureci-registry  │ uae-azureci-registry  │ 40.120.125.69   │
+│ uae-azureci-registry  │ uae-azureci-registry  │ 74.162.68.150   │
 │ uae-lab-node1         │ uae-lab-node1         │ 172.31.107.42   │
 │ uae-nethsm-gateway    │ uae-nethsm-gateway    │ 172.31.141.51   │
 │ uae-testagent-prod    │ uae-testagent-prod    │ 172.20.16.24    │
@@ -93,7 +96,7 @@ Host 65.21.20.242
     IdentityFile /path/to/my/private_key
 ```
 
-Since `task.py` internally uses ssh when accessing hosts, the above example configuration would be applied when accessing the `hetzarm` alias.
+Since `tasks.py` internally uses ssh when accessing hosts, the above example configuration would be applied when accessing the `hetzarm` alias.
 
 ## install
 
@@ -119,7 +122,10 @@ Install configuration 'hetz86-rel-2'? [y/N] y
 
 ## update-sops-files
 
-The `update-sops-files` task updates all sops yaml and json files according to the rules in [`.sops.yaml`](../.sops.yaml). The intended use is to update the secrets after adding new hosts, admins, or secrets:
+The `update-sops-files` task runs `sops updatekeys` on every file matched by
+a `path_regex` rule in [`.sops.yaml`](../.sops.yaml), including YAML, JSON,
+and encrypted `.crypt` files. Run it after changing host or admin keys, or
+the rules that determine who can decrypt each file:
 
 ```bash
 inv update-sops-files

--- a/hosts/hetzci/README.md
+++ b/hosts/hetzci/README.md
@@ -46,13 +46,16 @@ hosts/hetzci/
 │       └── pipelineModel.groovy
 ```
 
+Pipeline tests live in [`tests/jenkins/`](../../tests/jenkins/) at the
+repository root and run through the `nix fmt` hooks.
+
 ### Environments
 
-- **`prod`** — production CI for ghaf development. Web UI: https://ci-prod.vedenemo.dev/
-- **`release`** — release CI for ghaf release builds. Web UI: https://ci-release.vedenemo.dev/
-- **`dev`** — development CI for ghaf-infra and hw-test development. Web UI: https://ci-dev.vedenemo.dev/
-- **`dbg`** — debug CI environment.
-- **`vm`** — local QEMU VM for testing changes before deploying. Modified for local use: simplified Caddy config, no Jenkins authentication, auto-login as root.
+- **`prod`**: production CI for ghaf development. Web UI: https://ci-prod.vedenemo.dev/
+- **`release`**: release CI for ghaf release builds. Web UI: https://ci-release.vedenemo.dev/
+- **`dev`**: development CI for ghaf-infra and hw-test development. Web UI: https://ci-dev.vedenemo.dev/
+- **`dbg`**: debug CI environment.
+- **`vm`**: local QEMU VM for testing changes before deploying. Modified for local use: simplified Caddy config, no Jenkins authentication, auto-login as root.
 
 ## Usage
 
@@ -92,7 +95,7 @@ Common options:
 - Guest writes to `/nix/store` do not go to host `/nix/store`; host impact is mainly extra store read activity.
 
 **`--no-host-nix-store`** switches to a fully guest-managed store:
-- Better isolation — host store paths are not mounted into the guest.
+- Better isolation: host store paths are not mounted into the guest.
 - Trade-offs: slower startup (cannot reuse host store paths), guest must fetch more paths itself, higher disk usage.
 
 #### Secrets access

--- a/hosts/uae/nethsm-gateway/configuration.nix
+++ b/hosts/uae/nethsm-gateway/configuration.nix
@@ -54,7 +54,7 @@
 
   services.nebula.networks."vedenemo".firewall = {
     outbound = lib.mkForce [
-      # allow udp outbound only to hetzner, uae-lab and azureci
+      # allow udp outbound only to hetzner
       {
         port = 4242;
         proto = "udp";


### PR DESCRIPTION
Update onboarding, host inventory, access rules, and task documentation. Simplify wording while keeping the existing structure.