### PR TITLE
Run storedisk installer hw tests on secboot enabled Darter Pro

### DIFF
--- a/hosts/hetzci/pipelines/ghaf-nightly.groovy
+++ b/hosts/hetzci/pipelines/ghaf-nightly.groovy
@@ -41,6 +41,7 @@ def TARGETS = [
       device_tag: 'darter-pro',
       variant: 'storeDisk-debug-installer',
       testset: '_relayboot_regression_',
+      test_secboot: true,
     ]],
   ],
   [ target: "packages.x86_64-linux.intel-laptop-release",


### PR DESCRIPTION
Testing team ran successful manual tests with UEFI signed `intel-laptop-storeDisk-debug-installer` image on secure boot enabled Darter Pro in prod environment. This PR will make prod `ghaf-nightly` pipeline to run  `intel-laptop-storeDisk-debug-installer` hardware tests on secure boot enabled Darter Pro laptop.