### PR TITLE
Set parameter USE_ZEPHYR as env var

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-hw-test.groovy
+++ b/hosts/hetzci/pipelines/ghaf-hw-test.groovy
@@ -154,10 +154,6 @@ def ghaf_robot_test(String testname='relayboot') {
       }
     }
     try {
-      def useZephyr =
-        env.JIRA_TOKEN_AVAILABLE == 'true' &&
-        params.SEND_RESULTS_TO_ZEPHYR
-
       def robotCommand = { String extraArgs ->
         env.EXTRA_ROBOT_ARGS = extraArgs ?: ''
 
@@ -175,7 +171,7 @@ def ghaf_robot_test(String testname='relayboot') {
         '''
       }
 
-      if (useZephyr) {
+      if (env.USE_ZEPHYR == 'true') {
         withCredentials([
           string(credentialsId: 'jenkins_jira_token', variable: 'JIRA_TOKEN')
         ]) {
@@ -235,6 +231,11 @@ pipeline {
       agent { label 'built-in' }
       steps {
         script {
+          env.USE_ZEPHYR = (
+            env.JIRA_TOKEN_AVAILABLE == 'true' &&
+            params.SEND_RESULTS_TO_ZEPHYR
+            ).toString()
+
           env.TEST_AGENT_LABEL = init()
         }
       }


### PR DESCRIPTION
params.SEND_RESULTS_TO_ZEPHYR wasn't visible and has value of null.
Moved definition of use_zephyr to Initialize, where SEND_RESULTS_TO_ZEPHYR is accessible 

[Run nightly on DEV](https://ci-dev.vedenemo.dev/job/ghaf-nightly/421/), canceled execution when [test execution started](https://ci-dev.vedenemo.dev/job/ghaf-hw-test/1535/console) and verified that SEND_RESULTS_TO_ZEPHYR is visible(false for DEV)
<img width="679" height="275" alt="image" src="https://github.com/user-attachments/assets/2399d18e-d88c-437c-b9e4-44455bc6d0fe" />


